### PR TITLE
Increase PHP memory limit to 1G in PR checks

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -89,7 +89,7 @@ jobs:
           php-version: '8.4'
           extensions: mbstring, intl, pcntl, pdo_pgsql
           coverage: pcov
-          ini-values: memory_limit=512M
+          ini-values: memory_limit=1G
 
       - name: Authenticate to FluxUI Composer repo
         run: |


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Increased memory allocation for testing infrastructure in CI/CD pipeline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->