### PR TITLE
PRD: Harden Minecraft lh command reliability and add bulk permission reset

### DIFF
--- a/app/Actions/CompleteVerification.php
+++ b/app/Actions/CompleteVerification.php
@@ -168,44 +168,13 @@ class CompleteVerification
                 $this->completedAccount = $account;
             });
 
-            // Sync permissions OUTSIDE the transaction so the jobs see committed data.
+            // Sync permissions OUTSIDE the transaction so the service sees committed data.
             // Only sync this specific account — not all of the user's accounts.
             if ($this->completedAccount) {
                 $user = $verification->user;
                 $account = $this->completedAccount;
 
-                $rank = $user->membership_level->minecraftRank();
-                if ($rank !== null) {
-                    SendMinecraftCommand::dispatch(
-                        "lh setmember {$account->username} {$rank}",
-                        'rank',
-                        $account->username,
-                        $user,
-                        ['action' => 'sync_rank', 'membership_level' => $user->membership_level->value]
-                    );
-
-                    RecordActivity::handle(
-                        $user,
-                        'minecraft_rank_synced',
-                        "Synced Minecraft rank to {$rank} for {$account->username}"
-                    );
-                }
-
-                if ($user->staff_department !== null) {
-                    SendMinecraftCommand::dispatch(
-                        "lh setstaff {$account->username} {$user->staff_department->value}",
-                        'rank',
-                        $account->username,
-                        $user,
-                        ['action' => 'set_staff_position', 'department' => $user->staff_department->value]
-                    );
-
-                    RecordActivity::handle(
-                        $user,
-                        'minecraft_staff_position_set',
-                        "Set Minecraft staff position to {$user->staff_department->label()} for {$account->username}"
-                    );
-                }
+                SyncMinecraftAccount::run($account);
 
                 // Grant new-player reward (first verified account only).
                 // Wrapped in try/catch so reward failures never block a successful verification.

--- a/app/Actions/DemoteUser.php
+++ b/app/Actions/DemoteUser.php
@@ -32,7 +32,7 @@ class DemoteUser
 
         RecordActivity::handle($user, 'user_demoted', "Demoted from {$current->label()} to {$previousLevel->label()}.");
 
-        SyncMinecraftRanks::run($user);
+        SyncMinecraftPermissions::run($user);
         SyncDiscordRoles::run($user);
     }
 }

--- a/app/Actions/PromoteUser.php
+++ b/app/Actions/PromoteUser.php
@@ -56,7 +56,7 @@ class PromoteUser
 
         RecordActivity::run($user, 'user_promoted', "Promoted from {$current->label()} to {$nextLevel->label()}.");
 
-        SyncMinecraftRanks::run($user);
+        SyncMinecraftPermissions::run($user);
 
         try {
             SyncDiscordRoles::run($user);

--- a/app/Actions/ReactivateMinecraftAccount.php
+++ b/app/Actions/ReactivateMinecraftAccount.php
@@ -5,7 +5,6 @@ namespace App\Actions;
 use App\Enums\MinecraftAccountStatus;
 use App\Models\MinecraftAccount;
 use App\Models\User;
-use App\Services\MinecraftRconService;
 use Lorisleiva\Actions\Concerns\AsAction;
 
 class ReactivateMinecraftAccount
@@ -45,33 +44,22 @@ class ReactivateMinecraftAccount
             ];
         }
 
-        $rconService = app(MinecraftRconService::class);
-
-        $whitelistResult = $rconService->executeCommand(
-            $account->whitelistAddCommand(),
-            'whitelist',
-            $account->username,
-            $user,
-            ['action' => 'reactivate']
-        );
-
-        if (! $whitelistResult['success']) {
-            return [
-                'success' => false,
-                'message' => 'Failed to add player to server whitelist. Please try again later.',
-            ];
-        }
-
         $account->status = MinecraftAccountStatus::Active;
         $account->save();
 
         // If user has no primary account, make this reactivated one primary
         AutoAssignPrimaryAccount::run($owner);
 
-        SyncMinecraftRanks::run($owner);
+        $syncResult = SyncMinecraftAccount::run($account);
 
