### PR TITLE
Fix verification for linked Bedrock accounts by adding fallback matching

### DIFF
--- a/app/Models/MinecraftAccount.php
+++ b/app/Models/MinecraftAccount.php
@@ -18,6 +18,7 @@ class MinecraftAccount extends Model
         'user_id',
         'username',
         'uuid',
+        'bedrock_xuid',
         'avatar_url',
         'account_type',
         'status',

--- a/database/migrations/2026_02_28_043322_add_bedrock_xuid_to_minecraft_accounts_table.php
+++ b/database/migrations/2026_02_28_043322_add_bedrock_xuid_to_minecraft_accounts_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('minecraft_accounts', function (Blueprint $table) {
+            $table->string('bedrock_xuid')->nullable()->after('uuid');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('minecraft_accounts', function (Blueprint $table) {
+            $table->dropColumn('bedrock_xuid');
+        });
+    }
+};

--- a/routes/web.php
+++ b/routes/web.php
@@ -115,12 +115,17 @@ Route::post('/api/minecraft/verify', function (\Illuminate\Http\Request $request
         'code' => 'required|string|size:6',
         'minecraft_username' => 'required|string',
         'minecraft_uuid' => 'required|string',
+        'is_bedrock' => 'sometimes|boolean',
+        'bedrock_username' => 'sometimes|string',
+        'bedrock_xuid' => 'sometimes|string',
     ]);
 
     $result = \App\Actions\CompleteVerification::run(
         $request->code,
         $request->minecraft_username,
-        $request->minecraft_uuid
+        $request->minecraft_uuid,
+        bedrockUsername: $request->input('bedrock_username'),
+        bedrockXuid: $request->input('bedrock_xuid'),
     );
 
     return response()->json($result);

--- a/tests/Feature/Minecraft/CompleteVerificationTest.php
+++ b/tests/Feature/Minecraft/CompleteVerificationTest.php
@@ -204,6 +204,125 @@ test('completes verification for bedrock account with dot-prefix username', func
     expect($result['success'])->toBeTrue();
 });
 
+test('completes verification for linked bedrock account using bedrock fallback', function () {
+    // Website stored the Floodgate identity
+    MinecraftVerification::factory()->for($this->user)->pending()->create([
+        'code' => 'LNK123',
+        'account_type' => 'bedrock',
+        'minecraft_username' => '.Ghostridr6007',
+        'minecraft_uuid' => '00000000-0000-0000-0009-01234567890a',
+    ]);
+
+    MinecraftAccount::factory()->for($this->user)->verifying()->create([
+        'username' => '.Ghostridr6007',
+        'uuid' => '00000000-0000-0000-0009-01234567890a',
+        'account_type' => 'bedrock',
+    ]);
+
+    // Plugin sends the linked Java identity as minecraft_username/uuid,
+    // plus the bedrock_username for fallback matching
+    $result = $this->action->handle(
+        'LNK123',
+        'Ghostridr',                              // linked Java username (won't match stored)
+        'a008f810-1af7-48fa-8a3d-cbc07e29c811',   // linked Java UUID (won't match stored)
+        bedrockUsername: 'Ghostridr6007',
+        bedrockXuid: '2535406112136054',
+    );
+
+    expect($result['success'])->toBeTrue();
+
+    $this->assertDatabaseHas('minecraft_accounts', [
+        'user_id' => $this->user->id,
+        'username' => '.Ghostridr6007',
+        'status' => 'active',
+        'bedrock_xuid' => '2535406112136054',
+    ]);
+});
+
+test('stores bedrock xuid on verification', function () {
+    MinecraftVerification::factory()->for($this->user)->pending()->create([
+        'code' => 'BDX123',
+        'account_type' => 'bedrock',
+        'minecraft_username' => '.BedrockPlayer',
+        'minecraft_uuid' => '00000000-0000-0000-0009-01234567890a',
+    ]);
+
+    MinecraftAccount::factory()->for($this->user)->verifying()->create([
+        'username' => '.BedrockPlayer',
+        'uuid' => '00000000-0000-0000-0009-01234567890a',
+        'account_type' => 'bedrock',
+    ]);
+
+    $result = $this->action->handle(
+        'BDX123',
+        '.BedrockPlayer',
+        '00000000-0000-0000-0009-01234567890a',
+        bedrockXuid: '2535406112136054',
+    );
+
+    expect($result['success'])->toBeTrue();
+
+    $this->assertDatabaseHas('minecraft_accounts', [
+        'uuid' => '00000000-0000-0000-0009-01234567890a',
+        'bedrock_xuid' => '2535406112136054',
+    ]);
+});
+
+test('does not overwrite existing bedrock xuid', function () {
+    MinecraftVerification::factory()->for($this->user)->pending()->create([
+        'code' => 'BDX456',
+        'account_type' => 'bedrock',
+        'minecraft_username' => '.BedrockPlayer',
+        'minecraft_uuid' => '00000000-0000-0000-0009-01234567890a',
+    ]);
+
+    MinecraftAccount::factory()->for($this->user)->verifying()->create([
+        'username' => '.BedrockPlayer',
+        'uuid' => '00000000-0000-0000-0009-01234567890a',
+        'account_type' => 'bedrock',
+        'bedrock_xuid' => 'existing-xuid-value',
+    ]);
+
+    $result = $this->action->handle(
+        'BDX456',
+        '.BedrockPlayer',
+        '00000000-0000-0000-0009-01234567890a',
+        bedrockXuid: 'new-xuid-value',
+    );
+
+    expect($result['success'])->toBeTrue();
+
+    $this->assertDatabaseHas('minecraft_accounts', [
+        'uuid' => '00000000-0000-0000-0009-01234567890a',
+        'bedrock_xuid' => 'existing-xuid-value',
+    ]);
+});
+
+test('bedrock fallback does not match when bedrock_username is not provided', function () {
+    MinecraftVerification::factory()->for($this->user)->pending()->create([
+        'code' => 'NOB123',
+        'account_type' => 'bedrock',
+        'minecraft_username' => '.BedrockPlayer',
+        'minecraft_uuid' => '00000000-0000-0000-0009-01234567890a',
+    ]);
+
+    MinecraftAccount::factory()->for($this->user)->verifying()->create([
+        'username' => '.BedrockPlayer',
+        'uuid' => '00000000-0000-0000-0009-01234567890a',
+        'account_type' => 'bedrock',
+    ]);
+
+    // Send mismatched Java identity without bedrock fallback fields
+    $result = $this->action->handle(
+        'NOB123',
+        'SomeJavaPlayer',
+        'a008f810-1af7-48fa-8a3d-cbc07e29c811',
+    );
+
+    expect($result['success'])->toBeFalse()
+        ->and($result['message'])->toBe('Username or UUID mismatch.');
+});
+
 test('syncs staff position when staff member verifies account', function () {
     Notification::fake();
 


### PR DESCRIPTION
When a Bedrock player has a linked Java account, the plugin sends the Java identity as minecraft_username/uuid which doesn't match the stored Floodgate identity. This adds bedrock_username fallback matching (strip prefix, compare) and stores bedrock_xuid for future stable identification.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for verifying and linking Bedrock/Xbox edition accounts to player profiles
  * Verification system now accepts Bedrock username and Xbox ID parameters for account identification
  * Implemented fallback matching mechanism to ensure reliable Bedrock account verification

* **Tests**
  * Added test coverage for Bedrock verification and account linking scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->