### PR TITLE
Add missing removestaff command to RevokeMinecraftAccount action

### DIFF
--- a/app/Actions/RevokeMinecraftAccount.php
+++ b/app/Actions/RevokeMinecraftAccount.php
@@ -42,13 +42,28 @@ class RevokeMinecraftAccount
 
         // Remove staff position if the affected user holds one
         if ($affectedUser->staff_department !== null) {
-            $rconService->executeCommand(
+            $staffResult = $rconService->executeCommand(
                 "lh removestaff {$account->username}",
                 'rank',
                 $account->username,
                 $admin,
                 ['action' => 'revoke_staff_reset', 'affected_user_id' => $affectedUser->id]
             );
+
+            if (! $staffResult['success']) {
+                Log::error('Failed to remove staff position during account revocation', [
+                    'account_id' => $account->id,
+                    'username' => $username,
+                    'admin' => $admin->name,
+                    'response' => $staffResult['response'] ?? null,
+                    'error' => $staffResult['error'] ?? null,
+                ]);
+
+                return [
+                    'success' => false,
+                    'message' => 'Failed to remove staff position from server. Account has not been revoked.',
+                ];
+            }
 
             RecordActivity::run(
                 $affectedUser,


### PR DESCRIPTION
RevokeMinecraftAccount was only resetting rank and removing whitelist, but skipped the lh removestaff command for staff members. This meant staff who revoked their own MC account kept their in-game staff position.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Revocation of Minecraft accounts now fully removes staff roles when applicable. Staff position removal is performed as part of the revocation flow, with failures logged and successful removals recorded, ensuring staff accounts are reliably stripped of privileges in addition to whitelist removal and account disabling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->