-        if ($owner->staff_department !== null) {
-            SyncMinecraftStaff::run($owner, $owner->staff_department);
+        if (! $syncResult['whitelist']['success']) {
+            $account->status = MinecraftAccountStatus::Removed;
+            $account->save();
+
+            return [
+                'success' => false,
+                'message' => 'Failed to add player to server whitelist. Please try again later.',
+            ];
         }
 
         RecordActivity::run(

--- a/app/Actions/ReleaseUserFromBrig.php
+++ b/app/Actions/ReleaseUserFromBrig.php
@@ -44,44 +44,19 @@ class ReleaseUserFromBrig
         // Restore all banned Minecraft accounts
         foreach ($target->minecraftAccounts()->where('status', MinecraftAccountStatus::Banned->value)->get() as $account) {
             try {
-                if ($mcRestoreStatus === MinecraftAccountStatus::Active) {
-                    SendMinecraftCommand::run(
-                        $account->whitelistAddCommand(),
-                        'whitelist',
-                        $account->username,
-                        $target
-                    );
-                }
                 $account->status = $mcRestoreStatus;
                 $account->save();
+
+                if ($mcRestoreStatus === MinecraftAccountStatus::Active) {
+                    SyncMinecraftAccount::run($account);
+                }
             } catch (\Exception $e) {
-                Log::error('Failed to whitelist account on brig release', [
+                Log::error('Failed to restore Minecraft account on brig release', [
                     'username' => $account->username,
                     'user_id' => $target->id,
                     'error' => $e->getMessage(),
                     'exception' => $e,
                 ]);
-            }
-        }
-
-        if ($mcRestoreStatus === MinecraftAccountStatus::Active) {
-            try {
-                SyncMinecraftRanks::run($target);
-            } catch (\Exception $e) {
-                Log::error('Failed to sync Minecraft ranks on brig release', [
-                    'user_id' => $target->id,
-                    'error' => $e->getMessage(),
-                ]);
-            }
-            if ($target->staff_department !== null) {
-                try {
-                    SyncMinecraftStaff::run($target, $target->staff_department);
-                } catch (\Exception $e) {
-                    Log::error('Failed to sync Minecraft staff on brig release', [
-                        'user_id' => $target->id,
-                        'error' => $e->getMessage(),
-                    ]);
-                }
             }
         }
 

--- a/app/Actions/SyncMinecraftAccount.php
+++ b/app/Actions/SyncMinecraftAccount.php
@@ -1,0 +1,127 @@
+<?php
+
+namespace App\Actions;
+
+use App\Models\MinecraftAccount;
+use App\Services\MinecraftRconService;
+use Lorisleiva\Actions\Concerns\AsAction;
+
+class SyncMinecraftAccount
+{
+    use AsAction;
+
+    /**
+     * Compute and apply the desired Minecraft state for a single active account.
+     *
+     * Evaluates whitelist eligibility, member rank, and staff assignment from the
+     * account owner's current website state — membership level, brig status, and
+     * parent Minecraft restrictions — and sends the appropriate RCON commands to
+     * realise that state. Stale whitelist or staff access is removed when the user
+     * is no longer eligible.
+     *
+     * @return array{
+     *     eligible: bool,
+     *     whitelist: array{success: bool, action: string},
+     *     rank: array{success: bool, rank: string}|null,
+     *     staff: array{success: bool, action: string, department: string|null}|null,
+     * }
+     */
+    public function handle(MinecraftAccount $account): array
+    {
+        $user = $account->user;
+        $rcon = app(MinecraftRconService::class);
+
+        $rank = $user->membership_level->minecraftRank();
+        $eligible = $rank !== null && ! $user->isInBrig() && $user->parent_allows_minecraft;
+
+        if (! $eligible) {
+            $whitelistResult = $rcon->executeCommand(
+                $account->whitelistRemoveCommand(),
+                'whitelist',
+                $account->username,
+                $user,
+                ['action' => 'sync_remove_ineligible']
+            );
+
+            return [
+                'eligible' => false,
+                'whitelist' => ['success' => $whitelistResult['success'], 'action' => 'remove'],
+                'rank' => null,
+                'staff' => null,
+            ];
+        }
+
+        $whitelistResult = $rcon->executeCommand(
+            $account->whitelistAddCommand(),
+            'whitelist',
+            $account->username,
+            $user,
+            ['action' => 'sync_add_eligible']
+        );
+
+        $rankResult = $rcon->executeCommand(
+            "lh setmember {$account->username} {$rank}",
+            'rank',
+            $account->username,
+            $user,
+            ['action' => 'sync_rank', 'membership_level' => $user->membership_level->value]
+        );
+
+        RecordActivity::handle(
+            $user,
+            'minecraft_rank_synced',
+            "Synced Minecraft rank to {$rank} for {$account->username}"
+        );
+
+        $staffDepartment = $user->staff_department;
+
+        if ($staffDepartment !== null) {
+            $staffResult = $rcon->executeCommand(
+                "lh setstaff {$account->username} {$staffDepartment->value}",
+                'staff',
+                $account->username,
+                $user,
+                ['action' => 'set_staff_position', 'department' => $staffDepartment->value]
+            );
+
+            RecordActivity::handle(
+                $user,
+                'minecraft_staff_position_set',
+                "Set Minecraft staff position to {$staffDepartment->label()} for {$account->username}"
+            );
+
+            $staffReturn = [
+                'success' => $staffResult['success'],
+                'action' => 'set',
+                'department' => $staffDepartment->value,
+            ];
+        } else {
+            $staffResult = $rcon->executeCommand(
+                "lh removestaff {$account->username}",
+                'staff',
+                $account->username,
+                $user,
+                ['action' => 'remove_staff_position']
+            );
+
+            RecordActivity::handle(
+                $user,
+                'minecraft_staff_position_removed',
+                "Removed Minecraft staff position for {$account->username}"
+            );
+
+            $staffReturn = [
+                'success' => $staffResult['success'],
+                'action' => 'remove',
+                'department' => null,
+            ];
+        }
+
+        return [
+            'eligible' => true,
+            'whitelist' => ['success' => $whitelistResult['success'], 'action' => 'add'],
+            'rank' => ['success' => $rankResult['success'], 'rank' => $rank],
+            'staff' => $staffReturn,
+        ];
+    }
+}

--- a/app/Actions/SyncMinecraftPermissions.php
+++ b/app/Actions/SyncMinecraftPermissions.php
@@ -10,14 +10,18 @@ class SyncMinecraftPermissions
     use AsAction;
 
     /**
-     * Sync all Minecraft permissions for a user — both membership rank and staff position.
+     * Sync all Minecraft permissions for a user across every active account.
      *
-     * Calls SyncMinecraftRanks (which handles the server-access guard) and
-     * SyncMinecraftStaff (passing the user's current department, or null to remove staff).
+     * Delegates to SyncMinecraftAccount for each active account, which applies
+     * the authoritative desired state: whitelist eligibility, member rank, and
+     * staff assignment — all in one consistent synchronous pass.
      */
     public function handle(User $user): void
     {
-        SyncMinecraftRanks::run($user);
-        SyncMinecraftStaff::run($user, $user->staff_department);
+        $activeAccounts = $user->minecraftAccounts()->active()->get();
+
+        foreach ($activeAccounts as $account) {
+            SyncMinecraftAccount::run($account);
+        }
     }
 }

--- a/app/Actions/SyncMinecraftRanks.php
+++ b/app/Actions/SyncMinecraftRanks.php
@@ -28,12 +28,13 @@ class SyncMinecraftRanks
         $activeAccounts = $user->minecraftAccounts()->active()->get();
 
         foreach ($activeAccounts as $account) {
-            SendMinecraftCommand::dispatch(
+            SendMinecraftCommand::run(
                 "lh setmember {$account->username} {$rank}",
                 'rank',
                 $account->username,
                 $user,
-                ['action' => 'sync_rank', 'membership_level' => $user->membership_level->value]
+                ['action' => 'sync_rank', 'membership_level' => $user->membership_level->value],
+                false
             );
 
             RecordActivity::handle(

--- a/app/Actions/SyncMinecraftStaff.php
+++ b/app/Actions/SyncMinecraftStaff.php
@@ -26,12 +26,13 @@ class SyncMinecraftStaff
 
         foreach ($activeAccounts as $account) {
             if ($department !== null) {
-                SendMinecraftCommand::dispatch(
+                SendMinecraftCommand::run(
                     "lh setstaff {$account->username} {$department->value}",
                     'staff',
                     $account->username,
                     $user,
-                    ['action' => 'set_staff_position', 'department' => $department->value]
+                    ['action' => 'set_staff_position', 'department' => $department->value],
+                    false
                 );
 
                 RecordActivity::handle(
@@ -40,12 +41,13 @@ class SyncMinecraftStaff
                     "Set Minecraft staff position to {$department->label()} for {$account->username}"
                 );
             } else {
-                SendMinecraftCommand::dispatch(
+                SendMinecraftCommand::run(
                     "lh removestaff {$account->username}",
                     'staff',
                     $account->username,
                     $user,
-                    ['action' => 'remove_staff_position']
+                    ['action' => 'remove_staff_position'],
+                    false
                 );
 
                 RecordActivity::handle(

--- a/app/Actions/UpdateChildPermission.php
+++ b/app/Actions/UpdateChildPermission.php
@@ -75,16 +75,11 @@ class UpdateChildPermission
         if (! $enabled) {
             foreach ($child->minecraftAccounts()->whereIn('status', [MinecraftAccountStatus::Active, MinecraftAccountStatus::Verifying])->get() as $account) {
                 try {
-                    SendMinecraftCommand::run(
-                        $account->whitelistRemoveCommand(),
-                        'whitelist',
-                        $account->username,
-                        $parent
-                    );
                     $account->status = MinecraftAccountStatus::ParentDisabled;
                     $account->save();
+                    SyncMinecraftAccount::run($account);
                 } catch (\Exception $e) {
-                    Log::warning('Failed to whitelist-remove MC account for parent disable', [
+                    Log::warning('Failed to disable MC account for parent disable', [
                         'username' => $account->username,
                         'error' => $e->getMessage(),
                     ]);
@@ -93,29 +88,15 @@ class UpdateChildPermission
         } else {
             foreach ($child->minecraftAccounts()->where('status', MinecraftAccountStatus::ParentDisabled)->get() as $account) {
                 try {
-                    SendMinecraftCommand::run(
-                        $account->whitelistAddCommand(),
-                        'whitelist',
-                        $account->username,
-                        $parent
-                    );
                     $account->status = MinecraftAccountStatus::Active;
                     $account->save();
+                    SyncMinecraftAccount::run($account);
                 } catch (\Exception $e) {
-                    Log::warning('Failed to whitelist-add MC account for parent enable', [
+                    Log::warning('Failed to enable MC account for parent enable', [
                         'username' => $account->username,
                         'error' => $e->getMessage(),
                     ]);
                 }
-            }
-
-            try {
-                SyncMinecraftRanks::run($child);
-            } catch (\Exception $e) {
-                Log::error('Failed to sync MC ranks after parent enable', [
-                    'user_id' => $child->id,
-                    'error' => $e->getMessage(),
-                ]);
             }
         }
 

--- a/app/Console/Commands/RepairMinecraftPermissions.php
+++ b/app/Console/Commands/RepairMinecraftPermissions.php
@@ -1,0 +1,177 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\MinecraftAccount;
+use App\Services\MinecraftRconService;
+use Illuminate\Console\Command;
+
+class RepairMinecraftPermissions extends Command
+{
+    protected $signature = 'minecraft:repair-permissions
+        {--dry-run : Print planned actions without sending Minecraft commands}
+        {--pace=1 : Seconds to pause between outbound commands (use 0 for testing)}';
+
+    protected $description = 'Repair Minecraft whitelist, member rank, and staff state for all active accounts';
+
+    public function handle(): int
+    {
+        $dryRun = (bool) $this->option('dry-run');
+        $pace = max(0, (int) $this->option('pace'));
+
+        $mode = $dryRun ? 'DRY RUN' : 'LIVE';
+        $this->info("minecraft:repair-permissions [{$mode}]");
+        $this->newLine();
+
+        $accounts = MinecraftAccount::active()->with('user')->get();
+
+        if ($accounts->isEmpty()) {
+            $this->info('No active Minecraft accounts found.');
+
+            return Command::SUCCESS;
+        }
+
+        $counts = [
+            'adds' => 0,
+            'removes' => 0,
+            'rank_changes' => 0,
+            'staff_changes' => 0,
+            'failures' => 0,
+        ];
+
+        $rcon = $dryRun ? null : app(MinecraftRconService::class);
+        $firstCommand = true;
+
+        foreach ($accounts as $account) {
+            $user = $account->user;
+            $rank = $user->membership_level->minecraftRank();
+            $eligible = $rank !== null && ! $user->isInBrig() && $user->parent_allows_minecraft;
+
+            $this->line("  <fg=cyan>{$account->username}</> ({$user->name})");
+
+            if ($eligible) {
+                $staffDepartment = $user->staff_department;
+
+                // ── Whitelist add ─────────────────────────────────────────────
+                $whitelistCmd = $account->whitelistAddCommand();
+                if ($dryRun) {
+                    $this->line("    [dry-run] {$whitelistCmd}");
+                    $counts['adds']++;
+                } else {
+                    $firstCommand = $this->pauseIfNeeded($firstCommand, $pace);
+                    $result = $rcon->executeCommand(
+                        $whitelistCmd, 'whitelist', $account->username, $user,
+                        ['action' => 'repair_whitelist_add']
+                    );
+                    $this->reportResult($whitelistCmd, $result['success']);
+                    $result['success'] ? $counts['adds']++ : $counts['failures']++;
+                }
+
+                // ── Member rank ───────────────────────────────────────────────
+                $rankCmd = "lh setmember {$account->username} {$rank}";
+                if ($dryRun) {
+                    $this->line("    [dry-run] {$rankCmd}");
+                    $counts['rank_changes']++;
+                } else {
+                    $firstCommand = $this->pauseIfNeeded($firstCommand, $pace);
+                    $result = $rcon->executeCommand(
+                        $rankCmd, 'rank', $account->username, $user,
+                        ['action' => 'repair_rank', 'rank' => $rank]
+                    );
+                    $this->reportResult($rankCmd, $result['success']);
+                    $result['success'] ? $counts['rank_changes']++ : $counts['failures']++;
+                }
+
+                // ── Staff position ────────────────────────────────────────────
+                $staffCmd = $staffDepartment !== null
+                    ? "lh setstaff {$account->username} {$staffDepartment->value}"
+                    : "lh removestaff {$account->username}";
+
+                if ($dryRun) {
+                    $this->line("    [dry-run] {$staffCmd}");
+                    $counts['staff_changes']++;
+                } else {
+                    $firstCommand = $this->pauseIfNeeded($firstCommand, $pace);
+                    $result = $rcon->executeCommand(
+                        $staffCmd, 'staff', $account->username, $user,
+                        ['action' => $staffDepartment !== null ? 'repair_staff_set' : 'repair_staff_remove']
+                    );
+                    $this->reportResult($staffCmd, $result['success']);
+                    $result['success'] ? $counts['staff_changes']++ : $counts['failures']++;
+                }
+            } else {
+                // ── Ineligible: whitelist remove ──────────────────────────────
+                $reason = $this->ineligibilityReason($user, $rank);
+                $removeCmd = $account->whitelistRemoveCommand();
+
+                if ($dryRun) {
+                    $this->line("    [dry-run] {$removeCmd}");
+                    $this->line("      ({$reason})");
+                    $counts['removes']++;
+                } else {
+                    $firstCommand = $this->pauseIfNeeded($firstCommand, $pace);
+                    $result = $rcon->executeCommand(
+                        $removeCmd, 'whitelist', $account->username, $user,
+                        ['action' => 'repair_whitelist_remove', 'reason' => $reason]
+                    );
+                    $this->reportResult($removeCmd, $result['success']);
+                    $result['success'] ? $counts['removes']++ : $counts['failures']++;
+                }
+            }
+        }
+
+        $this->printSummary($counts, $dryRun);
+
+        return Command::SUCCESS;
+    }
+
+    /**
+     * Sleep between commands if this is not the first outbound command in the run.
+     * Returns false to signal the caller to clear the "first command" flag.
+     */
+    private function pauseIfNeeded(bool $firstCommand, int $pace): bool
+    {
+        if (! $firstCommand && $pace > 0) {
+            sleep($pace);
+        }
+
+        return false;
+    }
+
+    private function reportResult(string $command, bool $success): void
+    {
+        if ($success) {
+            $this->line("    <fg=green>✓</> {$command}");
+        } else {
+            $this->line("    <fg=red>✗</> {$command}");
+        }
+    }
+
+    private function ineligibilityReason(mixed $user, ?string $rank): string
+    {
+        if ($rank === null) {
+            return 'below server access threshold';
+        }
+        if ($user->isInBrig()) {
+            return 'in brig';
+        }
+
+        return 'parent disabled';
+    }
+
+    private function printSummary(array $counts, bool $dryRun): void
+    {
+        $prefix = $dryRun ? '[dry-run] ' : '';
+
+        $this->newLine();
+        $this->info('─── Summary ───────────────────────────────────────');
+        $this->line("  {$prefix}Whitelist adds:    {$counts['adds']}");
+        $this->line("  {$prefix}Whitelist removes: {$counts['removes']}");
+        $this->line("  {$prefix}Rank changes:      {$counts['rank_changes']}");
+        $this->line("  {$prefix}Staff changes:     {$counts['staff_changes']}");
+
+        if (! $dryRun) {
+            $this->line("  Failures:          {$counts['failures']}");
+        }
+    }
+}

--- a/app/Services/MinecraftRconService.php
+++ b/app/Services/MinecraftRconService.php
@@ -43,24 +43,24 @@ class MinecraftRconService
         ]);
 
         try {
-            $rcon = new Rcon(
-                config('services.minecraft.rcon_host'),
-                config('services.minecraft.rcon_port'),
-                config('services.minecraft.rcon_password'),
-                3 // timeout in seconds
-            );
+            ['connected' => $connected, 'result' => $result] = $this->connectAndSend($command);
 
-            if ($rcon->connect()) {
-                $result = $rcon->sendCommand($command);
-                if ($result === false) {
-                    $response = null;
-                    $errorMessage = 'Failed to send command to RCON server';
+            if (! $connected) {
+                $errorMessage = 'Failed to connect to RCON server';
+            } elseif ($result === false) {
+                $response = null;
+                $errorMessage = 'Failed to send command to RCON server';
+            } else {
+                $response = $result;
+                if ($this->isLhCommand($command)) {
+                    if (str_starts_with(trim($response), 'Success:')) {
+                        $status = 'success';
+                    } else {
+                        $errorMessage = 'lh command returned non-success response: '.(empty($response) ? '(empty)' : $response);
+                    }
                 } else {
-                    $response = $result;
                     $status = 'success';
                 }
-            } else {
-                $errorMessage = 'Failed to connect to RCON server';
             }
         } catch (\Exception $e) {
             $errorMessage = $e->getMessage();
@@ -81,5 +81,33 @@ class MinecraftRconService
             'response' => $response,
             'error' => $errorMessage,
         ];
+    }
+
+    /**
+     * Open an RCON connection and send a command.
+     *
+     * Returns ['connected' => true, 'result' => string|false] on successful connection,
+     * or ['connected' => false, 'result' => null] when the connection itself fails.
+     * Extracted as a protected method so tests can override it with simulated responses.
+     */
+    protected function connectAndSend(string $command): array
+    {
+        $rcon = new Rcon(
+            config('services.minecraft.rcon_host'),
+            config('services.minecraft.rcon_port'),
+            config('services.minecraft.rcon_password'),
+            3 // timeout in seconds
+        );
+
+        if (! $rcon->connect()) {
+            return ['connected' => false, 'result' => null];
+        }
+
+        return ['connected' => true, 'result' => $rcon->sendCommand($command)];
+    }
+
+    private function isLhCommand(string $command): bool
+    {
+        return str_starts_with($command, 'lh ');
     }
 }

--- a/docs/features/Minecraft Permission Hardening and Bulk Repair.md
+++ b/docs/features/Minecraft Permission Hardening and Bulk Repair.md
@@ -1,0 +1,800 @@
+# Minecraft Permission Hardening and Bulk Repair -- Technical Documentation
+
+> **Audience:** Project owner, developers, AI agents
+> **Generated:** 2026-03-24
+> **Generator:** `/document-feature` skill
+
+---
+
+## Table of Contents
+
+1. [Overview](#1-overview)
+2. [Database Schema](#2-database-schema)
+3. [Models & Relationships](#3-models--relationships)
+4. [Enums Reference](#4-enums-reference)
+5. [Authorization & Permissions](#5-authorization--permissions)
+6. [Routes](#6-routes)
+7. [User Interface Components](#7-user-interface-components)
+8. [Actions (Business Logic)](#8-actions-business-logic)
+9. [Notifications](#9-notifications)
+10. [Background Jobs](#10-background-jobs)
+11. [Console Commands & Scheduled Tasks](#11-console-commands--scheduled-tasks)
+12. [Services](#12-services)
+13. [Activity Log Entries](#13-activity-log-entries)
+14. [Data Flow Diagrams](#14-data-flow-diagrams)
+15. [Configuration](#15-configuration)
+16. [Test Coverage](#16-test-coverage)
+17. [File Map](#17-file-map)
+18. [Known Issues & Improvement Opportunities](#18-known-issues--improvement-opportunities)
+
+---
+
+## 1. Overview
+
+This feature encompasses two closely related hardening efforts: (1) making the `MinecraftRconService` treat custom `lh` plugin commands as failed unless the server responds with a `Success:` prefix, and (2) consolidating all desired-state Minecraft synchronisation into a single, authoritative code path shared by lifecycle events and an administrative bulk-repair command.
+
+Prior to this work, `lh` plugin commands (e.g., `lh setmember`, `lh setstaff`, `lh removestaff`) were treated as successful as long as RCON delivered any response, including empty strings or error messages from the plugin. The hardening change means any `lh` command response that does not start with `Success:` is now logged as `failed`, surfacing silent permission-drift that was previously invisible in logs.
+
+The unified sync path is implemented as `SyncMinecraftAccount` (single account) and `SyncMinecraftPermissions` (all active accounts for a user). Every lifecycle transition — promotion, demotion, brig release, parent permission toggle, and account reactivation — now funnels through these two actions instead of calling disparate rank and staff actions independently. This guarantees that whitelist eligibility, member rank, and staff position are always evaluated together and applied atomically from the server's perspective.
+
+The `minecraft:repair-permissions` Artisan command provides operators with a bulk-repair tool that iterates over all active Minecraft accounts in the database, applies the same desired-state logic as `SyncMinecraftAccount`, and produces a detailed summary of actions taken. A `--dry-run` flag allows safe inspection before any RCON commands are sent, and a `--pace` flag throttles command throughput to avoid flooding the Minecraft server.
+
+The primary audiences are server administrators (who run `minecraft:repair-permissions` after deployments, server restarts, or data migrations) and the application itself (which calls `SyncMinecraftPermissions` on every membership or staff state change).
+
+---
+
+## 2. Database Schema
+
+### `minecraft_accounts` table
+
+| Column | Type | Nullable | Default | Notes |
+|--------|------|----------|---------|-------|
+| `id` | bigint unsigned | No | auto | Primary key |
+| `user_id` | bigint unsigned | No | — | FK to `users.id`, cascades on delete |
+| `username` | varchar | No | — | Minecraft Java username or Bedrock gamertag |
+| `uuid` | varchar | No | — | Unique; Java UUID or Floodgate UUID for Bedrock |
+| `bedrock_xuid` | varchar | Yes | null | Bedrock Xbox User ID |
+| `avatar_url` | varchar | Yes | null | Cached avatar image URL |
+| `account_type` | varchar | No | — | `java` or `bedrock` |
+| `status` | enum | No | `verifying` | `verifying`, `active`, `cancelling`, `cancelled`, `banned`, `removed`, `parent_disabled` |
+| `is_primary` | boolean | No | false | Whether this is the user's primary account |
+| `verified_at` | timestamp | Yes | null | When verification completed |
+| `last_username_check_at` | timestamp | Yes | null | Last username refresh check |
+| `created_at` | timestamp | Yes | null | |
+| `updated_at` | timestamp | Yes | null | |
+
+**Indexes:** `status` (single), `last_username_check_at` (single), `uuid` (unique)
+**Foreign Keys:** `user_id` → `users.id` ON DELETE CASCADE
+**Migrations:**
+- `database/migrations/2026_02_17_064252_create_minecraft_accounts_table.php`
+- `database/migrations/2026_02_19_000001_add_avatar_url_to_minecraft_accounts_table.php`
+- `database/migrations/2026_02_20_060607_add_status_and_command_id_to_minecraft_accounts_table.php`
+- `database/migrations/2026_02_20_063640_make_verified_at_nullable_on_minecraft_accounts_table.php`
+- `database/migrations/2026_02_20_072300_make_verified_at_nullable_on_minecraft_accounts_table.php`
+- `database/migrations/2026_02_21_100000_add_banned_status_to_minecraft_accounts_table.php`
+- `database/migrations/2026_02_22_000000_drop_command_id_from_minecraft_accounts_table.php`
+- `database/migrations/2026_02_26_000000_add_removed_status_to_minecraft_accounts_table.php`
+- `database/migrations/2026_02_27_100000_add_is_primary_to_minecraft_accounts_table.php`
+- `database/migrations/2026_02_28_043322_add_bedrock_xuid_to_minecraft_accounts_table.php`
+- `database/migrations/2026_03_01_000002_add_parent_disabled_status_to_minecraft_accounts_table.php`
+- `database/migrations/2026_03_18_040000_add_cancelling_status_to_minecraft_accounts_table.php`
+
+### `minecraft_command_logs` table
+
+| Column | Type | Nullable | Default | Notes |
+|--------|------|----------|---------|-------|
+| `id` | bigint unsigned | No | auto | Primary key |
+| `user_id` | bigint unsigned | Yes | null | FK to `users.id`, nulls on delete |
+| `command` | varchar | No | — | Full RCON command string |
+| `command_type` | varchar | No | — | Category: `whitelist`, `rank`, `staff`, etc. |
+| `target` | varchar | Yes | null | Player or entity name |
+| `status` | enum | No | — | `success`, `failed`, `timeout` |
+| `response` | text | Yes | null | Raw RCON response string |
+| `error_message` | text | Yes | null | Failure reason |
+| `ip_address` | varchar | Yes | null | Originating request IP |
+| `meta` | json | Yes | null | Additional context (action, department, etc.) |
+| `executed_at` | timestamp | No | current | When the command was sent |
+| `execution_time_ms` | integer | Yes | null | Round-trip time in milliseconds |
+| `created_at` | timestamp | Yes | null | |
+| `updated_at` | timestamp | Yes | null | |
+
+**Indexes:** `command_type` (single), `status` (single), `(command_type, status)` (composite), `executed_at` (single)
+**Foreign Keys:** `user_id` → `users.id` ON DELETE SET NULL
+**Migration:** `database/migrations/2026_02_17_064300_create_minecraft_command_logs_table.php`
+
+---
+
+## 3. Models & Relationships
+
+### MinecraftAccount (`app/Models/MinecraftAccount.php`)
+
+**Relationships:**
+
+| Method | Type | Related Model | Notes |
+|--------|------|---------------|-------|
+| `user()` | belongsTo | User | Account owner |
+| `rewards()` | hasMany | MinecraftReward | In-game reward records |
+
+**Scopes:**
+
+| Scope | Filters |
+|-------|---------|
+| `scopeActive` | `status = active` |
+| `scopeVerifying` | `status = verifying` |
+| `scopeCancelling` | `status = cancelling` |
+| `scopeCancelled` | `status = cancelled` |
+| `scopeRemoved` | `status = removed` |
+| `scopePrimary` | `is_primary = true` |
+| `scopeCountingTowardLimit` | `status IN (active, verifying, banned)` |
+| `scopeWhereNormalizedUuid` | UUID match ignoring hyphens |
+
+**Key Methods:**
+- `whitelistAddCommand(): string` -- returns `whitelist add <username>` for Java or `fwhitelist add <uuid>` for Bedrock
+- `whitelistRemoveCommand(): string` -- returns `whitelist remove <username>` for Java or `fwhitelist remove <uuid>` for Bedrock
+
+**Casts:**
+- `account_type` => `MinecraftAccountType`
+- `status` => `MinecraftAccountStatus`
+- `is_primary` => `boolean`
+- `verified_at` => `datetime`
+- `last_username_check_at` => `datetime`
+
+### MinecraftCommandLog (`app/Models/MinecraftCommandLog.php`)
+
+**Relationships:**
+
+| Method | Type | Related Model | Notes |
+|--------|------|---------------|-------|
+| `user()` | belongsTo | User | User who triggered the command |
+
+**Scopes:**
+
+| Scope | Filters |
+|-------|---------|
+| `scopeSuccessful` | `status = success` |
+| `scopeFailed` | `status = failed` |
+
+**Casts:**
+- `meta` => `array`
+- `executed_at` => `datetime`
+
+---
+
+## 4. Enums Reference
+
+### MinecraftAccountStatus (`app/Enums/MinecraftAccountStatus.php`)
+
+| Case | Value | Label | Color | Notes |
+|------|-------|-------|-------|-------|
+| `Verifying` | `verifying` | Pending Verification | yellow | During token-based verification flow |
+| `Active` | `active` | Active | green | On whitelist, eligible |
+| `Cancelling` | `cancelling` | Cancelling Verification | amber | Verification being cancelled |
+| `Cancelled` | `cancelled` | Cancelled | red | Verification cancelled |
+| `Banned` | `banned` | Banned | orange | Temporarily blocked (e.g., in brig) |
+| `Removed` | `removed` | Removed | zinc | Manually removed by user or admin |
+| `ParentDisabled` | `parent_disabled` | Disabled by Parent | purple | Parent toggled Minecraft off |
+
+**Helper methods:** `label(): string`, `color(): string`
+
+### MinecraftAccountType (`app/Enums/MinecraftAccountType.php`)
+
+| Case | Value | Label |
+|------|-------|-------|
+| `Java` | `java` | Java Edition |
+| `Bedrock` | `bedrock` | Bedrock Edition |
+
+**Helper methods:** `label(): string`
+
+### MembershipLevel (`app/Enums/MembershipLevel.php`)
+
+| Case | Value | Label | Minecraft Rank | Notes |
+|------|-------|-------|----------------|-------|
+| `Drifter` | `0` | Drifter | null | Below server threshold |
+| `Stowaway` | `1` | Stowaway | null | Below server threshold |
+| `Traveler` | `2` | Traveler | `traveler` | Minimum eligible level |
+| `Resident` | `3` | Resident | `resident` | |
+| `Citizen` | `4` | Citizen | `citizen` | |
+
+**Helper methods:** `label(): string`, `discordRoleId(): ?string`, `minecraftRank(): ?string`
+
+The `minecraftRank()` method is the authoritative source for eligibility: a `null` return value means the user should not be on the Minecraft server.
+
+### StaffDepartment (`app/Enums/StaffDepartment.php`)
+
+| Case | Value | Label |
+|------|-------|-------|
+| `Command` | `command` | Command |
+| `Chaplain` | `chaplain` | Chaplain |
+| `Engineer` | `engineer` | Engineer |
+| `Quartermaster` | `quartermaster` | Quartermaster |
+| `Steward` | `steward` | Steward |
+
+**Helper methods:** `label(): string`, `discordRoleId(): ?string`
+
+---
+
+## 5. Authorization & Permissions
+
+### Gates (from `AuthServiceProvider`)
+
+| Gate Name | Who Can Pass | Logic Summary |
+|-----------|-------------|---------------|
+| `link-minecraft-account` | Traveler+ members not in brig with parent permission | `isAtLeastLevel(Traveler) && !in_brig && parent_allows_minecraft` |
+| `view-mc-command-log` | Users with "Logs - Viewer" role | `hasRole('Logs - Viewer')` |
+
+### Policies
+
+No Eloquent Policy classes are involved in this feature. Authorization for account management is handled via gates in `AuthServiceProvider` and role checks. The `minecraft:repair-permissions` Artisan command is protected by operating-system-level access (only users with shell access to the server can run it).
+
+### Permissions Matrix
+
+| User Type | Run repair-permissions | Sync permissions (automatic) | View command log |
+|-----------|----------------------|------------------------------|-----------------|
+| Drifter / Stowaway | No (shell access required) | Yes (lifecycle-triggered) | No |
+| Traveler / Resident / Citizen | No (shell access required) | Yes (lifecycle-triggered) | No |
+| Staff (no Logs role) | No (shell access required) | Yes (lifecycle-triggered) | No |
+| Staff with "Logs - Viewer" | No (shell access required) | Yes (lifecycle-triggered) | Yes |
+| Server operator (SSH) | Yes | N/A | N/A |
+
+---
+
+## 6. Routes
+
+Not applicable for this feature. The feature is entirely driven through Action classes called from other lifecycle actions and from the Artisan console. There are no dedicated HTTP routes.
+
+---
+
+## 7. User Interface Components
+
+Not applicable for this feature. The `minecraft:repair-permissions` command is a CLI-only tool. Permission synchronisation happens silently in the background as a side-effect of promotion, demotion, brig release, parent permission toggle, and account reactivation.
+
+The `minecraft_command_logs` table is viewable through the Admin Control Panel via the `view-mc-command-log` gate, but that ACP component is documented in the Admin Control Panel feature document, not here.
+
+---
+
+## 8. Actions (Business Logic)
+
+### SyncMinecraftAccount (`app/Actions/SyncMinecraftAccount.php`)
+
+**Signature:** `handle(MinecraftAccount $account): array`
+
+**Return type:**
+```php
+array{
+    eligible: bool,
+    whitelist: array{success: bool, action: string},
+    rank: array{success: bool, rank: string}|null,
+    staff: array{success: bool, action: string, department: string|null}|null,
+}
+```
+
+**Eligibility determination:**
+```php
+$rank = $user->membership_level->minecraftRank();  // null = ineligible
+$eligible = $rank !== null && !$user->isInBrig() && $user->parent_allows_minecraft;
+```
+
+**Step-by-step logic (ineligible path):**
+1. Evaluates eligibility from the account owner's `membership_level`, `isInBrig()`, and `parent_allows_minecraft`
+2. Sends `whitelistRemoveCommand()` via `MinecraftRconService::executeCommand()` with meta `['action' => 'sync_remove_ineligible']`
+3. Returns `eligible: false`, `whitelist: {action: 'remove'}`, `rank: null`, `staff: null`
+
+**Step-by-step logic (eligible path):**
+1. Sends `whitelistAddCommand()` via RCON with meta `['action' => 'sync_add_eligible']`
+2. Sends `lh setmember <username> <rank>` via RCON with meta `['action' => 'sync_rank', 'membership_level' => ...]`
+3. Logs activity: `RecordActivity::run($user, 'minecraft_rank_synced', "Synced Minecraft rank to {$rank} for {$account->username}")`
+4. If user has `staff_department` set: sends `lh setstaff <username> <department>` and logs `minecraft_staff_position_set`
+5. If user has no `staff_department`: sends `lh removestaff <username>` and logs `minecraft_staff_position_removed`
+6. Returns full result array with `eligible: true`, whitelist/rank/staff outcomes
+
+**Called by:**
+- `SyncMinecraftPermissions::run()` (iterates each active account)
+- `ReactivateMinecraftAccount::run()` (single account on reactivation)
+- `ReleaseUserFromBrig::run()` (each previously-banned account on brig release)
+- `UpdateChildPermission::toggleMinecraft()` (each affected account on parent toggle)
+- `CompleteVerification::handle()` (newly-verified account after verification succeeds)
+
+---
+
+### SyncMinecraftPermissions (`app/Actions/SyncMinecraftPermissions.php`)
+
+**Signature:** `handle(User $user): void`
+
+**Step-by-step logic:**
+1. Fetches all active accounts: `$user->minecraftAccounts()->active()->get()`
+2. Calls `SyncMinecraftAccount::run($account)` for each account
+3. Skips `Removed`, `Verifying`, `Cancelled`, `Banned`, and `ParentDisabled` accounts (only `active` scope is queried)
+
+**Called by:**
+- `PromoteUser::run()` (after membership level is saved)
+- `DemoteUser::run()` (after membership level is saved)
+
+---
+
+### PromoteUser (`app/Actions/PromoteUser.php`)
+
+**Signature:** `handle(User $user, MembershipLevel $maxLevel = MembershipLevel::Citizen)`
+
+**Minecraft-relevant steps:**
+1. Advances `membership_level` by one step
+2. Calls `SyncMinecraftPermissions::run($user)` to push the new rank to all active accounts
+3. Calls `SyncDiscordRoles::run($user)` (Discord, not Minecraft)
+
+---
+
+### DemoteUser (`app/Actions/DemoteUser.php`)
+
+**Signature:** `handle(User $user, MembershipLevel $minLevel = MembershipLevel::Drifter)`
+
+**Minecraft-relevant steps:**
+1. Decrements `membership_level` by one step
+2. Calls `SyncMinecraftPermissions::run($user)` to push the new (lower) rank or remove the user from the whitelist if now below threshold
+3. Calls `SyncDiscordRoles::run($user)` (Discord, not Minecraft)
+
+---
+
+### ReleaseUserFromBrig (`app/Actions/ReleaseUserFromBrig.php`)
+
+**Signature:** `handle(User $target, User $admin, string $reason, bool $notify = true): void`
+
+**Minecraft-relevant steps:**
+1. Clears all brig fields on `$target`
+2. Determines `$mcRestoreStatus`: `Active` if `parent_allows_minecraft`, else `ParentDisabled`
+3. For each `Banned` Minecraft account:
+   - Sets `status` to `$mcRestoreStatus`
+   - If status is `Active`: calls `SyncMinecraftAccount::run($account)` to restore whitelist and rank
+   - Wrapped in `try/catch`; failures are logged but do not abort the release
+4. Continues to Discord restoration (separate concern)
+
+---
+
+### ReactivateMinecraftAccount (`app/Actions/ReactivateMinecraftAccount.php`)
+
+**Signature:** `handle(MinecraftAccount $account, User $user): array`
+
+**Minecraft-relevant steps:**
+1. Guards: status must be `Removed`, not at account limit, not in brig
+2. Sets `status = Active` and saves
+3. Calls `AutoAssignPrimaryAccount::run($owner)` if needed
+4. Calls `SyncMinecraftAccount::run($account)` to whitelist-add and set rank/staff
+5. If `whitelist.success` is false, reverts `status` back to `Removed` and returns failure
+6. Logs `minecraft_account_reactivated` activity on success
+
+---
+
+### UpdateChildPermission (`app/Actions/UpdateChildPermission.php`)
+
+**Signature:** `handle(User $child, User $parent, string $permission, bool $enabled): void`
+
+The `minecraft` permission branch (`toggleMinecraft`):
+
+**Disabling:**
+1. Sets `parent_allows_minecraft = false` and saves
+2. For each `Active` or `Verifying` account: sets `status = ParentDisabled` and calls `SyncMinecraftAccount::run($account)`
+3. `SyncMinecraftAccount` evaluates `parent_allows_minecraft = false` → sends whitelist remove
+4. Logs `parent_permission_changed` activity
+
+**Enabling:**
+1. Sets `parent_allows_minecraft = true` and saves
+2. For each `ParentDisabled` account: sets `status = Active` and calls `SyncMinecraftAccount::run($account)`
+3. `SyncMinecraftAccount` evaluates eligibility → if eligible, sends whitelist add, rank, and staff commands
+4. Logs `parent_permission_changed` activity
+
+---
+
+### SyncMinecraftRanks (`app/Actions/SyncMinecraftRanks.php`) *(legacy, pre-unification)*
+
+**Signature:** `handle(User $user): void`
+
+Sends `lh setmember <username> <rank>` for each active account. This action predates the unified `SyncMinecraftAccount` path. It is still present and exercised by legacy tests in `MinecraftCommandsTest.php`, but lifecycle events now use `SyncMinecraftPermissions`/`SyncMinecraftAccount` instead.
+
+---
+
+### SyncMinecraftStaff (`app/Actions/SyncMinecraftStaff.php`) *(legacy, pre-unification)*
+
+**Signature:** `handle(User $user, ?StaffDepartment $department = null): void`
+
+Sends `lh setstaff <username> <department>` or `lh removestaff <username>` for each active account. Also predates the unified path and is exercised only by legacy tests. Lifecycle events now use `SyncMinecraftPermissions`/`SyncMinecraftAccount`.
+
+---
+
+## 9. Notifications
+
+Not applicable for this feature. No notifications are sent by `SyncMinecraftAccount`, `SyncMinecraftPermissions`, or `minecraft:repair-permissions`. Notifications that accompany lifecycle events (e.g., brig release, promotion) are sent by the calling action (`ReleaseUserFromBrig`, `PromoteUser`), which are separate concerns.
+
+---
+
+## 10. Background Jobs
+
+Not applicable for this feature. All RCON commands are executed synchronously inline. There are no queued jobs involved in permission synchronisation or bulk repair.
+
+---
+
+## 11. Console Commands & Scheduled Tasks
+
+### `minecraft:repair-permissions`
+**File:** `app/Console/Commands/RepairMinecraftPermissions.php`
+**Scheduled:** No — manual invocation only
+**Options:**
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `--dry-run` | false | Print planned commands without sending RCON; RCON is never called |
+| `--pace` | 1 | Seconds to sleep between outbound commands (use 0 in testing) |
+
+**What it does:**
+1. Announces `[DRY RUN]` or `[LIVE]` mode
+2. Loads all `MinecraftAccount::active()->with('user')->get()`
+3. For each account, applies the same eligibility logic as `SyncMinecraftAccount`:
+   - **Eligible:** sends whitelist add, `lh setmember`, and `lh setstaff`/`lh removestaff`
+   - **Ineligible:** sends whitelist remove with reason annotation (in dry-run: shown inline)
+4. Throttles via `pauseIfNeeded()` between commands (skips delay before first command)
+5. Prints a summary table: `Whitelist adds`, `Whitelist removes`, `Rank changes`, `Staff changes`, `Failures`
+6. Returns `Command::SUCCESS` in all non-exception paths
+
+**Note:** The repair command contains its own inline copy of the eligibility calculation rather than delegating to `SyncMinecraftAccount`. This is intentional to support the `--dry-run` flag without side effects; the two paths use the same logic and are verified to produce identical RCON commands by the consistency test suite in `MixedAccountScenariosTest.php`.
+
+---
+
+## 12. Services
+
+### MinecraftRconService (`app/Services/MinecraftRconService.php`)
+
+**Purpose:** Encapsulates RCON connections to the Minecraft server, logs every command to `minecraft_command_logs`, and applies the `lh` command hardening rule.
+
+**Key methods:**
+
+- `executeCommand(string $command, string $commandType, ?string $target, ?User $user, array $meta): array`
+  - Creates a `MinecraftCommandLog` record immediately with `status = failed`
+  - Calls `connectAndSend($command)` to open the RCON socket and transmit the command
+  - **lh command hardening:** if `str_starts_with($command, 'lh ')`, the result is only `success` if `str_starts_with(trim($response), 'Success:')`. Any other response (empty string, error text, plugin error message) is logged as `failed` with the raw response in `error_message`.
+  - **Non-lh commands** (e.g., `whitelist add`, `fwhitelist add`): any non-false response is treated as success. These commands are handled natively by Minecraft/Floodgate and do not use the `lh` plugin protocol.
+  - Updates the log entry with final `status`, `response`, `error_message`, and `execution_time_ms`
+  - Returns `['success' => bool, 'response' => string|null, 'error' => string|null]`
+
+- `connectAndSend(string $command): array` *(protected)*
+  - Opens a `Thedudeguy\Rcon` connection using `services.minecraft.rcon_*` config values
+  - Returns `['connected' => bool, 'result' => string|false|null]`
+  - Declared `protected` so tests can subclass and override with simulated responses without a real server
+
+**Error paths:**
+- Connection failure: `['connected' => false, 'result' => null]` → `error_message = 'Failed to connect to RCON server'`
+- Command send failure: `result === false` → `error_message = 'Failed to send command to RCON server'`
+- `lh` non-success response: `error_message = 'lh command returned non-success response: <raw>'`
+- Exception thrown: `error_message = $e->getMessage()`
+
+---
+
+## 13. Activity Log Entries
+
+| Action String | Logged By | Subject Model | Description |
+|---------------|-----------|---------------|-------------|
+| `minecraft_rank_synced` | `SyncMinecraftAccount` | User | `"Synced Minecraft rank to {$rank} for {$account->username}"` |
+| `minecraft_staff_position_set` | `SyncMinecraftAccount` | User | `"Set Minecraft staff position to {$department->label()} for {$account->username}"` |
+| `minecraft_staff_position_removed` | `SyncMinecraftAccount` | User | `"Removed Minecraft staff position for {$account->username}"` |
+| `minecraft_account_reactivated` | `ReactivateMinecraftAccount` | User | `"Reactivated {$account_type->label()} account: {$account->username}"` |
+| `minecraft_rank_synced` | `SyncMinecraftRanks` (legacy) | User | `"Synced Minecraft rank to {$rank} for {$account->username}"` |
+| `minecraft_staff_position_set` | `SyncMinecraftStaff` (legacy) | User | `"Set Minecraft staff position to {$department->label()} for {$account->username}"` |
+| `minecraft_staff_position_removed` | `SyncMinecraftStaff` (legacy) | User | `"Removed Minecraft staff position for {$account->username}"` |
+
+Note: The repair command (`minecraft:repair-permissions`) does **not** write activity log entries. It writes RCON command logs to `minecraft_command_logs` with action metadata in the `meta` JSON column.
+
+---
+
+## 14. Data Flow Diagrams
+
+### Lifecycle-Triggered Sync (Promotion Example)
+
+```
+Staff clicks "Promote" on user management page
+  -> VoltComponent::promote()
+    -> $this->authorize('...')
+    -> PromoteUser::run($user)
+      -> $user->membership_level = $nextLevel
+      -> $user->save()
+      -> RecordActivity::run($user, 'user_promoted', ...)
+      -> SyncMinecraftPermissions::run($user)
+        -> foreach $user->minecraftAccounts()->active() as $account
+          -> SyncMinecraftAccount::run($account)
+            -> evaluate: rank = $user->membership_level->minecraftRank()
+            -> evaluate: eligible = rank !== null && !in_brig && parent_allows_minecraft
+            [eligible path]
+            -> MinecraftRconService::executeCommand('whitelist add <username>', ...)
+              -> MinecraftCommandLog::create([status: 'failed', ...])
+              -> connectAndSend('whitelist add <username>')
+              -> response not lh command -> status = 'success'
+              -> log->update([status: 'success', ...])
+              -> return ['success' => true, ...]
+            -> MinecraftRconService::executeCommand('lh setmember <username> <rank>', ...)
+              -> MinecraftCommandLog::create([status: 'failed', ...])
+              -> connectAndSend('lh setmember ...')
+              -> lh command: check str_starts_with(response, 'Success:')
+              -> if yes: status = 'success'; if no: status = 'failed' + error_message
+              -> log->update([status: ..., ...])
+              -> return ['success' => bool, ...]
+            -> RecordActivity::run($user, 'minecraft_rank_synced', ...)
+            -> if staff: executeCommand('lh setstaff ...') + log activity
+            -> else: executeCommand('lh removestaff ...') + log activity
+      -> SyncDiscordRoles::run($user)
+      -> send promotion notification
+  -> Flux::toast('User promoted', variant: 'success')
+```
+
+### Brig Release Flow
+
+```
+Admin clicks "Release from Brig"
+  -> ReleaseUserFromBrig::run($target, $admin, $reason)
+    -> clear brig fields, $target->save()
+    -> $mcRestoreStatus = parent_allows_minecraft ? Active : ParentDisabled
+    -> foreach $target->minecraftAccounts()->where('status', Banned) as $account
+      -> $account->status = $mcRestoreStatus
+      -> $account->save()
+      -> if Active: SyncMinecraftAccount::run($account)
+           -> whitelist add + lh setmember + lh setstaff/removestaff
+    -> RecordActivity::run($target, 'user_released_from_brig', ...)
+    -> TicketNotificationService::send($target, UserReleasedFromBrigNotification)
+```
+
+### Parent Disabling Minecraft
+
+```
+Parent toggles Minecraft off on Parent Portal
+  -> UpdateChildPermission::run($child, $parent, 'minecraft', false)
+    -> $child->parent_allows_minecraft = false
+    -> $child->save()
+    -> foreach Active or Verifying accounts:
+      -> $account->status = ParentDisabled
+      -> $account->save()
+      -> SyncMinecraftAccount::run($account)
+           -> eligible = false (parent_allows_minecraft is false)
+           -> MinecraftRconService::executeCommand('whitelist remove <username>', ...)
+           -> return ['eligible' => false, 'whitelist' => {action: 'remove'}, ...]
+    -> RecordActivity::run($child, 'parent_permission_changed', ...)
+```
+
+### Account Reactivation Flow
+
+```
+User clicks "Reactivate" on their Minecraft settings page
+  -> ReactivateMinecraftAccount::run($account, $user)
+    -> guard: status == Removed, not at limit, not in brig
+    -> $account->status = Active; $account->save()
+    -> AutoAssignPrimaryAccount::run($owner)
+    -> syncResult = SyncMinecraftAccount::run($account)
+      -> whitelist add + lh setmember + lh setstaff/removestaff
+    -> if !syncResult['whitelist']['success']:
+      -> $account->status = Removed; $account->save()
+      -> return ['success' => false, ...]
+    -> RecordActivity::run($owner, 'minecraft_account_reactivated', ...)
+    -> return ['success' => true, ...]
+```
+
+### Bulk Repair Command Flow
+
+```
+Operator runs: php artisan minecraft:repair-permissions [--dry-run] [--pace=N]
+
+  -> RepairMinecraftPermissions::handle()
+    -> MinecraftAccount::active()->with('user')->get()
+    -> foreach account:
+      -> $rank = $user->membership_level->minecraftRank()
+      -> $eligible = $rank !== null && !$user->isInBrig() && $user->parent_allows_minecraft
+      -> if eligible:
+           -> [dry-run]: print planned commands; increment counts
+           -> [live]: MinecraftRconService::executeCommand(whitelist add ...)
+                      pauseIfNeeded($firstCommand, $pace)
+                      MinecraftRconService::executeCommand(lh setmember ...)
+                      MinecraftRconService::executeCommand(lh setstaff/removestaff ...)
+                      increment counts / failures
+      -> if ineligible:
+           -> compute reason string
+           -> [dry-run]: print planned remove + reason; increment removes
+           -> [live]: MinecraftRconService::executeCommand(whitelist remove ...)
+    -> printSummary($counts, $dryRun)
+    -> return Command::SUCCESS
+```
+
+---
+
+## 15. Configuration
+
+### `config/services.php`
+
+| Key | Env Variable | Default | Purpose |
+|-----|-------------|---------|---------|
+| `services.minecraft.rcon_host` | `MINECRAFT_RCON_HOST` | `localhost` | RCON server hostname |
+| `services.minecraft.rcon_port` | `MINECRAFT_RCON_PORT` | `25575` | RCON port |
+| `services.minecraft.rcon_password` | `MINECRAFT_RCON_PASSWORD` | — | RCON authentication password |
+| `services.minecraft.verification_token` | `MINECRAFT_VERIFICATION_TOKEN` | — | Token for verification webhook |
+
+### `config/lighthouse.php`
+
+| Key | Env Variable | Default | Purpose |
+|-----|-------------|---------|---------|
+| `lighthouse.max_minecraft_accounts` | `MAX_MINECRAFT_ACCOUNTS` | `2` | Max accounts per user (checked in ReactivateMinecraftAccount) |
+| `lighthouse.minecraft.server_name` | `MINECRAFT_SERVER_NAME` | `Lighthouse MC` | Display name |
+| `lighthouse.minecraft.server_host` | `MINECRAFT_SERVER_HOST` | `play.lighthousemc.net` | Public server address |
+
+---
+
+## 16. Test Coverage
+
+### Test Files
+
+| File | Tests | What It Covers |
+|------|-------|----------------|
+| `tests/Feature/Minecraft/SyncMinecraftAccountTest.php` | 8 | Core `SyncMinecraftAccount` logic: eligibility paths, activity logging, Bedrock command variant |
+| `tests/Feature/Minecraft/MinecraftCommandsTest.php` | 12 | `lh` command hardening, RCON logging, connection failures, legacy `SyncMinecraftRanks`/`SyncMinecraftStaff` |
+| `tests/Feature/Minecraft/RepairMinecraftPermissionsTest.php` | 13 | `minecraft:repair-permissions`: dry-run and live modes, ineligibility reasons, summary output, Bedrock |
+| `tests/Feature/Minecraft/MinecraftLifecycleSyncTest.php` | 10 | Lifecycle integration: `SyncMinecraftPermissions`, promotion, demotion, reactivation, brig release, parent toggle |
+| `tests/Feature/Minecraft/MixedAccountScenariosTest.php` | 11 | Multi-account scenarios, Java/Bedrock mixed, consistency between lifecycle sync and repair command |
+
+### Test Case Inventory
+
+#### SyncMinecraftAccountTest.php
+- `eligible user receives whitelist add, rank set, and staff removed`
+- `eligible staff user receives setstaff command`
+- `eligible user records rank sync and staff activity`
+- `eligible staff user records staff position set activity`
+- `user below membership threshold receives whitelist remove`
+- `ineligible user does not receive rank or staff commands`
+- `brigged user receives whitelist remove`
+- `parent-disabled user receives whitelist remove`
+- `bedrock account uses fwhitelist add command`
+
+#### MinecraftCommandsTest.php
+- `cleanup command removes expired verifications`
+- `cleanup command sends whitelist remove command via rcon`
+- `cleanup command runs successfully`
+- `rcon service logs commands`
+- `rcon service records execution time`
+- `rcon service handles connection failure`
+- `lh command is recorded as success when response starts with Success:`
+- `lh command is recorded as failed when response is blank`
+- `lh command is recorded as failed when response does not start with Success:`
+- `non-lh command is recorded as success for any non-false response`
+- `rcon connection failure is recorded as failed for lh command`
+- `SyncMinecraftRanks sends rank command synchronously via rcon service`
+- `SyncMinecraftStaff sends setstaff command synchronously via rcon service`
+- `SyncMinecraftStaff sends removestaff command synchronously via rcon service`
+
+#### RepairMinecraftPermissionsTest.php
+- `exits successfully with message when no active accounts exist`
+- `dry-run reports planned whitelist add and rank for eligible account`
+- `dry-run reports planned whitelist remove for brigged account`
+- `dry-run reports planned whitelist remove for below-threshold account`
+- `dry-run reports planned whitelist remove for parent-disabled account`
+- `dry-run reports setstaff command for staff members`
+- `dry-run sends no RCON commands and prints summary`
+- `live mode sends whitelist, rank, and staff RCON commands for eligible account`
+- `live mode sends whitelist remove for ineligible account`
+- `live mode records failures in summary when RCON returns error`
+- `mixed eligible and ineligible accounts processed correctly in dry-run`
+- `mixed live run sends correct RCON commands with pace=0`
+- `bedrock account uses fwhitelist command in dry-run`
+
+#### MinecraftLifecycleSyncTest.php
+- `SyncMinecraftPermissions sends whitelist add and rank for each active account`
+- `SyncMinecraftPermissions skips removed and verifying accounts`
+- `PromoteUser syncs Minecraft permissions through unified path`
+- `DemoteUser syncs Minecraft permissions through unified path`
+- `reactivation uses unified sync to restore whitelist and rank`
+- `reactivation reverts account to Removed if whitelist add fails`
+- `brig release restores Minecraft access via unified sync when parent allows`
+- `brig release sets account to ParentDisabled and skips sync when parent blocks MC`
+- `parent disabling MC triggers whitelist remove via unified sync`
+- `parent enabling MC triggers whitelist add and rank sync via unified sync`
+- `parent enabling MC also syncs staff position when child is staff`
+
+#### MixedAccountScenariosTest.php
+- `repair command repairs all active accounts when a user has multiple`
+- `repair command removes all whitelist entries when a brigged user has multiple accounts`
+- `repair command sets staff on all accounts when a staff member has multiple accounts`
+- `repair command handles a user with both java and bedrock accounts`
+- `lifecycle sync and repair command send the same whitelist and rank commands for an eligible user`
+- `lifecycle sync and repair command both remove a brigged user from the whitelist`
+- `lifecycle sync and repair command both remove a parent-disabled user from the whitelist`
+- `lifecycle sync and repair command both set staff position for a staff user`
+- `dry-run correctly reports all planned actions across multiple users and accounts`
+
+### Coverage Gaps
+
+- **No test for `SyncMinecraftAccount` when the RCON call for `lh setmember` fails after whitelist add succeeds.** The caller (`ReactivateMinecraftAccount`) only checks `whitelist.success`, so a rank-set failure is silently ignored.
+- **No test for `SyncMinecraftAccount` when `staff_department` is set but `lh setstaff` fails.** The action returns success regardless; there is no rollback path.
+- **No test for `RepairMinecraftPermissions` with `--pace` greater than 0.** The `sleep()` call in `pauseIfNeeded()` is not exercised by any test (all tests pass `--pace=0`).
+- **No integration test for `CompleteVerification` calling `SyncMinecraftAccount` for a newly-verified account.** This caller is referenced in the action grep but its sync behavior is not covered in the lifecycle test suite.
+- **No test for the repair command handling an exception from RCON** (e.g., `connectAndSend` throwing). The `executeCommand` catch clause wraps this at the service level and returns `success: false`, but the command's outer loop does not have its own exception handling.
+
+---
+
+## 17. File Map
+
+**Models:**
+- `app/Models/MinecraftAccount.php`
+- `app/Models/MinecraftCommandLog.php`
+
+**Enums:**
+- `app/Enums/MinecraftAccountStatus.php`
+- `app/Enums/MinecraftAccountType.php`
+- `app/Enums/MembershipLevel.php`
+- `app/Enums/StaffDepartment.php`
+
+**Actions:**
+- `app/Actions/SyncMinecraftAccount.php` (core unified sync, new)
+- `app/Actions/SyncMinecraftPermissions.php` (user-level wrapper, new)
+- `app/Actions/PromoteUser.php` (calls `SyncMinecraftPermissions`)
+- `app/Actions/DemoteUser.php` (calls `SyncMinecraftPermissions`)
+- `app/Actions/ReleaseUserFromBrig.php` (calls `SyncMinecraftAccount`)
+- `app/Actions/ReactivateMinecraftAccount.php` (calls `SyncMinecraftAccount`)
+- `app/Actions/UpdateChildPermission.php` (calls `SyncMinecraftAccount`)
+- `app/Actions/CompleteVerification.php` (calls `SyncMinecraftAccount`)
+- `app/Actions/SyncMinecraftRanks.php` (legacy, pre-unification)
+- `app/Actions/SyncMinecraftStaff.php` (legacy, pre-unification)
+
+**Policies:** None specific to this feature.
+
+**Gates:** `app/Providers/AuthServiceProvider.php` -- gates: `link-minecraft-account`, `view-mc-command-log`
+
+**Notifications:** None specific to this feature.
+
+**Jobs:** None specific to this feature.
+
+**Services:**
+- `app/Services/MinecraftRconService.php`
+
+**Controllers:** None specific to this feature.
+
+**Volt Components:** None specific to this feature.
+
+**Routes:** None specific to this feature.
+
+**Migrations:**
+- `database/migrations/2026_02_17_064252_create_minecraft_accounts_table.php`
+- `database/migrations/2026_02_17_064300_create_minecraft_command_logs_table.php`
+- `database/migrations/2026_02_19_000001_add_avatar_url_to_minecraft_accounts_table.php`
+- `database/migrations/2026_02_20_060607_add_status_and_command_id_to_minecraft_accounts_table.php`
+- `database/migrations/2026_02_20_063640_make_verified_at_nullable_on_minecraft_accounts_table.php`
+- `database/migrations/2026_02_20_072300_make_verified_at_nullable_on_minecraft_accounts_table.php`
+- `database/migrations/2026_02_21_100000_add_banned_status_to_minecraft_accounts_table.php`
+- `database/migrations/2026_02_22_000000_drop_command_id_from_minecraft_accounts_table.php`
+- `database/migrations/2026_02_24_200000_create_minecraft_rewards_table.php`
+- `database/migrations/2026_02_26_000000_add_removed_status_to_minecraft_accounts_table.php`
+- `database/migrations/2026_02_27_100000_add_is_primary_to_minecraft_accounts_table.php`
+- `database/migrations/2026_02_28_043322_add_bedrock_xuid_to_minecraft_accounts_table.php`
+- `database/migrations/2026_03_01_000002_add_parent_disabled_status_to_minecraft_accounts_table.php`
+- `database/migrations/2026_03_18_040000_add_cancelling_status_to_minecraft_accounts_table.php`
+
+**Console Commands:**
+- `app/Console/Commands/RepairMinecraftPermissions.php`
+
+**Tests:**
+- `tests/Feature/Minecraft/SyncMinecraftAccountTest.php`
+- `tests/Feature/Minecraft/MinecraftCommandsTest.php`
+- `tests/Feature/Minecraft/RepairMinecraftPermissionsTest.php`
+- `tests/Feature/Minecraft/MinecraftLifecycleSyncTest.php`
+- `tests/Feature/Minecraft/MixedAccountScenariosTest.php`
+
+**Config:**
+- `config/services.php` -- keys: `services.minecraft.*`
+- `config/lighthouse.php` -- keys: `lighthouse.max_minecraft_accounts`, `lighthouse.minecraft.*`
+
+---
+
+## 18. Known Issues & Improvement Opportunities
+
+1. **Duplicate eligibility logic in `RepairMinecraftPermissions`.** The repair command contains its own inline copy of the three-condition eligibility check (`rank !== null && !isInBrig() && parent_allows_minecraft`). If the eligibility rules change (e.g., a new condition is added), it must be updated in both `SyncMinecraftAccount` and `RepairMinecraftPermissions` separately. A shared eligibility helper on `MinecraftAccount` or `User` would eliminate this duplication.
+
+2. **Partial sync failures are silently successful.** In `SyncMinecraftAccount`, if `lh setmember` or `lh setstaff` fails (non-`Success:` response), the action still returns `eligible: true` and `rank.success: false` — but the callers (`PromoteUser`, `DemoteUser`, `SyncMinecraftPermissions`) do not inspect the return value at all. Permission drift can occur without any alerting or retry mechanism.
+
+3. **`ReactivateMinecraftAccount` only guards on `whitelist.success`.** After calling `SyncMinecraftAccount`, it checks only `$syncResult['whitelist']['success']`. A whitelist-add success + rank-set failure leaves the player on the whitelist with the wrong rank, and the reactivation is reported as successful.
+
+4. **No rate-limiting on `SyncMinecraftAccount` calls from lifecycle actions.** A user with many active accounts who is simultaneously released from brig could trigger multiple `lh` plugin commands in rapid succession with no `sleep()` between them, unlike the repair command which has `--pace`. The Minecraft server or plugin could be overwhelmed.
+
+5. **No test for `--pace > 0` in the repair command.** The `sleep()` branch in `pauseIfNeeded()` is untested. If the method's logic were broken (e.g., always sleeping even before the first command), no test would catch it.
+
+6. **Legacy actions (`SyncMinecraftRanks`, `SyncMinecraftStaff`) still exist alongside the unified path.** These actions are no longer called by any lifecycle action but remain in the codebase and are exercised by `MinecraftCommandsTest.php`. They use `SendMinecraftCommand` (a different dispatch path) rather than `MinecraftRconService::executeCommand` directly, so their behavior and logging semantics differ from the unified path. This creates confusion about which path is canonical. These legacy actions should be deprecated and eventually removed.
+
+7. **`SyncMinecraftAccount` activity logs are recorded even when RCON commands fail.** The `RecordActivity::run(...)` calls for `minecraft_rank_synced` and `minecraft_staff_position_set/removed` execute regardless of whether `$rankResult['success']` or `$staffResult['success']` is true. The activity log thus records a "sync" that may not have actually taken effect on the server.
+
+8. **`BrigType` enum not checked during repair.** The repair command uses `$user->isInBrig()` to determine ineligibility, which correctly covers all brig types including `ParentalDisabled`. This is correct behavior but worth noting explicitly since `ParentalDisabled` brig type overlaps with `parent_allows_minecraft` — a user could be ineligible for two reasons simultaneously and the repair command reports only the first matching reason from `ineligibilityReason()`.

--- a/resources/library/books/staff-handbook/05-minecraft/02-server-operations/01-rank-and-staff-syncing.md
+++ b/resources/library/books/staff-handbook/05-minecraft/02-server-operations/01-rank-and-staff-syncing.md
@@ -40,6 +40,8 @@ The website communicates with the Minecraft server using **RCON** (Remote Consol
 
 All RCON commands sent to the Minecraft server are logged. Officers and Engineering department staff can view these logs in the **Admin Control Panel** under the Logs category. This is useful for debugging if a rank sync or whitelist change didn't seem to go through.
 
+The **MC Command Log** shows each command alongside its status (success, failed, or timeout) and the actual response text returned by the server. For `lh` plugin commands, a successful response will show `Success:` followed by a confirmation message. A failed entry will show the raw error or empty response that the plugin returned -- this is the first place to look when a rank or staff sync doesn't behave as expected.
+
 ## Important Notes
 
 - RCON commands are sent as background jobs -- there may be a brief delay between a website action and the in-game change

--- a/resources/library/books/staff-handbook/05-minecraft/02-server-operations/02-repairing-permissions.md
+++ b/resources/library/books/staff-handbook/05-minecraft/02-server-operations/02-repairing-permissions.md
@@ -1,0 +1,70 @@
+---
+title: "Repairing Minecraft Permissions"
+visibility: officer
+order: 2
+summary: "How to run the bulk permission repair command after a server restart or data migration."
+---
+
+## Overview
+
+The `minecraft:repair-permissions` command re-applies whitelist, rank, and staff permissions for every active Minecraft account in the database. It's the tool to reach for when the server's in-game state has drifted out of sync with the website -- for example after a server restart, a plugin reinstall, or a bulk data migration.
+
+The command evaluates the same eligibility logic used by normal lifecycle events (promotions, brig releases, etc.). It's safe to run at any time.
+
+## Who Can Run This
+
+This command requires **shell (SSH) access to the server**. It's an admin/ops tool -- you can't run it from the website. If you don't have SSH access and think a bulk repair is needed, contact an Admin.
+
+## How to Run It
+
+### Dry Run First
+
+Always start with a dry run. This prints everything the command would do without sending any RCON commands to the server:
+
+```
+php artisan minecraft:repair-permissions --dry-run
+```
+
+Review the output carefully. Each account shows whether it would be added to the whitelist or removed, what rank would be set, and what staff group (if any) would be applied.
+
+### Live Execution
+
+Once you're satisfied with what the dry run shows, run it for real:
+
+```
+php artisan minecraft:repair-permissions
+```
+
+The command will iterate every active Minecraft account and send the appropriate RCON commands. When it finishes, it prints a summary table showing how many whitelist adds, whitelist removes, rank changes, staff changes, and failures occurred.
+
+### Pacing (Optional)
+
+By default, the command sends commands as fast as the server can handle them. If you're concerned about flooding the Minecraft server with RCON traffic -- for example on a busy server during peak hours -- use the `--pace` flag to add a delay between commands:
+
+```
+php artisan minecraft:repair-permissions --pace=2
+```
+
+This adds a 2-second pause between outbound commands. You can set `--pace` to any whole number of seconds.
+
+## What the Command Repairs
+
+For each active Minecraft account, the command evaluates eligibility using the member's current website state:
+
+- **Eligible** (Traveler or higher, not in the Brig, parent permissions allow Minecraft): adds the account to the whitelist, sets the in-game rank to match the membership level, and applies or removes the staff department group depending on whether the member holds a staff position
+- **Ineligible** (Drifter/Stowaway, in the Brig, or parent has disabled Minecraft): removes the account from the whitelist
+
+Accounts in `verifying`, `banned`, `cancelled`, `removed`, or `parent_disabled` status are skipped -- the command only processes accounts with `active` status.
+
+## Checking the Results
+
+After a live run, check the **MC Command Log** in the Admin Control Panel (Logs category) for any failed entries. A failed `lh` plugin command means the server responded with something other than a `Success:` prefix -- the log entry shows the exact response text, which helps narrow down what went wrong.
+
+See [[books/staff-handbook/minecraft/server-operations/rank-and-staff-syncing|Rank & Staff Syncing]] for more detail on how the command log works and what to look for.
+
+## Important Notes
+
+- The repair command does **not** write to the Activity Log. Results are only visible in the MC Command Log.
+- Running the command multiple times is safe -- it's idempotent. Sending a `whitelist add` for someone who's already whitelisted doesn't break anything.
+- If the Minecraft server is offline when you run the command, every RCON command will fail. Wait until the server is back up and run it again.
+- The `--dry-run` flag never sends RCON commands, even if the server is online. It's always safe to use for inspection.

--- a/tests/Feature/Minecraft/CompleteVerificationTest.php
+++ b/tests/Feature/Minecraft/CompleteVerificationTest.php
@@ -8,8 +8,6 @@ use App\Enums\StaffRank;
 use App\Models\MinecraftAccount;
 use App\Models\MinecraftVerification;
 use App\Models\User;
-use App\Notifications\MinecraftCommandNotification;
-use Illuminate\Support\Facades\Notification;
 
 beforeEach(function () {
     $this->user = User::factory()->create();
@@ -388,10 +386,7 @@ test('completes verification for linked bedrock with clean gamertag via bedrock_
     ]);
 });
 
-test('syncs staff position when staff member verifies account', function () {
-    Notification::fake();
-
-    // Create staff user with server access
+test('syncs rank and staff position synchronously when staff member verifies account', function () {
     $staffUser = User::factory()->create([
         'membership_level' => \App\Enums\MembershipLevel::Traveler,
         'staff_department' => StaffDepartment::Command,
@@ -406,38 +401,33 @@ test('syncs staff position when staff member verifies account', function () {
         'minecraft_uuid' => '169a79f4-44e9-4726-a5be-fca90e38aaf5',
     ]);
 
-    // Create the verifying account
     MinecraftAccount::factory()->for($staffUser)->verifying()->create([
         'username' => 'StaffPlayer',
         'uuid' => '169a79f4-44e9-4726-a5be-fca90e38aaf5',
         'account_type' => 'java',
     ]);
 
+    $rconMock = $this->mock(\App\Services\MinecraftRconService::class);
+    $rconMock->shouldReceive('executeCommand')
+        ->with(Mockery::pattern('/^whitelist/'), Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
+        ->andReturn(['success' => true, 'response' => 'Added to whitelist', 'error' => null]);
+    $rconMock->shouldReceive('executeCommand')
+        ->with(Mockery::pattern('/^lh setmember StaffPlayer/'), 'rank', 'StaffPlayer', Mockery::any(), Mockery::any())
+        ->once()
+        ->andReturn(['success' => true, 'response' => 'Success: rank set', 'error' => null]);
+    $rconMock->shouldReceive('executeCommand')
+        ->with('lh setstaff StaffPlayer command', 'staff', 'StaffPlayer', Mockery::any(), Mockery::any())
+        ->once()
+        ->andReturn(['success' => true, 'response' => 'Success: staff set', 'error' => null]);
+
     $action = new CompleteVerification;
-    $result = $action->handle(
-        'ABC123',
-        'StaffPlayer',
-        '169a79f4-44e9-4726-a5be-fca90e38aaf5'
-    );
+    $result = $action->handle('ABC123', 'StaffPlayer', '169a79f4-44e9-4726-a5be-fca90e38aaf5');
 
     expect($result['success'])->toBeTrue();
 
-    // Verify account is active
     $this->assertDatabaseHas('minecraft_accounts', [
         'user_id' => $staffUser->id,
         'username' => 'StaffPlayer',
         'status' => 'active',
     ]);
-
-    // setmember command dispatched for Traveler rank assignment
-    Notification::assertSentOnDemand(
-        MinecraftCommandNotification::class,
-        fn ($n) => str_contains($n->command, 'lh setmember')
-    );
-
-    // setstaff command dispatched for staff position sync
-    Notification::assertSentOnDemand(
-        MinecraftCommandNotification::class,
-        fn ($n) => str_contains($n->command, 'lh setstaff')
-    );
 });

--- a/tests/Feature/Minecraft/MinecraftCommandsTest.php
+++ b/tests/Feature/Minecraft/MinecraftCommandsTest.php
@@ -2,6 +2,10 @@
 
 declare(strict_types=1);
 
+use App\Actions\SyncMinecraftRanks;
+use App\Actions\SyncMinecraftStaff;
+use App\Enums\MembershipLevel;
+use App\Enums\StaffDepartment;
 use App\Models\MinecraftAccount;
 use App\Models\MinecraftCommandLog;
 use App\Models\MinecraftVerification;
@@ -107,4 +111,148 @@ test('rcon service handles connection failure', function () {
     $this->assertDatabaseHas('minecraft_command_logs', [
         'status' => 'failed',
     ]);
+});
+
+// lh command hardening tests
+
+/**
+ * Return a MinecraftRconService subclass that returns a controlled RCON response
+ * without opening a real network connection.
+ */
+function makeRconServiceWithResponse(string $response): MinecraftRconService
+{
+    return new class($response) extends MinecraftRconService
+    {
+        public function __construct(private readonly string $simulatedResponse) {}
+
+        protected function connectAndSend(string $command): array
+        {
+            return ['connected' => true, 'result' => $this->simulatedResponse];
+        }
+    };
+}
+
+function makeRconServiceConnectionFailed(): MinecraftRconService
+{
+    return new class extends MinecraftRconService
+    {
+        protected function connectAndSend(string $command): array
+        {
+            return ['connected' => false, 'result' => null];
+        }
+    };
+}
+
+test('lh command is recorded as success when response starts with Success:', function () {
+    $user = User::factory()->create();
+    $service = makeRconServiceWithResponse('Success: Rank updated for TestPlayer');
+
+    $result = $service->executeCommand('lh setmember TestPlayer traveler', 'rank', 'TestPlayer', $user);
+
+    expect($result['success'])->toBeTrue()
+        ->and($result['error'])->toBeNull();
+
+    $this->assertDatabaseHas('minecraft_command_logs', [
+        'command' => 'lh setmember TestPlayer traveler',
+        'status' => 'success',
+    ]);
+});
+
+test('lh command is recorded as failed when response is blank', function () {
+    $user = User::factory()->create();
+    $service = makeRconServiceWithResponse('');
+
+    $result = $service->executeCommand('lh setmember TestPlayer traveler', 'rank', 'TestPlayer', $user);
+
+    expect($result['success'])->toBeFalse();
+
+    $this->assertDatabaseHas('minecraft_command_logs', [
+        'command' => 'lh setmember TestPlayer traveler',
+        'status' => 'failed',
+    ]);
+});
+
+test('lh command is recorded as failed when response does not start with Success:', function () {
+    $user = User::factory()->create();
+    $service = makeRconServiceWithResponse('Player not found: TestPlayer');
+
+    $result = $service->executeCommand('lh setmember TestPlayer traveler', 'rank', 'TestPlayer', $user);
+
+    expect($result['success'])->toBeFalse()
+        ->and($result['error'])->toContain('Player not found');
+
+    $this->assertDatabaseHas('minecraft_command_logs', [
+        'command' => 'lh setmember TestPlayer traveler',
+        'status' => 'failed',
+    ]);
+});
+
+test('non-lh command is recorded as success for any non-false response', function () {
+    $user = User::factory()->create();
+    $service = makeRconServiceWithResponse('Added TestPlayer to the whitelist');
+
+    $result = $service->executeCommand('whitelist add TestPlayer', 'whitelist', 'TestPlayer', $user);
+
+    expect($result['success'])->toBeTrue();
+
+    $this->assertDatabaseHas('minecraft_command_logs', [
+        'command' => 'whitelist add TestPlayer',
+        'status' => 'success',
+    ]);
+});
+
+test('rcon connection failure is recorded as failed for lh command', function () {
+    $user = User::factory()->create();
+    $service = makeRconServiceConnectionFailed();
+
+    $result = $service->executeCommand('lh setmember TestPlayer traveler', 'rank', 'TestPlayer', $user);
+
+    expect($result['success'])->toBeFalse()
+        ->and($result['error'])->toBe('Failed to connect to RCON server');
+
+    $this->assertDatabaseHas('minecraft_command_logs', [
+        'command' => 'lh setmember TestPlayer traveler',
+        'status' => 'failed',
+    ]);
+});
+
+// Synchronous command execution tests
+
+test('SyncMinecraftRanks sends rank command synchronously via rcon service', function () {
+    $user = User::factory()->create(['membership_level' => MembershipLevel::Traveler]);
+    MinecraftAccount::factory()->for($user)->active()->create(['username' => 'TestPlayer']);
+
+    $rconMock = $this->mock(MinecraftRconService::class);
+    $rconMock->shouldReceive('executeCommand')
+        ->once()
+        ->with('lh setmember TestPlayer traveler', 'rank', 'TestPlayer', Mockery::any(), Mockery::any())
+        ->andReturn(['success' => true, 'response' => 'Success: rank set', 'error' => null]);
+
+    SyncMinecraftRanks::run($user);
+});
+
+test('SyncMinecraftStaff sends setstaff command synchronously via rcon service', function () {
+    $user = User::factory()->create();
+    MinecraftAccount::factory()->for($user)->active()->create(['username' => 'StaffPlayer']);
+
+    $rconMock = $this->mock(MinecraftRconService::class);
+    $rconMock->shouldReceive('executeCommand')
+        ->once()
+        ->with('lh setstaff StaffPlayer engineer', 'staff', 'StaffPlayer', Mockery::any(), Mockery::any())
+        ->andReturn(['success' => true, 'response' => 'Success: staff set', 'error' => null]);
+
+    SyncMinecraftStaff::run($user, StaffDepartment::Engineer);
+});
+
+test('SyncMinecraftStaff sends removestaff command synchronously via rcon service', function () {
+    $user = User::factory()->create();
+    MinecraftAccount::factory()->for($user)->active()->create(['username' => 'StaffPlayer']);
+
+    $rconMock = $this->mock(MinecraftRconService::class);
+    $rconMock->shouldReceive('executeCommand')
+        ->once()
+        ->with('lh removestaff StaffPlayer', 'staff', 'StaffPlayer', Mockery::any(), Mockery::any())
+        ->andReturn(['success' => true, 'response' => 'Success: staff removed', 'error' => null]);
+
+    SyncMinecraftStaff::run($user, null);
 });

--- a/tests/Feature/Minecraft/MinecraftLifecycleSyncTest.php
+++ b/tests/Feature/Minecraft/MinecraftLifecycleSyncTest.php
@@ -219,10 +219,6 @@ test('parent enabling MC triggers whitelist add and rank sync via unified sync',
         'status' => MinecraftAccountStatus::ParentDisabled,
     ]);
 
-    // First save parent_allows_minecraft = true so the sync evaluates eligible
-    $child->parent_allows_minecraft = true;
-    $child->save();
-
     $this->rconMock->shouldReceive('executeCommand')
         ->with('whitelist add ReEnabledKid', 'whitelist', 'ReEnabledKid', Mockery::any(), Mockery::any())
         ->once()
@@ -235,7 +231,8 @@ test('parent enabling MC triggers whitelist add and rank sync via unified sync',
 
     UpdateChildPermission::run($child, $parent, 'minecraft', true);
 
-    expect($account->fresh()->status)->toBe(MinecraftAccountStatus::Active);
+    expect($child->fresh()->parent_allows_minecraft)->toBeTrue()
+        ->and($account->fresh()->status)->toBe(MinecraftAccountStatus::Active);
 });
 
 test('parent enabling MC also syncs staff position when child is staff', function () {
@@ -249,9 +246,6 @@ test('parent enabling MC also syncs staff position when child is staff', functio
         'username' => 'StaffKid',
         'status' => MinecraftAccountStatus::ParentDisabled,
     ]);
-
-    $child->parent_allows_minecraft = true;
-    $child->save();
 
     $this->rconMock->shouldReceive('executeCommand')
         ->with('lh setstaff StaffKid engineer', 'staff', 'StaffKid', Mockery::any(), Mockery::any())

--- a/tests/Feature/Minecraft/MinecraftLifecycleSyncTest.php
+++ b/tests/Feature/Minecraft/MinecraftLifecycleSyncTest.php
@@ -1,0 +1,262 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Actions\DemoteUser;
+use App\Actions\PromoteUser;
+use App\Actions\ReactivateMinecraftAccount;
+use App\Actions\ReleaseUserFromBrig;
+use App\Actions\SyncMinecraftPermissions;
+use App\Actions\UpdateChildPermission;
+use App\Enums\BrigType;
+use App\Enums\MembershipLevel;
+use App\Enums\MinecraftAccountStatus;
+use App\Enums\StaffDepartment;
+use App\Models\MinecraftAccount;
+use App\Models\User;
+use App\Services\MinecraftRconService;
+
+beforeEach(function () {
+    $this->rconMock = $this->mock(MinecraftRconService::class);
+    $this->rconMock->shouldReceive('executeCommand')
+        ->andReturn(['success' => true, 'response' => 'ok', 'error' => null])
+        ->byDefault();
+});
+
+// ─── SyncMinecraftPermissions ─────────────────────────────────────────────────
+
+test('SyncMinecraftPermissions sends whitelist add and rank for each active account', function () {
+    $user = User::factory()->create(['membership_level' => MembershipLevel::Traveler]);
+    MinecraftAccount::factory()->for($user)->active()->create(['username' => 'Player1']);
+    MinecraftAccount::factory()->for($user)->active()->create(['username' => 'Player2']);
+
+    $this->rconMock->shouldReceive('executeCommand')
+        ->with(Mockery::pattern('/^whitelist add/'), Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
+        ->twice()
+        ->andReturn(['success' => true, 'response' => 'Added', 'error' => null]);
+
+    $this->rconMock->shouldReceive('executeCommand')
+        ->with(Mockery::pattern('/^lh setmember/'), Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
+        ->twice()
+        ->andReturn(['success' => true, 'response' => 'Success: rank set', 'error' => null]);
+
+    SyncMinecraftPermissions::run($user);
+});
+
+test('SyncMinecraftPermissions skips removed and verifying accounts', function () {
+    $user = User::factory()->create(['membership_level' => MembershipLevel::Traveler]);
+    MinecraftAccount::factory()->for($user)->removed()->create(['username' => 'OldPlayer']);
+    MinecraftAccount::factory()->for($user)->verifying()->create(['username' => 'NewPlayer']);
+
+    $this->rconMock->shouldReceive('executeCommand')->never();
+
+    SyncMinecraftPermissions::run($user);
+});
+
+// ─── Promotion / Demotion ─────────────────────────────────────────────────────
+
+test('PromoteUser syncs Minecraft permissions through unified path', function () {
+    $user = User::factory()->create(['membership_level' => MembershipLevel::Stowaway]);
+    MinecraftAccount::factory()->for($user)->active()->create(['username' => 'PromoPlayer']);
+
+    // After promotion to Traveler the account is eligible — expect whitelist add + rank
+    $this->rconMock->shouldReceive('executeCommand')
+        ->with('whitelist add PromoPlayer', Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
+        ->once()
+        ->andReturn(['success' => true, 'response' => 'Added', 'error' => null]);
+
+    $this->rconMock->shouldReceive('executeCommand')
+        ->with('lh setmember PromoPlayer traveler', Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
+        ->once()
+        ->andReturn(['success' => true, 'response' => 'Success: rank set', 'error' => null]);
+
+    PromoteUser::run($user);
+
+    expect($user->fresh()->membership_level)->toBe(MembershipLevel::Traveler);
+});
+
+test('DemoteUser syncs Minecraft permissions through unified path', function () {
+    $user = User::factory()->create(['membership_level' => MembershipLevel::Resident]);
+    MinecraftAccount::factory()->for($user)->active()->create(['username' => 'DemotePlayer']);
+
+    // After demotion to Traveler the account is still eligible
+    $this->rconMock->shouldReceive('executeCommand')
+        ->with('lh setmember DemotePlayer traveler', Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
+        ->once()
+        ->andReturn(['success' => true, 'response' => 'Success: rank set', 'error' => null]);
+
+    DemoteUser::run($user);
+
+    expect($user->fresh()->membership_level)->toBe(MembershipLevel::Traveler);
+});
+
+// ─── Reactivation ────────────────────────────────────────────────────────────
+
+test('reactivation uses unified sync to restore whitelist and rank', function () {
+    $user = User::factory()->create(['membership_level' => MembershipLevel::Traveler]);
+    $account = MinecraftAccount::factory()->for($user)->removed()->create(['username' => 'ReactPlayer']);
+
+    $this->rconMock->shouldReceive('executeCommand')
+        ->with('whitelist add ReactPlayer', 'whitelist', 'ReactPlayer', Mockery::any(), Mockery::any())
+        ->once()
+        ->andReturn(['success' => true, 'response' => 'Added ReactPlayer to the whitelist', 'error' => null]);
+
+    $this->rconMock->shouldReceive('executeCommand')
+        ->with('lh setmember ReactPlayer traveler', 'rank', 'ReactPlayer', Mockery::any(), Mockery::any())
+        ->once()
+        ->andReturn(['success' => true, 'response' => 'Success: rank set', 'error' => null]);
+
+    $result = ReactivateMinecraftAccount::run($account, $user);
+
+    expect($result['success'])->toBeTrue()
+        ->and($account->fresh()->status)->toBe(MinecraftAccountStatus::Active);
+});
+
+test('reactivation reverts account to Removed if whitelist add fails', function () {
+    $user = User::factory()->create(['membership_level' => MembershipLevel::Traveler]);
+    $account = MinecraftAccount::factory()->for($user)->removed()->create(['username' => 'FailPlayer']);
+
+    $this->rconMock->shouldReceive('executeCommand')
+        ->with('whitelist add FailPlayer', Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
+        ->andReturn(['success' => false, 'response' => null, 'error' => 'Server unreachable']);
+
+    $result = ReactivateMinecraftAccount::run($account, $user);
+
+    expect($result['success'])->toBeFalse()
+        ->and($account->fresh()->status)->toBe(MinecraftAccountStatus::Removed);
+});
+
+// ─── Brig release ────────────────────────────────────────────────────────────
+
+test('brig release restores Minecraft access via unified sync when parent allows', function () {
+    $admin = User::factory()->create();
+    $user = User::factory()->create([
+        'membership_level' => MembershipLevel::Traveler,
+        'in_brig' => false,
+        'parent_allows_minecraft' => true,
+    ]);
+    $account = MinecraftAccount::factory()->for($user)->create([
+        'username' => 'BrigPlayer',
+        'status' => MinecraftAccountStatus::Banned,
+    ]);
+
+    // Simulate brig state
+    $user->in_brig = true;
+    $user->brig_reason = 'Test';
+    $user->brig_type = BrigType::Discipline;
+    $user->save();
+
+    $this->rconMock->shouldReceive('executeCommand')
+        ->with('whitelist add BrigPlayer', 'whitelist', 'BrigPlayer', Mockery::any(), Mockery::any())
+        ->once()
+        ->andReturn(['success' => true, 'response' => 'Added', 'error' => null]);
+
+    $this->rconMock->shouldReceive('executeCommand')
+        ->with('lh setmember BrigPlayer traveler', 'rank', 'BrigPlayer', Mockery::any(), Mockery::any())
+        ->once()
+        ->andReturn(['success' => true, 'response' => 'Success: rank set', 'error' => null]);
+
+    ReleaseUserFromBrig::run($user, $admin, 'Testing release', notify: false);
+
+    expect($account->fresh()->status)->toBe(MinecraftAccountStatus::Active);
+});
+
+test('brig release sets account to ParentDisabled and skips sync when parent blocks MC', function () {
+    $admin = User::factory()->create();
+    $user = User::factory()->create([
+        'membership_level' => MembershipLevel::Traveler,
+        'in_brig' => false,
+        'parent_allows_minecraft' => false,
+    ]);
+    $account = MinecraftAccount::factory()->for($user)->create([
+        'username' => 'BlockedKid',
+        'status' => MinecraftAccountStatus::Banned,
+    ]);
+
+    $user->in_brig = true;
+    $user->brig_reason = 'Test';
+    $user->brig_type = BrigType::Discipline;
+    $user->save();
+
+    // No lh rank/whitelist-add commands when parent blocks MC
+    $this->rconMock->shouldReceive('executeCommand')
+        ->with(Mockery::pattern('/^lh |^whitelist add/'), Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
+        ->never();
+
+    ReleaseUserFromBrig::run($user, $admin, 'Testing release', notify: false);
+
+    expect($account->fresh()->status)->toBe(MinecraftAccountStatus::ParentDisabled);
+});
+
+// ─── Parent permission toggle ─────────────────────────────────────────────────
+
+test('parent disabling MC triggers whitelist remove via unified sync', function () {
+    $parent = User::factory()->create();
+    $child = User::factory()->create([
+        'membership_level' => MembershipLevel::Traveler,
+        'parent_allows_minecraft' => true,
+    ]);
+    $account = MinecraftAccount::factory()->for($child)->active()->create(['username' => 'ChildPlayer']);
+
+    $this->rconMock->shouldReceive('executeCommand')
+        ->with('whitelist remove ChildPlayer', 'whitelist', 'ChildPlayer', Mockery::any(), Mockery::any())
+        ->once()
+        ->andReturn(['success' => true, 'response' => 'Removed', 'error' => null]);
+
+    UpdateChildPermission::run($child, $parent, 'minecraft', false);
+
+    expect($account->fresh()->status)->toBe(MinecraftAccountStatus::ParentDisabled);
+});
+
+test('parent enabling MC triggers whitelist add and rank sync via unified sync', function () {
+    $parent = User::factory()->create();
+    $child = User::factory()->create([
+        'membership_level' => MembershipLevel::Traveler,
+        'parent_allows_minecraft' => false,
+    ]);
+    $account = MinecraftAccount::factory()->for($child)->create([
+        'username' => 'ReEnabledKid',
+        'status' => MinecraftAccountStatus::ParentDisabled,
+    ]);
+
+    // First save parent_allows_minecraft = true so the sync evaluates eligible
+    $child->parent_allows_minecraft = true;
+    $child->save();
+
+    $this->rconMock->shouldReceive('executeCommand')
+        ->with('whitelist add ReEnabledKid', 'whitelist', 'ReEnabledKid', Mockery::any(), Mockery::any())
+        ->once()
+        ->andReturn(['success' => true, 'response' => 'Added', 'error' => null]);
+
+    $this->rconMock->shouldReceive('executeCommand')
+        ->with('lh setmember ReEnabledKid traveler', 'rank', 'ReEnabledKid', Mockery::any(), Mockery::any())
+        ->once()
+        ->andReturn(['success' => true, 'response' => 'Success: rank set', 'error' => null]);
+
+    UpdateChildPermission::run($child, $parent, 'minecraft', true);
+
+    expect($account->fresh()->status)->toBe(MinecraftAccountStatus::Active);
+});
+
+test('parent enabling MC also syncs staff position when child is staff', function () {
+    $parent = User::factory()->create();
+    $child = User::factory()->create([
+        'membership_level' => MembershipLevel::Traveler,
+        'parent_allows_minecraft' => false,
+        'staff_department' => StaffDepartment::Engineer,
+    ]);
+    $account = MinecraftAccount::factory()->for($child)->create([
+        'username' => 'StaffKid',
+        'status' => MinecraftAccountStatus::ParentDisabled,
+    ]);
+
+    $child->parent_allows_minecraft = true;
+    $child->save();
+
+    $this->rconMock->shouldReceive('executeCommand')
+        ->with('lh setstaff StaffKid engineer', 'staff', 'StaffKid', Mockery::any(), Mockery::any())
+        ->once()
+        ->andReturn(['success' => true, 'response' => 'Success: staff set', 'error' => null]);
+
+    UpdateChildPermission::run($child, $parent, 'minecraft', true);
+});

--- a/tests/Feature/Minecraft/MixedAccountScenariosTest.php
+++ b/tests/Feature/Minecraft/MixedAccountScenariosTest.php
@@ -1,0 +1,222 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Actions\SyncMinecraftAccount;
+use App\Actions\SyncMinecraftPermissions;
+use App\Enums\MembershipLevel;
+use App\Enums\MinecraftAccountType;
+use App\Enums\StaffDepartment;
+use App\Models\MinecraftAccount;
+use App\Models\User;
+use App\Services\MinecraftRconService;
+
+beforeEach(function () {
+    $this->rconMock = $this->mock(MinecraftRconService::class);
+    $this->rconMock->shouldReceive('executeCommand')
+        ->andReturn(['success' => true, 'response' => 'ok', 'error' => null])
+        ->byDefault();
+});
+
+// ─── Multi-account repair ─────────────────────────────────────────────────────
+
+test('repair command repairs all active accounts when a user has multiple', function () {
+    $user = User::factory()->create(['membership_level' => MembershipLevel::Traveler]);
+    MinecraftAccount::factory()->for($user)->active()->create(['username' => 'MultiAcct1']);
+    MinecraftAccount::factory()->for($user)->active()->create(['username' => 'MultiAcct2']);
+
+    $this->rconMock->shouldReceive('executeCommand')
+        ->with('whitelist add MultiAcct1', Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
+        ->once()
+        ->andReturn(['success' => true, 'response' => 'Added', 'error' => null]);
+
+    $this->rconMock->shouldReceive('executeCommand')
+        ->with('whitelist add MultiAcct2', Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
+        ->once()
+        ->andReturn(['success' => true, 'response' => 'Added', 'error' => null]);
+
+    $this->rconMock->shouldReceive('executeCommand')
+        ->with(Mockery::pattern('/^lh /'), Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
+        ->times(4) // 2 accounts × (setmember + removestaff)
+        ->andReturn(['success' => true, 'response' => 'Success: done', 'error' => null]);
+
+    $this->artisan('minecraft:repair-permissions', ['--pace' => '0'])
+        ->assertSuccessful()
+        ->expectsOutputToContain('Whitelist adds:    2')
+        ->expectsOutputToContain('Rank changes:      2')
+        ->expectsOutputToContain('Staff changes:     2')
+        ->expectsOutputToContain('Failures:          0');
+});
+
+test('repair command removes all whitelist entries when a brigged user has multiple accounts', function () {
+    $user = User::factory()->create([
+        'membership_level' => MembershipLevel::Traveler,
+        'in_brig' => true,
+    ]);
+    MinecraftAccount::factory()->for($user)->active()->create(['username' => 'BrigMulti1']);
+    MinecraftAccount::factory()->for($user)->active()->create(['username' => 'BrigMulti2']);
+
+    $this->rconMock->shouldReceive('executeCommand')
+        ->with('whitelist remove BrigMulti1', Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
+        ->once()
+        ->andReturn(['success' => true, 'response' => 'Removed', 'error' => null]);
+
+    $this->rconMock->shouldReceive('executeCommand')
+        ->with('whitelist remove BrigMulti2', Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
+        ->once()
+        ->andReturn(['success' => true, 'response' => 'Removed', 'error' => null]);
+
+    $this->artisan('minecraft:repair-permissions', ['--pace' => '0'])
+        ->assertSuccessful()
+        ->expectsOutputToContain('Whitelist removes: 2')
+        ->expectsOutputToContain('Failures:          0');
+});
+
+test('repair command sets staff on all accounts when a staff member has multiple accounts', function () {
+    $user = User::factory()->create([
+        'membership_level' => MembershipLevel::Traveler,
+        'staff_department' => StaffDepartment::Engineer,
+    ]);
+    MinecraftAccount::factory()->for($user)->active()->create(['username' => 'StaffAcct1']);
+    MinecraftAccount::factory()->for($user)->active()->create(['username' => 'StaffAcct2']);
+
+    $this->rconMock->shouldReceive('executeCommand')
+        ->with('lh setstaff StaffAcct1 engineer', Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
+        ->once()
+        ->andReturn(['success' => true, 'response' => 'Success: staff set', 'error' => null]);
+
+    $this->rconMock->shouldReceive('executeCommand')
+        ->with('lh setstaff StaffAcct2 engineer', Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
+        ->once()
+        ->andReturn(['success' => true, 'response' => 'Success: staff set', 'error' => null]);
+
+    $this->artisan('minecraft:repair-permissions', ['--pace' => '0'])
+        ->assertSuccessful()
+        ->expectsOutputToContain('Staff changes:     2')
+        ->expectsOutputToContain('Failures:          0');
+});
+
+test('repair command handles a user with both java and bedrock accounts', function () {
+    $user = User::factory()->create(['membership_level' => MembershipLevel::Traveler]);
+    MinecraftAccount::factory()->for($user)->active()->create([
+        'username' => 'JavaUser',
+        'account_type' => MinecraftAccountType::Java,
+    ]);
+    MinecraftAccount::factory()->for($user)->active()->create([
+        'username' => 'BedrockUser',
+        'uuid' => 'bedrock-uuid-abcd',
+        'account_type' => MinecraftAccountType::Bedrock,
+    ]);
+
+    $this->rconMock->shouldReceive('executeCommand')
+        ->with('whitelist add JavaUser', Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
+        ->once()
+        ->andReturn(['success' => true, 'response' => 'Added', 'error' => null]);
+
+    $this->rconMock->shouldReceive('executeCommand')
+        ->with('fwhitelist add bedrock-uuid-abcd', Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
+        ->once()
+        ->andReturn(['success' => true, 'response' => 'Added', 'error' => null]);
+
+    $this->artisan('minecraft:repair-permissions', ['--pace' => '0'])
+        ->assertSuccessful()
+        ->expectsOutputToContain('Whitelist adds:    2')
+        ->expectsOutputToContain('Failures:          0');
+});
+
+// ─── Consistency: lifecycle sync and repair agree ─────────────────────────────
+
+test('lifecycle sync and repair command send the same whitelist and rank commands for an eligible user', function () {
+    $user = User::factory()->create(['membership_level' => MembershipLevel::Traveler]);
+    MinecraftAccount::factory()->for($user)->active()->create(['username' => 'ConsistElig']);
+
+    // Each RCON command fires once from SyncMinecraftPermissions, once from the repair command
+    $this->rconMock->shouldReceive('executeCommand')
+        ->with('whitelist add ConsistElig', Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
+        ->twice()
+        ->andReturn(['success' => true, 'response' => 'Added', 'error' => null]);
+
+    $this->rconMock->shouldReceive('executeCommand')
+        ->with('lh setmember ConsistElig traveler', Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
+        ->twice()
+        ->andReturn(['success' => true, 'response' => 'Success: rank set', 'error' => null]);
+
+    $this->rconMock->shouldReceive('executeCommand')
+        ->with('lh removestaff ConsistElig', Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
+        ->twice()
+        ->andReturn(['success' => true, 'response' => 'Success: staff removed', 'error' => null]);
+
+    SyncMinecraftPermissions::run($user);
+    $this->artisan('minecraft:repair-permissions', ['--pace' => '0'])->assertSuccessful();
+});
+
+test('lifecycle sync and repair command both remove a brigged user from the whitelist', function () {
+    $user = User::factory()->create([
+        'membership_level' => MembershipLevel::Traveler,
+        'in_brig' => true,
+    ]);
+    MinecraftAccount::factory()->for($user)->active()->create(['username' => 'BrigConsist']);
+
+    $this->rconMock->shouldReceive('executeCommand')
+        ->with('whitelist remove BrigConsist', Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
+        ->twice()
+        ->andReturn(['success' => true, 'response' => 'Removed', 'error' => null]);
+
+    SyncMinecraftAccount::run($user->minecraftAccounts()->active()->first());
+    $this->artisan('minecraft:repair-permissions', ['--pace' => '0'])->assertSuccessful();
+});
+
+test('lifecycle sync and repair command both remove a parent-disabled user from the whitelist', function () {
+    $user = User::factory()->create([
+        'membership_level' => MembershipLevel::Traveler,
+        'parent_allows_minecraft' => false,
+    ]);
+    MinecraftAccount::factory()->for($user)->active()->create(['username' => 'ParentConsist']);
+
+    $this->rconMock->shouldReceive('executeCommand')
+        ->with('whitelist remove ParentConsist', Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
+        ->twice()
+        ->andReturn(['success' => true, 'response' => 'Removed', 'error' => null]);
+
+    SyncMinecraftAccount::run($user->minecraftAccounts()->active()->first());
+    $this->artisan('minecraft:repair-permissions', ['--pace' => '0'])->assertSuccessful();
+});
+
+test('lifecycle sync and repair command both set staff position for a staff user', function () {
+    $user = User::factory()->create([
+        'membership_level' => MembershipLevel::Traveler,
+        'staff_department' => StaffDepartment::Engineer,
+    ]);
+    MinecraftAccount::factory()->for($user)->active()->create(['username' => 'StaffConsist']);
+
+    $this->rconMock->shouldReceive('executeCommand')
+        ->with('lh setstaff StaffConsist engineer', Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
+        ->twice()
+        ->andReturn(['success' => true, 'response' => 'Success: staff set', 'error' => null]);
+
+    SyncMinecraftPermissions::run($user);
+    $this->artisan('minecraft:repair-permissions', ['--pace' => '0'])->assertSuccessful();
+});
+
+// ─── Dry-run multi-account scenarios ─────────────────────────────────────────
+
+test('dry-run correctly reports all planned actions across multiple users and accounts', function () {
+    $eligible = User::factory()->create(['membership_level' => MembershipLevel::Traveler]);
+    MinecraftAccount::factory()->for($eligible)->active()->create(['username' => 'DryElig1']);
+    MinecraftAccount::factory()->for($eligible)->active()->create(['username' => 'DryElig2']);
+
+    $brigged = User::factory()->create(['membership_level' => MembershipLevel::Traveler, 'in_brig' => true]);
+    MinecraftAccount::factory()->for($brigged)->active()->create(['username' => 'DryBrig1']);
+    MinecraftAccount::factory()->for($brigged)->active()->create(['username' => 'DryBrig2']);
+
+    $this->rconMock->shouldReceive('executeCommand')->never();
+
+    $this->artisan('minecraft:repair-permissions', ['--dry-run' => true])
+        ->assertSuccessful()
+        ->expectsOutputToContain('[dry-run] whitelist add DryElig1')
+        ->expectsOutputToContain('[dry-run] whitelist add DryElig2')
+        ->expectsOutputToContain('[dry-run] whitelist remove DryBrig1')
+        ->expectsOutputToContain('[dry-run] whitelist remove DryBrig2')
+        ->expectsOutputToContain('[dry-run] Whitelist adds:    2')
+        ->expectsOutputToContain('[dry-run] Whitelist removes: 2');
+});

--- a/tests/Feature/Minecraft/RepairMinecraftPermissionsTest.php
+++ b/tests/Feature/Minecraft/RepairMinecraftPermissionsTest.php
@@ -1,0 +1,231 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Enums\MembershipLevel;
+use App\Enums\MinecraftAccountType;
+use App\Enums\StaffDepartment;
+use App\Models\MinecraftAccount;
+use App\Models\User;
+use App\Services\MinecraftRconService;
+
+beforeEach(function () {
+    $this->rconMock = $this->mock(MinecraftRconService::class);
+    $this->rconMock->shouldReceive('executeCommand')
+        ->andReturn(['success' => true, 'response' => 'ok', 'error' => null])
+        ->byDefault();
+});
+
+// ─── No accounts ─────────────────────────────────────────────────────────────
+
+test('exits successfully with message when no active accounts exist', function () {
+    $this->artisan('minecraft:repair-permissions', ['--dry-run' => true])
+        ->assertSuccessful()
+        ->expectsOutputToContain('No active Minecraft accounts found');
+});
+
+// ─── Dry-run behavior ────────────────────────────────────────────────────────
+
+test('dry-run reports planned whitelist add and rank for eligible account', function () {
+    $user = User::factory()->create(['membership_level' => MembershipLevel::Traveler]);
+    MinecraftAccount::factory()->for($user)->active()->create(['username' => 'EligiblePlayer']);
+
+    $this->rconMock->shouldReceive('executeCommand')->never();
+
+    $this->artisan('minecraft:repair-permissions', ['--dry-run' => true])
+        ->assertSuccessful()
+        ->expectsOutputToContain('[dry-run] whitelist add EligiblePlayer')
+        ->expectsOutputToContain('[dry-run] lh setmember EligiblePlayer traveler')
+        ->expectsOutputToContain('[dry-run] lh removestaff EligiblePlayer');
+});
+
+test('dry-run reports planned whitelist remove for brigged account', function () {
+    $user = User::factory()->create([
+        'membership_level' => MembershipLevel::Traveler,
+        'in_brig' => true,
+    ]);
+    MinecraftAccount::factory()->for($user)->active()->create(['username' => 'BriggedPlayer']);
+
+    $this->rconMock->shouldReceive('executeCommand')->never();
+
+    $this->artisan('minecraft:repair-permissions', ['--dry-run' => true])
+        ->assertSuccessful()
+        ->expectsOutputToContain('[dry-run] whitelist remove BriggedPlayer')
+        ->expectsOutputToContain('in brig');
+});
+
+test('dry-run reports planned whitelist remove for below-threshold account', function () {
+    $user = User::factory()->create(['membership_level' => MembershipLevel::Stowaway]);
+    MinecraftAccount::factory()->for($user)->active()->create(['username' => 'NewbiePlayer']);
+
+    $this->artisan('minecraft:repair-permissions', ['--dry-run' => true])
+        ->assertSuccessful()
+        ->expectsOutputToContain('[dry-run] whitelist remove NewbiePlayer')
+        ->expectsOutputToContain('below server access threshold');
+});
+
+test('dry-run reports planned whitelist remove for parent-disabled account', function () {
+    $user = User::factory()->create([
+        'membership_level' => MembershipLevel::Traveler,
+        'parent_allows_minecraft' => false,
+    ]);
+    MinecraftAccount::factory()->for($user)->active()->create(['username' => 'KidPlayer']);
+
+    $this->artisan('minecraft:repair-permissions', ['--dry-run' => true])
+        ->assertSuccessful()
+        ->expectsOutputToContain('[dry-run] whitelist remove KidPlayer')
+        ->expectsOutputToContain('parent disabled');
+});
+
+test('dry-run reports setstaff command for staff members', function () {
+    $user = User::factory()->create([
+        'membership_level' => MembershipLevel::Traveler,
+        'staff_department' => StaffDepartment::Engineer,
+    ]);
+    MinecraftAccount::factory()->for($user)->active()->create(['username' => 'StaffMember']);
+
+    $this->artisan('minecraft:repair-permissions', ['--dry-run' => true])
+        ->assertSuccessful()
+        ->expectsOutputToContain('[dry-run] lh setstaff StaffMember engineer');
+});
+
+test('dry-run sends no RCON commands and prints summary', function () {
+    $user = User::factory()->create(['membership_level' => MembershipLevel::Traveler]);
+    MinecraftAccount::factory()->for($user)->active()->create(['username' => 'APlayer']);
+
+    $this->rconMock->shouldReceive('executeCommand')->never();
+
+    $this->artisan('minecraft:repair-permissions', ['--dry-run' => true])
+        ->assertSuccessful()
+        ->expectsOutputToContain('Summary')
+        ->expectsOutputToContain('[dry-run] Whitelist adds:    1')
+        ->expectsOutputToContain('[dry-run] Rank changes:      1');
+});
+
+// ─── Live execution ───────────────────────────────────────────────────────────
+
+test('live mode sends whitelist, rank, and staff RCON commands for eligible account', function () {
+    $user = User::factory()->create(['membership_level' => MembershipLevel::Traveler]);
+    MinecraftAccount::factory()->for($user)->active()->create(['username' => 'LivePlayer']);
+
+    $this->rconMock->shouldReceive('executeCommand')
+        ->with('whitelist add LivePlayer', 'whitelist', 'LivePlayer', Mockery::any(), Mockery::any())
+        ->once()
+        ->andReturn(['success' => true, 'response' => 'Added', 'error' => null]);
+
+    $this->rconMock->shouldReceive('executeCommand')
+        ->with('lh setmember LivePlayer traveler', 'rank', 'LivePlayer', Mockery::any(), Mockery::any())
+        ->once()
+        ->andReturn(['success' => true, 'response' => 'Success: rank set', 'error' => null]);
+
+    $this->rconMock->shouldReceive('executeCommand')
+        ->with('lh removestaff LivePlayer', 'staff', 'LivePlayer', Mockery::any(), Mockery::any())
+        ->once()
+        ->andReturn(['success' => true, 'response' => 'Success: staff removed', 'error' => null]);
+
+    $this->artisan('minecraft:repair-permissions', ['--pace' => '0'])
+        ->assertSuccessful()
+        ->expectsOutputToContain('Whitelist adds:    1')
+        ->expectsOutputToContain('Rank changes:      1')
+        ->expectsOutputToContain('Staff changes:     1')
+        ->expectsOutputToContain('Failures:          0');
+});
+
+test('live mode sends whitelist remove for ineligible account', function () {
+    $user = User::factory()->create([
+        'membership_level' => MembershipLevel::Traveler,
+        'in_brig' => true,
+    ]);
+    MinecraftAccount::factory()->for($user)->active()->create(['username' => 'BrigPlayer']);
+
+    $this->rconMock->shouldReceive('executeCommand')
+        ->with('whitelist remove BrigPlayer', 'whitelist', 'BrigPlayer', Mockery::any(), Mockery::any())
+        ->once()
+        ->andReturn(['success' => true, 'response' => 'Removed', 'error' => null]);
+
+    $this->artisan('minecraft:repair-permissions', ['--pace' => '0'])
+        ->assertSuccessful()
+        ->expectsOutputToContain('Whitelist removes: 1');
+});
+
+test('live mode records failures in summary when RCON returns error', function () {
+    $user = User::factory()->create(['membership_level' => MembershipLevel::Traveler]);
+    MinecraftAccount::factory()->for($user)->active()->create(['username' => 'FailPlayer']);
+
+    $this->rconMock->shouldReceive('executeCommand')
+        ->andReturn(['success' => false, 'response' => null, 'error' => 'Server offline']);
+
+    $this->artisan('minecraft:repair-permissions', ['--pace' => '0'])
+        ->assertSuccessful()
+        ->expectsOutputToContain('Failures:');
+});
+
+// ─── Mixed account scenarios ─────────────────────────────────────────────────
+
+test('mixed eligible and ineligible accounts processed correctly in dry-run', function () {
+    $eligible = User::factory()->create(['membership_level' => MembershipLevel::Traveler]);
+    MinecraftAccount::factory()->for($eligible)->active()->create(['username' => 'EligPlayer']);
+
+    $brigged = User::factory()->create([
+        'membership_level' => MembershipLevel::Traveler,
+        'in_brig' => true,
+    ]);
+    MinecraftAccount::factory()->for($brigged)->active()->create(['username' => 'BrigPlayer2']);
+
+    $belowThreshold = User::factory()->create(['membership_level' => MembershipLevel::Drifter]);
+    MinecraftAccount::factory()->for($belowThreshold)->active()->create(['username' => 'DrifterPlayer']);
+
+    $this->rconMock->shouldReceive('executeCommand')->never();
+
+    $this->artisan('minecraft:repair-permissions', ['--dry-run' => true])
+        ->assertSuccessful()
+        ->expectsOutputToContain('[dry-run] whitelist add EligPlayer')
+        ->expectsOutputToContain('[dry-run] whitelist remove BrigPlayer2')
+        ->expectsOutputToContain('[dry-run] whitelist remove DrifterPlayer')
+        ->expectsOutputToContain('[dry-run] Whitelist adds:    1')
+        ->expectsOutputToContain('[dry-run] Whitelist removes: 2');
+});
+
+test('mixed live run sends correct RCON commands with pace=0', function () {
+    $eligible = User::factory()->create(['membership_level' => MembershipLevel::Traveler]);
+    MinecraftAccount::factory()->for($eligible)->active()->create(['username' => 'EligPlayer2']);
+
+    $ineligible = User::factory()->create(['membership_level' => MembershipLevel::Stowaway]);
+    MinecraftAccount::factory()->for($ineligible)->active()->create(['username' => 'IneligPlayer']);
+
+    $this->rconMock->shouldReceive('executeCommand')
+        ->with('whitelist add EligPlayer2', Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
+        ->once()
+        ->andReturn(['success' => true, 'response' => 'Added', 'error' => null]);
+
+    $this->rconMock->shouldReceive('executeCommand')
+        ->with(Mockery::pattern('/^lh /'), Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
+        ->twice()
+        ->andReturn(['success' => true, 'response' => 'Success: done', 'error' => null]);
+
+    $this->rconMock->shouldReceive('executeCommand')
+        ->with('whitelist remove IneligPlayer', Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
+        ->once()
+        ->andReturn(['success' => true, 'response' => 'Removed', 'error' => null]);
+
+    $this->artisan('minecraft:repair-permissions', ['--pace' => '0'])
+        ->assertSuccessful()
+        ->expectsOutputToContain('Whitelist adds:    1')
+        ->expectsOutputToContain('Whitelist removes: 1')
+        ->expectsOutputToContain('Failures:          0');
+});
+
+// ─── Bedrock account ─────────────────────────────────────────────────────────
+
+test('bedrock account uses fwhitelist command in dry-run', function () {
+    $user = User::factory()->create(['membership_level' => MembershipLevel::Traveler]);
+    MinecraftAccount::factory()->for($user)->active()->create([
+        'username' => 'BedrockGuy',
+        'uuid' => 'bedrock-uuid-5678',
+        'account_type' => MinecraftAccountType::Bedrock,
+    ]);
+
+    $this->artisan('minecraft:repair-permissions', ['--dry-run' => true])
+        ->assertSuccessful()
+        ->expectsOutputToContain('[dry-run] fwhitelist add');
+});

--- a/tests/Feature/Minecraft/SyncMinecraftAccountTest.php
+++ b/tests/Feature/Minecraft/SyncMinecraftAccountTest.php
@@ -1,0 +1,192 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Actions\SyncMinecraftAccount;
+use App\Enums\MembershipLevel;
+use App\Enums\MinecraftAccountType;
+use App\Enums\StaffDepartment;
+use App\Models\MinecraftAccount;
+use App\Models\User;
+use App\Services\MinecraftRconService;
+
+beforeEach(function () {
+    $this->rconMock = $this->mock(MinecraftRconService::class);
+    $this->rconMock->shouldReceive('executeCommand')
+        ->andReturn(['success' => true, 'response' => 'ok', 'error' => null])
+        ->byDefault();
+});
+
+// ─── Eligible user (Traveler+, not in brig, parent allows) ───────────────────
+
+test('eligible user receives whitelist add, rank set, and staff removed', function () {
+    $user = User::factory()->create(['membership_level' => MembershipLevel::Traveler]);
+    $account = MinecraftAccount::factory()->for($user)->active()->create(['username' => 'Steve']);
+
+    $this->rconMock->shouldReceive('executeCommand')
+        ->with('whitelist add Steve', 'whitelist', 'Steve', Mockery::any(), Mockery::any())
+        ->once()
+        ->andReturn(['success' => true, 'response' => 'Added Steve to whitelist', 'error' => null]);
+
+    $this->rconMock->shouldReceive('executeCommand')
+        ->with('lh setmember Steve traveler', 'rank', 'Steve', Mockery::any(), Mockery::any())
+        ->once()
+        ->andReturn(['success' => true, 'response' => 'Success: rank set', 'error' => null]);
+
+    $this->rconMock->shouldReceive('executeCommand')
+        ->with('lh removestaff Steve', 'staff', 'Steve', Mockery::any(), Mockery::any())
+        ->once()
+        ->andReturn(['success' => true, 'response' => 'Success: staff removed', 'error' => null]);
+
+    $result = SyncMinecraftAccount::run($account);
+
+    expect($result['eligible'])->toBeTrue()
+        ->and($result['whitelist']['action'])->toBe('add')
+        ->and($result['whitelist']['success'])->toBeTrue()
+        ->and($result['rank']['rank'])->toBe('traveler')
+        ->and($result['staff']['action'])->toBe('remove');
+});
+
+test('eligible staff user receives setstaff command', function () {
+    $user = User::factory()->create([
+        'membership_level' => MembershipLevel::Traveler,
+        'staff_department' => StaffDepartment::Engineer,
+    ]);
+    $account = MinecraftAccount::factory()->for($user)->active()->create(['username' => 'StaffPlayer']);
+
+    $this->rconMock->shouldReceive('executeCommand')
+        ->with('lh setstaff StaffPlayer engineer', 'staff', 'StaffPlayer', Mockery::any(), Mockery::any())
+        ->once()
+        ->andReturn(['success' => true, 'response' => 'Success: staff set', 'error' => null]);
+
+    $result = SyncMinecraftAccount::run($account);
+
+    expect($result['eligible'])->toBeTrue()
+        ->and($result['staff']['action'])->toBe('set')
+        ->and($result['staff']['department'])->toBe('engineer');
+});
+
+test('eligible user records rank sync and staff activity', function () {
+    $user = User::factory()->create(['membership_level' => MembershipLevel::Traveler]);
+    $account = MinecraftAccount::factory()->for($user)->active()->create(['username' => 'Steve']);
+
+    SyncMinecraftAccount::run($account);
+
+    $this->assertDatabaseHas('activity_logs', [
+        'subject_type' => User::class,
+        'subject_id' => $user->id,
+        'action' => 'minecraft_rank_synced',
+    ]);
+
+    $this->assertDatabaseHas('activity_logs', [
+        'subject_type' => User::class,
+        'subject_id' => $user->id,
+        'action' => 'minecraft_staff_position_removed',
+    ]);
+});
+
+test('eligible staff user records staff position set activity', function () {
+    $user = User::factory()->create([
+        'membership_level' => MembershipLevel::Traveler,
+        'staff_department' => StaffDepartment::Chaplain,
+    ]);
+    $account = MinecraftAccount::factory()->for($user)->active()->create(['username' => 'Padre']);
+
+    SyncMinecraftAccount::run($account);
+
+    $this->assertDatabaseHas('activity_logs', [
+        'subject_type' => User::class,
+        'subject_id' => $user->id,
+        'action' => 'minecraft_staff_position_set',
+    ]);
+});
+
+// ─── Ineligible: below server access threshold ───────────────────────────────
+
+test('user below membership threshold receives whitelist remove', function () {
+    $user = User::factory()->create(['membership_level' => MembershipLevel::Stowaway]);
+    $account = MinecraftAccount::factory()->for($user)->active()->create(['username' => 'NewGuy']);
+
+    $this->rconMock->shouldReceive('executeCommand')
+        ->with('whitelist remove NewGuy', 'whitelist', 'NewGuy', Mockery::any(), Mockery::any())
+        ->once()
+        ->andReturn(['success' => true, 'response' => 'Removed', 'error' => null]);
+
+    $result = SyncMinecraftAccount::run($account);
+
+    expect($result['eligible'])->toBeFalse()
+        ->and($result['whitelist']['action'])->toBe('remove')
+        ->and($result['rank'])->toBeNull()
+        ->and($result['staff'])->toBeNull();
+});
+
+test('ineligible user does not receive rank or staff commands', function () {
+    $user = User::factory()->create(['membership_level' => MembershipLevel::Drifter]);
+    $account = MinecraftAccount::factory()->for($user)->active()->create(['username' => 'Drifter1']);
+
+    $this->rconMock->shouldReceive('executeCommand')
+        ->with(Mockery::pattern('/^lh /'), Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
+        ->never();
+
+    SyncMinecraftAccount::run($account);
+});
+
+// ─── Ineligible: user is in brig ─────────────────────────────────────────────
+
+test('brigged user receives whitelist remove', function () {
+    $user = User::factory()->create([
+        'membership_level' => MembershipLevel::Traveler,
+        'in_brig' => true,
+    ]);
+    $account = MinecraftAccount::factory()->for($user)->active()->create(['username' => 'Trouble']);
+
+    $this->rconMock->shouldReceive('executeCommand')
+        ->with('whitelist remove Trouble', 'whitelist', 'Trouble', Mockery::any(), Mockery::any())
+        ->once()
+        ->andReturn(['success' => true, 'response' => 'Removed', 'error' => null]);
+
+    $result = SyncMinecraftAccount::run($account);
+
+    expect($result['eligible'])->toBeFalse()
+        ->and($result['whitelist']['action'])->toBe('remove');
+});
+
+// ─── Ineligible: parent has disabled Minecraft access ────────────────────────
+
+test('parent-disabled user receives whitelist remove', function () {
+    $user = User::factory()->create([
+        'membership_level' => MembershipLevel::Traveler,
+        'parent_allows_minecraft' => false,
+    ]);
+    $account = MinecraftAccount::factory()->for($user)->active()->create(['username' => 'KidPlayer']);
+
+    $this->rconMock->shouldReceive('executeCommand')
+        ->with('whitelist remove KidPlayer', 'whitelist', 'KidPlayer', Mockery::any(), Mockery::any())
+        ->once()
+        ->andReturn(['success' => true, 'response' => 'Removed', 'error' => null]);
+
+    $result = SyncMinecraftAccount::run($account);
+
+    expect($result['eligible'])->toBeFalse()
+        ->and($result['whitelist']['action'])->toBe('remove');
+});
+
+// ─── Bedrock account ─────────────────────────────────────────────────────────
+
+test('bedrock account uses fwhitelist add command', function () {
+    $user = User::factory()->create(['membership_level' => MembershipLevel::Traveler]);
+    $account = MinecraftAccount::factory()->for($user)->active()->create([
+        'username' => 'BedrockPlayer',
+        'uuid' => 'bedrock-uuid-1234',
+        'account_type' => MinecraftAccountType::Bedrock,
+    ]);
+
+    $this->rconMock->shouldReceive('executeCommand')
+        ->with(Mockery::pattern('/^fwhitelist add /'), 'whitelist', 'BedrockPlayer', Mockery::any(), Mockery::any())
+        ->once()
+        ->andReturn(['success' => true, 'response' => 'Added', 'error' => null]);
+
+    $result = SyncMinecraftAccount::run($account);
+
+    expect($result['eligible'])->toBeTrue();
+});


### PR DESCRIPTION
## What Changed

This PR hardens Minecraft permission reliability and adds a bulk permission repair tool for site administrators. Key changes:

- **`lh` command hardening**: Commands like `lh setmember` and `lh setstaff` are now only treated as successful when the RCON response begins with `Success:`. Blank or unrecognized responses are treated as failures. The full raw response is preserved in the MC Command Log.
- **Unified sync path**: All Minecraft permission flows (verification, promotion, demotion, reactivation, brig release, parent permission changes) now route through a single `SyncMinecraftAccount` action that evaluates whitelist eligibility, member rank, and staff assignment from current website state in one consistent pass.
- **Bulk repair command**: New artisan command `minecraft:repair-permissions` that audits every active Minecraft account and repairs their whitelist, rank, and staff state. Supports `--dry-run` (report planned changes without executing) and `--pace` (delay between commands to avoid flooding RCON).

## How to Test

### lh command response logging

1. Go to ACP → MC Command Log
2. Trigger a promotion or verification for a user with a Minecraft account
3. Verify the "Response" column shows the actual server response text (not blank)
4. If the server returns something other than `Success:` for an `lh` command, it should now log as a failure

### Unified sync path — promotion/demotion

1. Promote a Traveler with an active Minecraft account to Resident
2. Verify their in-game rank updates to `resident` immediately (no queue delay)
3. Demote them back — rank should update immediately

### Unified sync path — brig release

1. Put a user with an active Minecraft account in the brig
2. Release them from the brig
3. Verify whitelist access and rank are restored

### Bulk repair command (dry-run first)

1. SSH into the application server
2. Run: `php artisan minecraft:repair-permissions --dry-run`
3. Verify the output lists planned adds/removes/rank changes without touching the server
4. Run: `php artisan minecraft:repair-permissions --pace=1`
5. Verify the command runs, sends commands with 1-second pacing, and prints a summary

## Things to Watch For

- Minecraft verification flow: newly verified users should receive their rank immediately after verifying their account
- Brig enforcement: brigged users should NOT be whitelisted during bulk repair
- Parent restrictions: users with `parent_allows_minecraft = false` should NOT be whitelisted during bulk repair
- Staff users: staff position should be set alongside rank during any permission sync
- Accounts with both Java and Bedrock accounts: both should be processed independently

## Parent PRD

#354

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a bulk Minecraft permission repair console command with a --dry-run preview and optional pacing.

* **Improvements**
  * Unified Minecraft permission synchronization so whitelist, rank and staff updates run consistently across user lifecycle events.
  * Stricter validation and reporting for in-game/server command results to surface failures more reliably.

* **Documentation**
  * Added comprehensive guides and handbook pages covering sync workflows and the bulk repair process.

* **Tests**
  * New and updated feature tests covering lifecycle sync, per-account sync, repair command, and command-result handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->