### PR TITLE
Skip assignment notification when assigning a ticket to yourself

### DIFF
--- a/resources/views/livewire/ready-room/tickets/view-ticket.blade.php
+++ b/resources/views/livewire/ready-room/tickets/view-ticket.blade.php
@@ -382,9 +382,11 @@ new class extends Component
 
         \App\Actions\RecordActivity::run($this->thread, 'assignment_changed', $description);
 
-        // Notify both the new assignee and the ticket creator
+        // Notify the new assignee (skip if assigning to yourself) and the ticket creator
         $notificationService = app(TicketNotificationService::class);
-        $notificationService->send($newAssignee, new TicketAssignedNotification($this->thread));
+        if ($newAssignee->id !== auth()->id()) {
+            $notificationService->send($newAssignee, new TicketAssignedNotification($this->thread));
+        }
 
         if ($this->thread->createdBy && $this->thread->createdBy->id !== $newAssignee->id) {
             $notificationService->send($this->thread->createdBy, new TicketAssignedNotification($this->thread));


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented unnecessary self-notifications when assigning a ticket to yourself.
  * Improved cache clearing across all ticket participants for better data consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->