### PR TITLE
Fix ACP user edit to link parent accounts when parent_email matches e…

### DIFF
--- a/resources/views/livewire/admin-manage-users-page.blade.php
+++ b/resources/views/livewire/admin-manage-users-page.blade.php
@@ -7,6 +7,7 @@ use App\Models\Role;
 use Livewire\Volt\Component;
 use Illuminate\Support\Facades\Validator;
 use Livewire\WithPagination;
+use App\Actions\LinkParentByEmail;
 use Flux\Flux;
 
 
@@ -200,6 +201,10 @@ new class extends Component {
         // Use the scheduled ProcessAgeTransitions command for automated transitions.
         $user->update($updateData);
         $user->roles()->sync($this->editUserRoles);
+
+        if ($updateData['parent_email']) {
+            LinkParentByEmail::run($user);
+        }
 
         $this->editUserId = null;
         Flux::modal('edit-user-modal')->close();


### PR DESCRIPTION
…xisting user

The ACP edit modal saved parent_email but never called LinkParentByEmail, so no parent-child link was created even when a matching user existed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Admin users can now link a parent to a user account using an email address during user management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->