### PR TITLE
feat: lh syncuser command integration and staff rank differentiation

### DIFF
--- a/app/Actions/SyncMinecraftAccount.php
+++ b/app/Actions/SyncMinecraftAccount.php
@@ -51,21 +51,30 @@ class SyncMinecraftAccount
             ];
         }
 
-        $whitelistResult = $rcon->executeCommand(
-            $account->whitelistAddCommand(),
-            'whitelist',
+        $staffPosition = $user->minecraftStaffPosition();
+
+        $syncResult = $rcon->executeCommand(
+            $account->syncUserCommand($rank, $staffPosition),
+            'sync',
             $account->username,
             $user,
-            ['action' => 'sync_add_eligible']
+            ['action' => 'sync_user']
         );
 
-        $rankResult = $rcon->executeCommand(
-            "lh setmember {$account->username} {$rank}",
-            'rank',
-            $account->username,
-            $user,
-            ['action' => 'sync_rank', 'membership_level' => $user->membership_level->value]
-        );
+        // Old three-command sequence preserved for fallback reference:
+        // $whitelistResult = $rcon->executeCommand(
+        //     $account->whitelistAddCommand(),
+        //     'whitelist', $account->username, $user, ['action' => 'sync_add_eligible']
+        // );
+        // $rankResult = $rcon->executeCommand(
+        //     "lh setmember {$account->username} {$rank}",
+        //     'rank', $account->username, $user, ['action' => 'sync_rank', 'membership_level' => $user->membership_level->value]
+        // );
+        // if ($staffDepartment !== null) {
+        //     $rcon->executeCommand("lh setstaff {$account->username} {$staffDepartment->value}", 'staff', ...);
+        // } else {
+        //     $rcon->executeCommand("lh removestaff {$account->username}", 'staff', ...);
+        // }
 
         RecordActivity::handle(
             $user,
@@ -73,37 +82,19 @@ class SyncMinecraftAccount
             "Synced Minecraft rank to {$rank} for {$account->username}"
         );
 
-        $staffDepartment = $user->staff_department;
-
-        if ($staffDepartment !== null) {
-            $staffResult = $rcon->executeCommand(
-                "lh setstaff {$account->username} {$staffDepartment->value}",
-                'staff',
-                $account->username,
-                $user,
-                ['action' => 'set_staff_position', 'department' => $staffDepartment->value]
-            );
-
+        if ($staffPosition !== 'none') {
             RecordActivity::handle(
                 $user,
                 'minecraft_staff_position_set',
-                "Set Minecraft staff position to {$staffDepartment->label()} for {$account->username}"
+                "Set Minecraft staff position to {$staffPosition} for {$account->username}"
             );
 
             $staffReturn = [
-                'success' => $staffResult['success'],
+                'success' => $syncResult['success'],
                 'action' => 'set',
-                'department' => $staffDepartment->value,
+                'department' => $staffPosition,
             ];
         } else {
-            $staffResult = $rcon->executeCommand(
-                "lh removestaff {$account->username}",
-                'staff',
-                $account->username,
-                $user,
-                ['action' => 'remove_staff_position']
-            );
-
             RecordActivity::handle(
                 $user,
                 'minecraft_staff_position_removed',
@@ -111,7 +102,7 @@ class SyncMinecraftAccount
             );
 
             $staffReturn = [
-                'success' => $staffResult['success'],
+                'success' => $syncResult['success'],
                 'action' => 'remove',
                 'department' => null,
             ];
@@ -119,8 +110,8 @@ class SyncMinecraftAccount
 
         return [
             'eligible' => true,
-            'whitelist' => ['success' => $whitelistResult['success'], 'action' => 'add'],
-            'rank' => ['success' => $rankResult['success'], 'rank' => $rank],
+            'whitelist' => ['success' => $syncResult['success'], 'action' => 'add'],
+            'rank' => ['success' => $syncResult['success'], 'rank' => $rank],
             'staff' => $staffReturn,
         ];
     }

--- a/app/Console/Commands/RepairMinecraftPermissions.php
+++ b/app/Console/Commands/RepairMinecraftPermissions.php
@@ -42,6 +42,14 @@ class RepairMinecraftPermissions extends Command
         $rcon = $dryRun ? null : app(MinecraftRconService::class);
         $firstCommand = true;
 
+        // Send lh syncstart once before the per-account loop in live mode.
+        // This backs up and clears the whitelist so every account gets a clean resync.
+        // Dry-run skips this — it only shows planned per-account actions.
+        if (! $dryRun) {
+            $firstCommand = $this->pauseIfNeeded($firstCommand, $pace);
+            $rcon->executeCommand('lh syncstart', 'sync', null, null, ['action' => 'syncstart']);
+        }
+
         foreach ($accounts as $account) {
             $user = $account->user;
             $rank = $user->membership_level->minecraftRank();
@@ -50,55 +58,36 @@ class RepairMinecraftPermissions extends Command
             $this->line("  <fg=cyan>{$account->username}</> ({$user->name})");
 
             if ($eligible) {
-                $staffDepartment = $user->staff_department;
+                $staffPosition = $user->minecraftStaffPosition();
+                $syncCmd = $account->syncUserCommand($rank, $staffPosition);
 
-                // ── Whitelist add ─────────────────────────────────────────────
-                $whitelistCmd = $account->whitelistAddCommand();
                 if ($dryRun) {
-                    $this->line("    [dry-run] {$whitelistCmd}");
+                    $this->line("    [dry-run] {$syncCmd}");
                     $counts['adds']++;
-                } else {
-                    $firstCommand = $this->pauseIfNeeded($firstCommand, $pace);
-                    $result = $rcon->executeCommand(
-                        $whitelistCmd, 'whitelist', $account->username, $user,
-                        ['action' => 'repair_whitelist_add']
-                    );
-                    $this->reportResult($whitelistCmd, $result['success']);
-                    $result['success'] ? $counts['adds']++ : $counts['failures']++;
-                }
-
-                // ── Member rank ───────────────────────────────────────────────
-                $rankCmd = "lh setmember {$account->username} {$rank}";
-                if ($dryRun) {
-                    $this->line("    [dry-run] {$rankCmd}");
                     $counts['rank_changes']++;
-                } else {
-                    $firstCommand = $this->pauseIfNeeded($firstCommand, $pace);
-                    $result = $rcon->executeCommand(
-                        $rankCmd, 'rank', $account->username, $user,
-                        ['action' => 'repair_rank', 'rank' => $rank]
-                    );
-                    $this->reportResult($rankCmd, $result['success']);
-                    $result['success'] ? $counts['rank_changes']++ : $counts['failures']++;
-                }
-
-                // ── Staff position ────────────────────────────────────────────
-                $staffCmd = $staffDepartment !== null
-                    ? "lh setstaff {$account->username} {$staffDepartment->value}"
-                    : "lh removestaff {$account->username}";
-
-                if ($dryRun) {
-                    $this->line("    [dry-run] {$staffCmd}");
                     $counts['staff_changes']++;
                 } else {
                     $firstCommand = $this->pauseIfNeeded($firstCommand, $pace);
                     $result = $rcon->executeCommand(
-                        $staffCmd, 'staff', $account->username, $user,
-                        ['action' => $staffDepartment !== null ? 'repair_staff_set' : 'repair_staff_remove']
+                        $syncCmd, 'sync', $account->username, $user,
+                        ['action' => 'repair_sync']
                     );
-                    $this->reportResult($staffCmd, $result['success']);
-                    $result['success'] ? $counts['staff_changes']++ : $counts['failures']++;
+                    $this->reportResult($syncCmd, $result['success']);
+                    if ($result['success']) {
+                        $counts['adds']++;
+                        $counts['rank_changes']++;
+                        $counts['staff_changes']++;
+                    } else {
+                        $counts['failures']++;
+                    }
                 }
+
+                // Old three-command sequence preserved for fallback reference:
+                // $whitelistCmd = $account->whitelistAddCommand();
+                // $rankCmd = "lh setmember {$account->username} {$rank}";
+                // $staffCmd = $staffDepartment !== null
+                //     ? "lh setstaff {$account->username} {$staffDepartment->value}"
+                //     : "lh removestaff {$account->username}";
             } else {
                 // ── Ineligible: whitelist remove ──────────────────────────────
                 $reason = $this->ineligibilityReason($user, $rank);

--- a/app/Console/Commands/RepairMinecraftPermissions.php
+++ b/app/Console/Commands/RepairMinecraftPermissions.php
@@ -47,7 +47,10 @@ class RepairMinecraftPermissions extends Command
         // Dry-run skips this — it only shows planned per-account actions.
         if (! $dryRun) {
             $firstCommand = $this->pauseIfNeeded($firstCommand, $pace);
-            $rcon->executeCommand('lh syncstart', 'sync', null, null, ['action' => 'syncstart']);
+            $syncstartResult = $rcon->executeCommand('lh syncstart', 'sync', null, null, ['action' => 'syncstart']);
+            if (! $syncstartResult['success']) {
+                $this->warn('lh syncstart failed — proceeding with per-account sync anyway');
+            }
         }
 
         foreach ($accounts as $account) {

--- a/app/Models/MinecraftAccount.php
+++ b/app/Models/MinecraftAccount.php
@@ -126,4 +126,20 @@ class MinecraftAccount extends Model
             MinecraftAccountType::Bedrock => "fwhitelist remove {$this->uuid}",
         };
     }
+
+    /**
+     * Returns the lh syncuser command for this account.
+     * Java:    "lh syncuser <username> <rank> <staffPosition>"
+     * Bedrock: "lh syncuser <username> <rank> <staffPosition> -bedrock <uuid>"
+     */
+    public function syncUserCommand(string $rank, string $staffPosition): string
+    {
+        $base = "lh syncuser {$this->username} {$rank} {$staffPosition}";
+
+        if ($this->account_type === MinecraftAccountType::Bedrock) {
+            return "{$base} -bedrock {$this->uuid}";
+        }
+
+        return $base;
+    }
 }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -388,7 +388,7 @@ class User extends Authenticatable // implements MustVerifyEmail
 
     public function minecraftStaffPosition(): string
     {
-        if ($this->staff_department === null) {
+        if ($this->staff_department === null || $this->staff_rank === null || $this->staff_rank === StaffRank::None) {
             return 'none';
         }
 

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -386,6 +386,17 @@ class User extends Authenticatable // implements MustVerifyEmail
         return $this->staff_rank === StaffRank::JrCrew;
     }
 
+    public function minecraftStaffPosition(): string
+    {
+        if ($this->staff_department === null) {
+            return 'none';
+        }
+
+        return $this->isAtLeastRank(StaffRank::Officer)
+            ? $this->staff_department->value
+            : $this->staff_department->value.'_crew';
+    }
+
     public function staffPosition(): HasOne
     {
         return $this->hasOne(StaffPosition::class);

--- a/docs/features/lh syncuser Command Integration and Staff Rank Differentiation.md
+++ b/docs/features/lh syncuser Command Integration and Staff Rank Differentiation.md
@@ -1,0 +1,589 @@
+# lh syncuser Command Integration and Staff Rank Differentiation -- Technical Documentation
+
+> **Audience:** Project owner, developers, AI agents
+> **Generated:** 2026-03-24
+> **Generator:** `/document-feature` skill
+
+---
+
+## Table of Contents
+
+1. [Overview](#1-overview)
+2. [Database Schema](#2-database-schema)
+3. [Models & Relationships](#3-models--relationships)
+4. [Enums Reference](#4-enums-reference)
+5. [Authorization & Permissions](#5-authorization--permissions)
+6. [Routes](#6-routes)
+7. [User Interface Components](#7-user-interface-components)
+8. [Actions (Business Logic)](#8-actions-business-logic)
+9. [Notifications](#9-notifications)
+10. [Background Jobs](#10-background-jobs)
+11. [Console Commands & Scheduled Tasks](#11-console-commands--scheduled-tasks)
+12. [Services](#12-services)
+13. [Activity Log Entries](#13-activity-log-entries)
+14. [Data Flow Diagrams](#14-data-flow-diagrams)
+15. [Configuration](#15-configuration)
+16. [Test Coverage](#16-test-coverage)
+17. [File Map](#17-file-map)
+18. [Known Issues & Improvement Opportunities](#18-known-issues--improvement-opportunities)
+
+---
+
+## 1. Overview
+
+This feature updates the Lighthouse Website's Minecraft synchronization layer to use two new plugin commands introduced by the server-side Minecraft plugin:
+
+- **`lh syncuser`** — a single command that whitelists a player, sets their member rank, and sets or removes their staff position in one RCON call (replacing the previous three-command sequence of `whitelist add` + `lh setmember` + `lh setstaff`/`lh removestaff`).
+- **`lh syncstart`** — a pre-run command for the bulk repair artisan command that backs up and clears the whitelist before a full resync, ensuring no stale entries remain.
+
+Additionally, the plugin now requires **rank-differentiated staff group assignments**: Officers receive their department name as-is (e.g., `engineer`), while Crew Members and Jr Crew receive a `_crew` suffix (e.g., `engineer_crew`). This reflects a LuckPerms staff track change on the Minecraft server.
+
+**Who is affected:**
+- **Site administrators** running `minecraft:repair-permissions` — the command now runs one-third the RCON traffic and completes faster.
+- **Staff members** having their accounts synced — their correct Minecraft staff group (officer vs. crew) is applied based on actual rank.
+- **All members** with active Minecraft accounts — any sync operation (promotion, demotion, verification, brig release, parent permission toggle) now uses the single unified `lh syncuser` call.
+
+**How it fits in:** This feature builds directly on PRD #354 (Minecraft Permission Hardening and Bulk Repair), which established the `SyncMinecraftAccount` unified sync path and `RepairMinecraftPermissions` artisan command. PRD #365 updates those components to use the new plugin API without changing the external surface or authorization model.
+
+**Key concepts:**
+- **`lh syncuser` command**: `lh syncuser <username> <rank> <staffPosition>` for Java accounts; appends `-bedrock <uuid>` for Bedrock accounts. Staff position is either `none` or a LuckPerms group name.
+- **`lh syncstart` command**: Run once before a bulk repair loop. Backs up whitelist to a timestamped JSON file and clears the live whitelist so every account gets a fresh add.
+- **Officer vs. Crew staff distinction**: Officers use the plain department value (e.g., `engineer`). Crew Members and Jr Crew use the department value with `_crew` appended (e.g., `engineer_crew`).
+
+---
+
+## 2. Database Schema
+
+No new migrations were introduced by this feature. All data lives in pre-existing tables.
+
+### `users` table (relevant columns)
+
+| Column | Type | Nullable | Notes |
+|--------|------|----------|-------|
+| `staff_rank` | int (cast to `StaffRank`) | Yes | `null`=None, 1=JrCrew, 2=CrewMember, 3=Officer |
+| `staff_department` | string (cast to `StaffDepartment`) | Yes | `command`, `chaplain`, `engineer`, `quartermaster`, `steward` |
+| `membership_level` | int (cast to `MembershipLevel`) | No | Determines `minecraftRank()` |
+| `in_brig` | boolean | No | Ineligible if true |
+| `parent_allows_minecraft` | boolean | No | Ineligible if false |
+
+### `minecraft_accounts` table (relevant columns)
+
+| Column | Type | Nullable | Notes |
+|--------|------|----------|-------|
+| `username` | string | No | Used in `lh syncuser` command |
+| `uuid` | string | Yes | Bedrock UUID appended with `-bedrock` flag |
+| `account_type` | string (cast to `MinecraftAccountType`) | No | `java` or `bedrock` |
+| `status` | string (cast to `MinecraftAccountStatus`) | No | Only `active` accounts are synced |
+
+### `minecraft_command_logs` table (relevant columns)
+
+| Column | Type | Nullable | Notes |
+|--------|------|----------|-------|
+| `command` | string | No | Full `lh syncuser` or `lh syncstart` command string |
+| `command_type` | string | No | `'sync'` for both syncuser and syncstart |
+| `target` | string | Yes | Username for syncuser; `null` for syncstart |
+| `user_id` | FK | Yes | Associated user; `null` for syncstart |
+| `status` | string | No | `success` or `failed` |
+
+**Migrations:** No new migrations. Existing schema from prior PRDs covers all required columns.
+
+---
+
+## 3. Models & Relationships
+
+### `User` (`app/Models/User.php`)
+
+**New method introduced by this feature:**
+
+#### `minecraftStaffPosition(): string`
+
+Returns the LuckPerms staff group name for this user's Minecraft account sync.
+
+```
+Logic:
+- If staff_department is null → return 'none'
+- If isAtLeastRank(StaffRank::Officer) → return $this->staff_department->value  (e.g., 'engineer')
+- Otherwise (CrewMember, JrCrew, None with dept) → return $this->staff_department->value . '_crew'  (e.g., 'engineer_crew')
+```
+
+**Called by:** `SyncMinecraftAccount::handle()`, `RepairMinecraftPermissions::handle()`
+
+**Helper methods used internally:**
+- `isAtLeastRank(StaffRank $rank): bool` — checks `($this->staff_rank?->value ?? 0) >= $rank->value`
+
+---
+
+### `MinecraftAccount` (`app/Models/MinecraftAccount.php`)
+
+**New method introduced by this feature:**
+
+#### `syncUserCommand(string $rank, string $staffPosition): string`
+
+Returns the correct `lh syncuser` RCON command string for this account.
+
+```
+Java:    "lh syncuser {username} {rank} {staffPosition}"
+Bedrock: "lh syncuser {username} {rank} {staffPosition} -bedrock {uuid}"
+```
+
+**Placed alongside existing methods** `whitelistAddCommand()` and `whitelistRemoveCommand()` in the `// RCON Command Helpers` section of the model.
+
+**Existing relationships (unchanged):**
+| Method | Type | Related Model | Notes |
+|--------|------|---------------|-------|
+| `user()` | belongsTo | User | Account owner |
+| `rewards()` | hasMany | MinecraftReward | Rewards linked to this account |
+
+---
+
+## 4. Enums Reference
+
+### `StaffRank` (`app/Enums/StaffRank.php`)
+
+| Case | Value | Label | Minecraft staff group suffix |
+|------|-------|-------|------------------------------|
+| `None` | 0 | None | N/A (no staff group) |
+| `JrCrew` | 1 | Junior Crew Member | `_crew` suffix |
+| `CrewMember` | 2 | Crew Member | `_crew` suffix |
+| `Officer` | 3 | Officer | No suffix (plain department name) |
+
+**Key helper:** `isAtLeastRank(StaffRank::Officer)` tests `$value >= 3`.
+
+---
+
+### `StaffDepartment` (`app/Enums/StaffDepartment.php`)
+
+| Case | Value | Label | Officer group | Crew group |
+|------|-------|-------|---------------|------------|
+| `Command` | `'command'` | Command | `command` | `command_crew` |
+| `Chaplain` | `'chaplain'` | Chaplain | `chaplain` | `chaplain_crew` |
+| `Engineer` | `'engineer'` | Engineer | `engineer` | `engineer_crew` |
+| `Quartermaster` | `'quartermaster'` | Quartermaster | `quartermaster` | `quartermaster_crew` |
+| `Steward` | `'steward'` | Steward | `steward` | `steward_crew` |
+
+---
+
+### `MinecraftAccountType` (`app/Enums/MinecraftAccountType.php`)
+
+| Case | Value | Sync command format |
+|------|-------|---------------------|
+| `Java` | `'java'` | `lh syncuser <username> <rank> <pos>` |
+| `Bedrock` | `'bedrock'` | `lh syncuser <username> <rank> <pos> -bedrock <uuid>` |
+
+---
+
+### `MembershipLevel` (relevant to eligibility)
+
+The `minecraftRank()` method returns:
+- `null` for Drifter and Stowaway (ineligible for server access)
+- `'traveler'`, `'resident'`, `'citizen'` for higher levels
+
+---
+
+## 5. Authorization & Permissions
+
+No new gates or policies were added by this feature. The sync operations are internal server-to-server calls, not user-facing actions requiring authorization.
+
+**Existing gates that trigger Minecraft syncs (unchanged):**
+- Promotion/demotion actions require admin-level access (controlled by existing gates)
+- `minecraft:repair-permissions` artisan command requires server shell access
+
+### Permissions Matrix
+
+| Action | Regular Member | Staff (any rank) | Admin |
+|--------|---------------|-----------------|-------|
+| `lh syncuser` sent on account sync | Automatic (no user action) | Automatic | Automatic |
+| `lh syncstart` + bulk repair | No | No | Yes (artisan only) |
+
+---
+
+## 6. Routes
+
+No new routes introduced by this feature. All sync operations are triggered internally by actions called from existing routes.
+
+---
+
+## 7. User Interface Components
+
+Not applicable for this feature. No new Volt components or UI changes were introduced. The `lh syncuser` command replaces three internal RCON calls; users see no visible difference.
+
+---
+
+## 8. Actions (Business Logic)
+
+### `SyncMinecraftAccount` (`app/Actions/SyncMinecraftAccount.php`)
+
+**Signature:** `handle(MinecraftAccount $account): array`
+
+**Step-by-step logic:**
+
+1. Load `$account->user` and resolve `$rcon = app(MinecraftRconService::class)`
+2. Determine `$rank = $user->membership_level->minecraftRank()` (null = ineligible)
+3. Check eligibility: `$rank !== null && !$user->isInBrig() && $user->parent_allows_minecraft`
+
+**Ineligible path:**
+4. Send `$account->whitelistRemoveCommand()` via RCON (type `'whitelist'`)
+5. Return `['eligible' => false, 'whitelist' => [...], 'rank' => null, 'staff' => null]`
+
+**Eligible path (changed by this PRD):**
+4. Call `$user->minecraftStaffPosition()` → `$staffPosition` (`'none'`, `'engineer'`, `'engineer_crew'`, etc.)
+5. Call `$account->syncUserCommand($rank, $staffPosition)` → full `lh syncuser ...` string
+6. Send the command via RCON (type `'sync'`, meta `['action' => 'sync_user']`)
+7. Log `RecordActivity::run($user, 'minecraft_rank_synced', ...)`
+8. If `$staffPosition !== 'none'`:
+   - Log `RecordActivity::run($user, 'minecraft_staff_position_set', ...)`
+   - `$staffReturn = ['success' => ..., 'action' => 'set', 'department' => $staffPosition]`
+9. Else:
+   - Log `RecordActivity::run($user, 'minecraft_staff_position_removed', ...)`
+   - `$staffReturn = ['success' => ..., 'action' => 'remove', 'department' => null]`
+10. Return `['eligible' => true, 'whitelist' => ['success' => ..., 'action' => 'add'], 'rank' => [...], 'staff' => $staffReturn]`
+
+**Return shape (unchanged from pre-PRD):**
+```php
+[
+    'eligible' => bool,
+    'whitelist' => ['success' => bool, 'action' => 'add'|'remove'],
+    'rank'     => ['success' => bool, 'rank' => string] | null,
+    'staff'    => ['success' => bool, 'action' => 'set'|'remove', 'department' => string|null] | null,
+]
+```
+
+**Called by:**
+- `SyncMinecraftPermissions::run($user)` — for lifecycle syncs (promotion, demotion, etc.)
+- `ReactivateMinecraftAccount::handle()` — checks `$result['whitelist']['success']` to decide whether to revert
+- `UpdateChildPermission::handle()` — when parent enables Minecraft access
+- `ReleaseUserFromBrig::handle()` — when a user is released from the brig
+- `CompleteVerification::handle()` — after account verification succeeds
+
+**Old fallback commands** (preserved as comments for reference):
+```php
+// $account->whitelistAddCommand()          → "whitelist add <username>" / "fwhitelist add <uuid>"
+// "lh setmember {$username} {$rank}"
+// "lh setstaff {$username} {$dept}" / "lh removestaff {$username}"
+```
+
+---
+
+## 9. Notifications
+
+Not applicable for this feature. No notifications are sent by the sync commands themselves.
+
+---
+
+## 10. Background Jobs
+
+Not applicable for this feature. Minecraft sync calls are made synchronously via RCON.
+
+---
+
+## 11. Console Commands & Scheduled Tasks
+
+### `minecraft:repair-permissions`
+**File:** `app/Console/Commands/RepairMinecraftPermissions.php`
+**Scheduled:** No (manual invocation only)
+
+**Options:**
+- `--dry-run` — Print planned actions without sending RCON commands
+- `--pace=1` — Seconds to pause between outbound commands (default: 1, use 0 for testing)
+
+**What it does (updated by this PRD):**
+
+**Live mode:**
+1. Fetches all active `MinecraftAccount` records with their `user` relationship eager-loaded
+2. **NEW:** Sends `lh syncstart` once before the per-account loop (RCON type `'sync'`, target `null`, user `null`, meta `['action' => 'syncstart']`)
+   - This backs up the server whitelist to a timestamped JSON file and clears the live whitelist
+3. For each active account:
+   - If eligible: sends `$account->syncUserCommand($rank, $user->minecraftStaffPosition())` (RCON type `'sync'`)
+     - Success: increments `adds`, `rank_changes`, `staff_changes` counters
+     - Failure: increments `failures` counter
+   - If ineligible: sends `$account->whitelistRemoveCommand()` (RCON type `'whitelist'`)
+4. Prints summary: Whitelist adds / Whitelist removes / Rank changes / Staff changes / Failures
+
+**Dry-run mode:**
+- Skips `lh syncstart` entirely (no output for it)
+- For each eligible account: prints `[dry-run] lh syncuser <username> <rank> <staffPos>` and increments all counters
+- For each ineligible account: prints `[dry-run] whitelist remove <username>` and the reason
+- Prints summary with `[dry-run]` prefix (no Failures line)
+
+**Old fallback commands** (preserved as comments):
+```php
+// $account->whitelistAddCommand()
+// "lh setmember {$username} {$rank}"
+// "lh setstaff {$username} {$dept}" / "lh removestaff {$username}"
+```
+
+---
+
+## 12. Services
+
+### `MinecraftRconService` (`app/Services/MinecraftRconService.php`)
+
+No changes to this service. Relevant behavior:
+
+- `executeCommand(string $command, string $commandType, ?string $target, ?User $user, array $meta): array`
+  - Accepts `null` for `$target` and `$user` (used by `lh syncstart` call which has no associated account/user)
+  - For `lh ` commands: success requires response starts with `"Success:"`
+  - Logs every command to `minecraft_command_logs`
+  - Returns `['success' => bool, 'response' => string|null, 'error' => string|null]`
+
+The `lh syncstart` and `lh syncuser` commands both start with `lh ` so they are automatically subject to the strict `Success:` response validation introduced in PRD #354.
+
+---
+
+## 13. Activity Log Entries
+
+| Action String | Logged By | Subject Model | Description Template |
+|---------------|-----------|---------------|---------------------|
+| `minecraft_rank_synced` | `SyncMinecraftAccount` | `User` | `"Synced Minecraft rank to {rank} for {username}"` |
+| `minecraft_staff_position_set` | `SyncMinecraftAccount` | `User` | `"Set Minecraft staff position to {staffPosition} for {username}"` |
+| `minecraft_staff_position_removed` | `SyncMinecraftAccount` | `User` | `"Removed Minecraft staff position for {username}"` |
+
+Note: `RepairMinecraftPermissions` does not log activity directly; activity logging happens inside `SyncMinecraftAccount` which the repair command does not call (it sends RCON directly). Only lifecycle syncs via `SyncMinecraftAccount` generate activity log entries.
+
+---
+
+## 14. Data Flow Diagrams
+
+### Lifecycle Sync (Promotion, Demotion, Brig Release, Parent Permission Change, Verification)
+
+```
+Event triggers (e.g., PromoteUser::run($user))
+  -> SyncMinecraftPermissions::run($user)
+    -> foreach active account:
+      -> SyncMinecraftAccount::run($account)
+        -> $rank = $user->membership_level->minecraftRank()
+        -> eligibility check (rank, brig, parent_allows_minecraft)
+        ->
+        -> [INELIGIBLE PATH]
+        ->   rcon->executeCommand($account->whitelistRemoveCommand(), 'whitelist', ...)
+        ->   return ['eligible' => false, ...]
+        ->
+        -> [ELIGIBLE PATH]
+        ->   $staffPosition = $user->minecraftStaffPosition()
+        ->       staff_department null → 'none'
+        ->       isAtLeastRank(Officer) → dept->value (e.g., 'engineer')
+        ->       otherwise → dept->value . '_crew' (e.g., 'engineer_crew')
+        ->   $cmd = $account->syncUserCommand($rank, $staffPosition)
+        ->       Java:    "lh syncuser {username} {rank} {staffPos}"
+        ->       Bedrock: "lh syncuser {username} {rank} {staffPos} -bedrock {uuid}"
+        ->   rcon->executeCommand($cmd, 'sync', $account->username, $user, ...)
+        ->   RecordActivity::run($user, 'minecraft_rank_synced', ...)
+        ->   if staffPosition != 'none': RecordActivity::run($user, 'minecraft_staff_position_set', ...)
+        ->   else: RecordActivity::run($user, 'minecraft_staff_position_removed', ...)
+        ->   return ['eligible' => true, 'whitelist' => [...], 'rank' => [...], 'staff' => [...]]
+```
+
+---
+
+### Bulk Repair (Live Mode)
+
+```
+Admin runs: php artisan minecraft:repair-permissions [--pace=N]
+  -> RepairMinecraftPermissions::handle()
+    -> MinecraftAccount::active()->with('user')->get()
+    -> [if !dryRun]
+    ->   rcon->executeCommand('lh syncstart', 'sync', null, null, ['action' => 'syncstart'])
+    ->   (backs up whitelist, clears live whitelist on server)
+    ->
+    -> foreach $accounts as $account:
+    ->   eligibility check
+    ->
+    ->   [ELIGIBLE]
+    ->   $staffPosition = $user->minecraftStaffPosition()
+    ->   $syncCmd = $account->syncUserCommand($rank, $staffPosition)
+    ->   rcon->executeCommand($syncCmd, 'sync', $account->username, $user, ...)
+    ->   success → adds++, rank_changes++, staff_changes++
+    ->   failure → failures++
+    ->
+    ->   [INELIGIBLE]
+    ->   rcon->executeCommand($account->whitelistRemoveCommand(), 'whitelist', ...)
+    ->   success → removes++
+    ->
+    -> printSummary($counts, $dryRun)
+```
+
+---
+
+### Bulk Repair (Dry-Run Mode)
+
+```
+Admin runs: php artisan minecraft:repair-permissions --dry-run
+  -> RepairMinecraftPermissions::handle()
+    -> MinecraftAccount::active()->with('user')->get()
+    -> (lh syncstart NOT sent, NOT shown in output)
+    ->
+    -> foreach $accounts as $account:
+    ->   [ELIGIBLE]
+    ->   output: "[dry-run] lh syncuser {username} {rank} {staffPos}"
+    ->   adds++, rank_changes++, staff_changes++
+    ->
+    ->   [INELIGIBLE]
+    ->   output: "[dry-run] whitelist remove {username}"
+    ->   output: "  ({reason})"
+    ->   removes++
+    ->
+    -> printSummary — all lines prefixed "[dry-run]", no Failures line
+```
+
+---
+
+## 15. Configuration
+
+Not applicable for this feature. No new environment variables or config keys were introduced. The feature relies on existing `services.minecraft.rcon_*` config (from prior PRDs).
+
+---
+
+## 16. Test Coverage
+
+### Test Files
+
+| File | Tests | What It Covers |
+|------|-------|----------------|
+| `tests/Feature/Minecraft/SyncUserCommandTest.php` | 7 | Model methods `minecraftStaffPosition()` and `syncUserCommand()` |
+| `tests/Feature/Minecraft/SyncMinecraftAccountTest.php` | 10 | Full SyncMinecraftAccount action with new lh syncuser |
+| `tests/Feature/Minecraft/MinecraftLifecycleSyncTest.php` | 11 | Promotion, demotion, reactivation, brig release, parent permission toggle all using lh syncuser |
+| `tests/Feature/Minecraft/RepairMinecraftPermissionsTest.php` | 16 | Repair command dry-run and live mode with lh syncstart and lh syncuser |
+| `tests/Feature/Minecraft/MixedAccountScenariosTest.php` | 9 | Multi-account users, Java+Bedrock, consistency between lifecycle and repair |
+| `tests/Feature/Minecraft/CompleteVerificationTest.php` | (1 relevant) | Staff member verification uses lh syncuser with correct officer staff group |
+
+### Test Case Inventory
+
+**SyncUserCommandTest.php:**
+- `minecraftStaffPosition returns none when user has no department`
+- `minecraftStaffPosition returns department value for Officer`
+- `minecraftStaffPosition returns department_crew for Crew Member`
+- `minecraftStaffPosition returns department_crew for Jr Crew`
+- `syncUserCommand returns correct string for Java account`
+- `syncUserCommand returns correct string with none staff position for Java account`
+- `syncUserCommand returns correct string for Bedrock account with -bedrock suffix`
+
+**SyncMinecraftAccountTest.php:**
+- `eligible user receives single lh syncuser command`
+- `eligible staff Officer receives lh syncuser with department name (no _crew suffix)`
+- `eligible staff Crew Member receives lh syncuser with _crew suffix`
+- `eligible user records rank sync and staff activity`
+- `eligible staff user records staff position set activity`
+- `user below membership threshold receives whitelist remove`
+- `ineligible user does not receive lh syncuser command`
+- `brigged user receives whitelist remove`
+- `parent-disabled user receives whitelist remove`
+- `bedrock account uses lh syncuser with -bedrock suffix`
+
+**MinecraftLifecycleSyncTest.php:**
+- `SyncMinecraftPermissions sends lh syncuser for each active account`
+- `SyncMinecraftPermissions skips removed and verifying accounts`
+- `PromoteUser syncs Minecraft permissions through unified path`
+- `DemoteUser syncs Minecraft permissions through unified path`
+- `reactivation uses unified sync to restore whitelist and rank`
+- `reactivation reverts account to Removed if sync fails`
+- `brig release restores Minecraft access via unified sync when parent allows`
+- `brig release sets account to ParentDisabled and skips sync when parent blocks MC`
+- `parent disabling MC triggers whitelist remove via unified sync`
+- `parent enabling MC triggers lh syncuser via unified sync`
+- `parent enabling MC syncs staff position for Officer child via lh syncuser`
+
+**RepairMinecraftPermissionsTest.php:**
+- `exits successfully with message when no active accounts exist`
+- `dry-run reports lh syncuser for eligible account`
+- `dry-run does not send lh syncstart`
+- `dry-run reports planned whitelist remove for brigged account`
+- `dry-run reports planned whitelist remove for below-threshold account`
+- `dry-run reports planned whitelist remove for parent-disabled account`
+- `dry-run reports lh syncuser with _crew suffix for crew staff member`
+- `dry-run reports lh syncuser with department for Officer staff member`
+- `dry-run sends no RCON commands and prints summary`
+- `live mode sends lh syncstart once before any per-account commands`
+- `live mode sends single lh syncuser command for eligible account`
+- `live mode sends whitelist remove for ineligible account`
+- `live mode records failures in summary when RCON returns error`
+- `mixed eligible and ineligible accounts processed correctly in dry-run`
+- `mixed live run sends lh syncstart then correct commands per account`
+- `bedrock account uses lh syncuser with -bedrock suffix in dry-run`
+
+**MixedAccountScenariosTest.php:**
+- `repair command repairs all active accounts when a user has multiple`
+- `repair command removes all whitelist entries when a brigged user has multiple accounts`
+- `repair command syncs staff on all accounts when a staff member has multiple accounts`
+- `repair command handles a user with both java and bedrock accounts`
+- `lifecycle sync and repair command both handle an eligible user via lh syncuser`
+- `lifecycle sync and repair command both remove a brigged user from the whitelist`
+- `lifecycle sync and repair command both remove a parent-disabled user from the whitelist`
+- `lifecycle sync and repair command both handle a staff user via lh syncuser`
+- `dry-run correctly reports all planned actions across multiple users and accounts`
+
+### Coverage Gaps
+
+- No test verifies that `lh syncstart` failure (non-Success response) is handled gracefully — the repair command proceeds with the loop regardless of syncstart result.
+- No test covers the ordering guarantee between `lh syncstart` and ineligible `whitelist remove` commands (e.g., does syncstart fire even when all accounts are ineligible?). In the current implementation it does, since syncstart is sent before any per-account logic.
+- No test covers `lh syncstart` with a non-null `pace` value to verify it counts as the "first command" and suppresses the initial sleep.
+
+---
+
+## 17. File Map
+
+**Models:**
+- `app/Models/User.php` — added `minecraftStaffPosition(): string`
+- `app/Models/MinecraftAccount.php` — added `syncUserCommand(string $rank, string $staffPosition): string`
+
+**Enums:**
+- `app/Enums/StaffRank.php` — used to determine officer vs. crew suffix
+- `app/Enums/StaffDepartment.php` — provides department string values for staff position
+- `app/Enums/MinecraftAccountType.php` — used in `syncUserCommand()` to detect Bedrock
+
+**Actions:**
+- `app/Actions/SyncMinecraftAccount.php` — updated to use `lh syncuser`
+
+**Callers of SyncMinecraftAccount (unchanged):**
+- `app/Actions/SyncMinecraftPermissions.php`
+- `app/Actions/ReactivateMinecraftAccount.php`
+- `app/Actions/UpdateChildPermission.php`
+- `app/Actions/ReleaseUserFromBrig.php`
+- `app/Actions/CompleteVerification.php`
+
+**Policies:** Not applicable for this feature.
+
+**Gates:** Not applicable for this feature.
+
+**Notifications:** Not applicable for this feature.
+
+**Jobs:** Not applicable for this feature.
+
+**Services:**
+- `app/Services/MinecraftRconService.php` — unchanged; accepts `null` target/user for syncstart
+
+**Controllers:** Not applicable for this feature.
+
+**Volt Components:** Not applicable for this feature.
+
+**Routes:** Not applicable for this feature.
+
+**Migrations:** None introduced by this feature.
+
+**Console Commands:**
+- `app/Console/Commands/RepairMinecraftPermissions.php` — updated with `lh syncstart` + `lh syncuser`
+
+**Tests:**
+- `tests/Feature/Minecraft/SyncUserCommandTest.php`
+- `tests/Feature/Minecraft/SyncMinecraftAccountTest.php`
+- `tests/Feature/Minecraft/MinecraftLifecycleSyncTest.php`
+- `tests/Feature/Minecraft/RepairMinecraftPermissionsTest.php`
+- `tests/Feature/Minecraft/MixedAccountScenariosTest.php`
+- `tests/Feature/Minecraft/CompleteVerificationTest.php` (one test updated)
+
+**Config:** No new config keys. Uses existing `services.minecraft.*` RCON configuration.
+
+---
+
+## 18. Known Issues & Improvement Opportunities
+
+1. **`lh syncstart` is always sent even when all accounts are ineligible.** If every active account is brigged or below threshold, the repair command will still send `lh syncstart` (clearing the whitelist) but then only send `whitelist remove` commands — redundant since the whitelist was already cleared. This is harmless but slightly wasteful.
+
+2. **`lh syncstart` failure is silently ignored.** The repair command calls `rcon->executeCommand('lh syncstart', ...)` but does not check the return value. If syncstart fails (e.g., backup filesystem full), the command proceeds to process accounts as if the whitelist was cleared. A warning line should be emitted if syncstart returns `success: false`.
+
+3. **Activity log `department` field stores the Minecraft group name, not the human label.** For an Engineer Officer, `minecraft_staff_position_set` logs `"Set Minecraft staff position to engineer for Steve"`. For an Engineer Crew Member, it logs `"engineer_crew"`. The ACP activity log will show the raw Minecraft group string rather than a friendly label. This is a cosmetic issue.
+
+4. **`RepairMinecraftPermissions` does not call `SyncMinecraftAccount`.** It sends RCON commands directly, which means it bypasses `SyncMinecraftAccount`'s activity logging. The repair command does not log `minecraft_rank_synced`, `minecraft_staff_position_set`, or `minecraft_staff_position_removed` entries. Only lifecycle syncs log these activities.
+
+5. **No retry or error recovery for `lh syncuser` failures during bulk repair.** If a `lh syncuser` call fails mid-repair, the account is counted as a failure in the summary but the repair command does not retry or skip to a fallback. A future improvement could retry failed accounts with individual old-style commands as fallback.
+
+6. **`minecraftStaffPosition()` assumes `staff_rank` is always set when `staff_department` is set.** If a user has a `staff_department` but no `staff_rank` (e.g., `staff_rank = null`), `isAtLeastRank(StaffRank::Officer)` evaluates `(null ?? 0) >= 3` → `false`, so they get the `_crew` suffix. This is a sensible default but should be verified as intentional behavior for edge cases.

--- a/resources/library/books/staff-handbook/05-minecraft/02-server-operations/01-rank-and-staff-syncing.md
+++ b/resources/library/books/staff-handbook/05-minecraft/02-server-operations/01-rank-and-staff-syncing.md
@@ -27,13 +27,22 @@ When a staff member is assigned to or removed from a position, the system syncs 
 
 This lets the Minecraft server display staff designations and grant any department-specific in-game permissions.
 
+## Staff Rank Differentiation
+
+Staff in-game groups are assigned based on both department and rank:
+
+- **Officers** receive their department name directly (e.g., `engineer`)
+- **Crew Members and Jr Crew** receive their department name with a `_crew` suffix (e.g., `engineer_crew`)
+
+This distinction exists on the Minecraft server's permission system (LuckPerms) to allow different capability levels between senior and junior staff within the same department.
+
 ## RCON Commands
 
 The website communicates with the Minecraft server using **RCON** (Remote Console). Commands are dispatched as background jobs so they don't block the website. Key commands include:
 
-- Whitelist add/remove (for account linking and brig actions)
-- Rank set (for membership level changes)
-- Staff set/remove (for staff position changes)
+- **`lh syncuser <username> <rank> <staffPosition>`** -- single unified command that whitelists a player, sets their member rank, and applies their staff group in one call
+- **Whitelist remove** -- for ineligible accounts (Brig, parent-disabled, below Traveler)
+- **`lh syncstart`** -- run once before a bulk repair to back up and clear the whitelist
 - Verification code processing (for the linking flow)
 
 ## The Command Log

--- a/resources/library/books/staff-handbook/05-minecraft/02-server-operations/02-repairing-permissions.md
+++ b/resources/library/books/staff-handbook/05-minecraft/02-server-operations/02-repairing-permissions.md
@@ -49,7 +49,7 @@ This adds a 2-second pause between outbound commands. You can set `--pace` to an
 
 ## What the Command Repairs
 
-Before touching any individual accounts, the command sends **`lh syncstart`** to the server. This backs up the current whitelist to a timestamped file and clears it completely, so every account gets a fresh resync with no stale entries.
+In a **live run** (non-dry-run), before touching any individual accounts, the command sends **`lh syncstart`** to the server. This backs up the current whitelist to a timestamped file and clears it completely, so every account gets a fresh resync with no stale entries.
 
 Then, for each active Minecraft account, the command evaluates eligibility using the member's current website state:
 

--- a/resources/library/books/staff-handbook/05-minecraft/02-server-operations/02-repairing-permissions.md
+++ b/resources/library/books/staff-handbook/05-minecraft/02-server-operations/02-repairing-permissions.md
@@ -49,10 +49,14 @@ This adds a 2-second pause between outbound commands. You can set `--pace` to an
 
 ## What the Command Repairs
 
-For each active Minecraft account, the command evaluates eligibility using the member's current website state:
+Before touching any individual accounts, the command sends **`lh syncstart`** to the server. This backs up the current whitelist to a timestamped file and clears it completely, so every account gets a fresh resync with no stale entries.
 
-- **Eligible** (Traveler or higher, not in the Brig, parent permissions allow Minecraft): adds the account to the whitelist, sets the in-game rank to match the membership level, and applies or removes the staff department group depending on whether the member holds a staff position
+Then, for each active Minecraft account, the command evaluates eligibility using the member's current website state:
+
+- **Eligible** (Traveler or higher, not in the Brig, parent permissions allow Minecraft): sends a single `lh syncuser` command that whitelists the account, sets the in-game rank, and applies the correct staff group all at once
 - **Ineligible** (Drifter/Stowaway, in the Brig, or parent has disabled Minecraft): removes the account from the whitelist
+
+For staff members, the applied in-game group depends on their rank: Officers get their department name (e.g., `engineer`), while Crew Members and Jr Crew get the department name with `_crew` appended (e.g., `engineer_crew`). Non-staff accounts receive `none` as the staff position.
 
 Accounts in `verifying`, `banned`, `cancelled`, `removed`, or `parent_disabled` status are skipped -- the command only processes accounts with `active` status.
 
@@ -65,6 +69,6 @@ See [[books/staff-handbook/minecraft/server-operations/rank-and-staff-syncing|Ra
 ## Important Notes
 
 - The repair command does **not** write to the Activity Log. Results are only visible in the MC Command Log.
-- Running the command multiple times is safe -- it's idempotent. Sending a `whitelist add` for someone who's already whitelisted doesn't break anything.
+- Running the command multiple times is safe. Each run starts with `lh syncstart` to clear and back up the whitelist, then re-adds every eligible account from scratch.
 - If the Minecraft server is offline when you run the command, every RCON command will fail. Wait until the server is back up and run it again.
 - The `--dry-run` flag never sends RCON commands, even if the server is online. It's always safe to use for inspection.

--- a/resources/library/books/user-handbook/02-minecraft/01-accounts/03-ranks-and-permissions.md
+++ b/resources/library/books/user-handbook/02-minecraft/01-accounts/03-ranks-and-permissions.md
@@ -19,7 +19,14 @@ Drifters and Stowaways don't have server access yet -- you'll need to be promote
 
 ## Staff Ranks
 
-If you're a staff member, your staff position is also reflected in-game. This helps other players know who to turn to for help and provides the permissions needed for staff duties.
+If you're a staff member, your staff position is reflected in-game alongside your membership rank. This helps other players know who to turn to for help and gives you the permissions needed for staff duties.
+
+Staff in-game ranks are based on both your **department** and your **staff rank**:
+
+- **Officers** and above show their department name in-game (for example, an Officer in the Engineering department appears as `engineer`).
+- **Crew Members** and Jr Crew Members show their department with a `_crew` suffix (for example, a Crew Member in Engineering appears as `engineer_crew`).
+
+Your in-game staff rank updates automatically when your staff position changes -- you don't need to do anything.
 
 ## Promotions
 

--- a/tests/Feature/Minecraft/CompleteVerificationTest.php
+++ b/tests/Feature/Minecraft/CompleteVerificationTest.php
@@ -409,16 +409,9 @@ test('syncs rank and staff position synchronously when staff member verifies acc
 
     $rconMock = $this->mock(\App\Services\MinecraftRconService::class);
     $rconMock->shouldReceive('executeCommand')
-        ->with(Mockery::pattern('/^whitelist/'), Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
-        ->andReturn(['success' => true, 'response' => 'Added to whitelist', 'error' => null]);
-    $rconMock->shouldReceive('executeCommand')
-        ->with(Mockery::pattern('/^lh setmember StaffPlayer/'), 'rank', 'StaffPlayer', Mockery::any(), Mockery::any())
+        ->with('lh syncuser StaffPlayer traveler command', 'sync', 'StaffPlayer', Mockery::any(), Mockery::any())
         ->once()
-        ->andReturn(['success' => true, 'response' => 'Success: rank set', 'error' => null]);
-    $rconMock->shouldReceive('executeCommand')
-        ->with('lh setstaff StaffPlayer command', 'staff', 'StaffPlayer', Mockery::any(), Mockery::any())
-        ->once()
-        ->andReturn(['success' => true, 'response' => 'Success: staff set', 'error' => null]);
+        ->andReturn(['success' => true, 'response' => 'Success: Synced StaffPlayer', 'error' => null]);
 
     $action = new CompleteVerification;
     $result = $action->handle('ABC123', 'StaffPlayer', '169a79f4-44e9-4726-a5be-fca90e38aaf5');

--- a/tests/Feature/Minecraft/MinecraftLifecycleSyncTest.php
+++ b/tests/Feature/Minecraft/MinecraftLifecycleSyncTest.php
@@ -12,6 +12,7 @@ use App\Enums\BrigType;
 use App\Enums\MembershipLevel;
 use App\Enums\MinecraftAccountStatus;
 use App\Enums\StaffDepartment;
+use App\Enums\StaffRank;
 use App\Models\MinecraftAccount;
 use App\Models\User;
 use App\Services\MinecraftRconService;
@@ -25,20 +26,20 @@ beforeEach(function () {
 
 // ─── SyncMinecraftPermissions ─────────────────────────────────────────────────
 
-test('SyncMinecraftPermissions sends whitelist add and rank for each active account', function () {
+test('SyncMinecraftPermissions sends lh syncuser for each active account', function () {
     $user = User::factory()->create(['membership_level' => MembershipLevel::Traveler]);
     MinecraftAccount::factory()->for($user)->active()->create(['username' => 'Player1']);
     MinecraftAccount::factory()->for($user)->active()->create(['username' => 'Player2']);
 
     $this->rconMock->shouldReceive('executeCommand')
-        ->with(Mockery::pattern('/^whitelist add/'), Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
-        ->twice()
-        ->andReturn(['success' => true, 'response' => 'Added', 'error' => null]);
+        ->with(Mockery::pattern('/^lh syncuser Player1 /'), Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
+        ->once()
+        ->andReturn(['success' => true, 'response' => 'Success: Synced Player1', 'error' => null]);
 
     $this->rconMock->shouldReceive('executeCommand')
-        ->with(Mockery::pattern('/^lh setmember/'), Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
-        ->twice()
-        ->andReturn(['success' => true, 'response' => 'Success: rank set', 'error' => null]);
+        ->with(Mockery::pattern('/^lh syncuser Player2 /'), Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
+        ->once()
+        ->andReturn(['success' => true, 'response' => 'Success: Synced Player2', 'error' => null]);
 
     SyncMinecraftPermissions::run($user);
 });
@@ -59,16 +60,11 @@ test('PromoteUser syncs Minecraft permissions through unified path', function ()
     $user = User::factory()->create(['membership_level' => MembershipLevel::Stowaway]);
     MinecraftAccount::factory()->for($user)->active()->create(['username' => 'PromoPlayer']);
 
-    // After promotion to Traveler the account is eligible — expect whitelist add + rank
+    // After promotion to Traveler the account is eligible — expect lh syncuser
     $this->rconMock->shouldReceive('executeCommand')
-        ->with('whitelist add PromoPlayer', Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
+        ->with('lh syncuser PromoPlayer traveler none', Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
         ->once()
-        ->andReturn(['success' => true, 'response' => 'Added', 'error' => null]);
-
-    $this->rconMock->shouldReceive('executeCommand')
-        ->with('lh setmember PromoPlayer traveler', Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
-        ->once()
-        ->andReturn(['success' => true, 'response' => 'Success: rank set', 'error' => null]);
+        ->andReturn(['success' => true, 'response' => 'Success: Synced PromoPlayer', 'error' => null]);
 
     PromoteUser::run($user);
 
@@ -81,9 +77,9 @@ test('DemoteUser syncs Minecraft permissions through unified path', function () 
 
     // After demotion to Traveler the account is still eligible
     $this->rconMock->shouldReceive('executeCommand')
-        ->with('lh setmember DemotePlayer traveler', Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
+        ->with('lh syncuser DemotePlayer traveler none', Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
         ->once()
-        ->andReturn(['success' => true, 'response' => 'Success: rank set', 'error' => null]);
+        ->andReturn(['success' => true, 'response' => 'Success: Synced DemotePlayer', 'error' => null]);
 
     DemoteUser::run($user);
 
@@ -97,14 +93,9 @@ test('reactivation uses unified sync to restore whitelist and rank', function ()
     $account = MinecraftAccount::factory()->for($user)->removed()->create(['username' => 'ReactPlayer']);
 
     $this->rconMock->shouldReceive('executeCommand')
-        ->with('whitelist add ReactPlayer', 'whitelist', 'ReactPlayer', Mockery::any(), Mockery::any())
+        ->with('lh syncuser ReactPlayer traveler none', 'sync', 'ReactPlayer', Mockery::any(), Mockery::any())
         ->once()
-        ->andReturn(['success' => true, 'response' => 'Added ReactPlayer to the whitelist', 'error' => null]);
-
-    $this->rconMock->shouldReceive('executeCommand')
-        ->with('lh setmember ReactPlayer traveler', 'rank', 'ReactPlayer', Mockery::any(), Mockery::any())
-        ->once()
-        ->andReturn(['success' => true, 'response' => 'Success: rank set', 'error' => null]);
+        ->andReturn(['success' => true, 'response' => 'Success: Synced ReactPlayer', 'error' => null]);
 
     $result = ReactivateMinecraftAccount::run($account, $user);
 
@@ -112,12 +103,12 @@ test('reactivation uses unified sync to restore whitelist and rank', function ()
         ->and($account->fresh()->status)->toBe(MinecraftAccountStatus::Active);
 });
 
-test('reactivation reverts account to Removed if whitelist add fails', function () {
+test('reactivation reverts account to Removed if sync fails', function () {
     $user = User::factory()->create(['membership_level' => MembershipLevel::Traveler]);
     $account = MinecraftAccount::factory()->for($user)->removed()->create(['username' => 'FailPlayer']);
 
     $this->rconMock->shouldReceive('executeCommand')
-        ->with('whitelist add FailPlayer', Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
+        ->with(Mockery::pattern('/^lh syncuser FailPlayer /'), Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
         ->andReturn(['success' => false, 'response' => null, 'error' => 'Server unreachable']);
 
     $result = ReactivateMinecraftAccount::run($account, $user);
@@ -147,14 +138,9 @@ test('brig release restores Minecraft access via unified sync when parent allows
     $user->save();
 
     $this->rconMock->shouldReceive('executeCommand')
-        ->with('whitelist add BrigPlayer', 'whitelist', 'BrigPlayer', Mockery::any(), Mockery::any())
+        ->with('lh syncuser BrigPlayer traveler none', 'sync', 'BrigPlayer', Mockery::any(), Mockery::any())
         ->once()
-        ->andReturn(['success' => true, 'response' => 'Added', 'error' => null]);
-
-    $this->rconMock->shouldReceive('executeCommand')
-        ->with('lh setmember BrigPlayer traveler', 'rank', 'BrigPlayer', Mockery::any(), Mockery::any())
-        ->once()
-        ->andReturn(['success' => true, 'response' => 'Success: rank set', 'error' => null]);
+        ->andReturn(['success' => true, 'response' => 'Success: Synced BrigPlayer', 'error' => null]);
 
     ReleaseUserFromBrig::run($user, $admin, 'Testing release', notify: false);
 
@@ -178,7 +164,7 @@ test('brig release sets account to ParentDisabled and skips sync when parent blo
     $user->brig_type = BrigType::Discipline;
     $user->save();
 
-    // No lh rank/whitelist-add commands when parent blocks MC
+    // No lh syncuser or whitelist-add when parent blocks MC
     $this->rconMock->shouldReceive('executeCommand')
         ->with(Mockery::pattern('/^lh |^whitelist add/'), Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
         ->never();
@@ -208,7 +194,7 @@ test('parent disabling MC triggers whitelist remove via unified sync', function 
     expect($account->fresh()->status)->toBe(MinecraftAccountStatus::ParentDisabled);
 });
 
-test('parent enabling MC triggers whitelist add and rank sync via unified sync', function () {
+test('parent enabling MC triggers lh syncuser via unified sync', function () {
     $parent = User::factory()->create();
     $child = User::factory()->create([
         'membership_level' => MembershipLevel::Traveler,
@@ -220,14 +206,9 @@ test('parent enabling MC triggers whitelist add and rank sync via unified sync',
     ]);
 
     $this->rconMock->shouldReceive('executeCommand')
-        ->with('whitelist add ReEnabledKid', 'whitelist', 'ReEnabledKid', Mockery::any(), Mockery::any())
+        ->with('lh syncuser ReEnabledKid traveler none', 'sync', 'ReEnabledKid', Mockery::any(), Mockery::any())
         ->once()
-        ->andReturn(['success' => true, 'response' => 'Added', 'error' => null]);
-
-    $this->rconMock->shouldReceive('executeCommand')
-        ->with('lh setmember ReEnabledKid traveler', 'rank', 'ReEnabledKid', Mockery::any(), Mockery::any())
-        ->once()
-        ->andReturn(['success' => true, 'response' => 'Success: rank set', 'error' => null]);
+        ->andReturn(['success' => true, 'response' => 'Success: Synced ReEnabledKid', 'error' => null]);
 
     UpdateChildPermission::run($child, $parent, 'minecraft', true);
 
@@ -235,11 +216,12 @@ test('parent enabling MC triggers whitelist add and rank sync via unified sync',
         ->and($account->fresh()->status)->toBe(MinecraftAccountStatus::Active);
 });
 
-test('parent enabling MC also syncs staff position when child is staff', function () {
+test('parent enabling MC syncs staff position for Officer child via lh syncuser', function () {
     $parent = User::factory()->create();
     $child = User::factory()->create([
         'membership_level' => MembershipLevel::Traveler,
         'parent_allows_minecraft' => false,
+        'staff_rank' => StaffRank::Officer,
         'staff_department' => StaffDepartment::Engineer,
     ]);
     $account = MinecraftAccount::factory()->for($child)->create([
@@ -248,9 +230,9 @@ test('parent enabling MC also syncs staff position when child is staff', functio
     ]);
 
     $this->rconMock->shouldReceive('executeCommand')
-        ->with('lh setstaff StaffKid engineer', 'staff', 'StaffKid', Mockery::any(), Mockery::any())
+        ->with('lh syncuser StaffKid traveler engineer', 'sync', 'StaffKid', Mockery::any(), Mockery::any())
         ->once()
-        ->andReturn(['success' => true, 'response' => 'Success: staff set', 'error' => null]);
+        ->andReturn(['success' => true, 'response' => 'Success: Synced StaffKid', 'error' => null]);
 
     UpdateChildPermission::run($child, $parent, 'minecraft', true);
 });

--- a/tests/Feature/Minecraft/MixedAccountScenariosTest.php
+++ b/tests/Feature/Minecraft/MixedAccountScenariosTest.php
@@ -126,24 +126,30 @@ test('repair command handles a user with both java and bedrock accounts', functi
 
 // ─── Consistency: lifecycle sync and repair agree ─────────────────────────────
 
-test('lifecycle sync and repair command send the same whitelist and rank commands for an eligible user', function () {
+test('lifecycle sync and repair command both handle an eligible user', function () {
     $user = User::factory()->create(['membership_level' => MembershipLevel::Traveler]);
     MinecraftAccount::factory()->for($user)->active()->create(['username' => 'ConsistElig']);
 
-    // Each RCON command fires once from SyncMinecraftPermissions, once from the repair command
+    // Lifecycle path uses lh syncuser (once from SyncMinecraftPermissions)
+    $this->rconMock->shouldReceive('executeCommand')
+        ->with('lh syncuser ConsistElig traveler none', Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
+        ->once()
+        ->andReturn(['success' => true, 'response' => 'Success: Synced ConsistElig', 'error' => null]);
+
+    // Repair command still uses old three-command sequence (updated in #368)
     $this->rconMock->shouldReceive('executeCommand')
         ->with('whitelist add ConsistElig', Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
-        ->twice()
+        ->once()
         ->andReturn(['success' => true, 'response' => 'Added', 'error' => null]);
 
     $this->rconMock->shouldReceive('executeCommand')
         ->with('lh setmember ConsistElig traveler', Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
-        ->twice()
+        ->once()
         ->andReturn(['success' => true, 'response' => 'Success: rank set', 'error' => null]);
 
     $this->rconMock->shouldReceive('executeCommand')
         ->with('lh removestaff ConsistElig', Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
-        ->twice()
+        ->once()
         ->andReturn(['success' => true, 'response' => 'Success: staff removed', 'error' => null]);
 
     SyncMinecraftPermissions::run($user);
@@ -182,16 +188,23 @@ test('lifecycle sync and repair command both remove a parent-disabled user from 
     $this->artisan('minecraft:repair-permissions', ['--pace' => '0'])->assertSuccessful();
 });
 
-test('lifecycle sync and repair command both set staff position for a staff user', function () {
+test('lifecycle sync and repair command both handle a staff user', function () {
     $user = User::factory()->create([
         'membership_level' => MembershipLevel::Traveler,
         'staff_department' => StaffDepartment::Engineer,
     ]);
     MinecraftAccount::factory()->for($user)->active()->create(['username' => 'StaffConsist']);
 
+    // Lifecycle path uses lh syncuser with _crew suffix (no staff_rank set → crew behavior)
+    $this->rconMock->shouldReceive('executeCommand')
+        ->with('lh syncuser StaffConsist traveler engineer_crew', Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
+        ->once()
+        ->andReturn(['success' => true, 'response' => 'Success: Synced StaffConsist', 'error' => null]);
+
+    // Repair command still uses old lh setstaff command (updated in #368)
     $this->rconMock->shouldReceive('executeCommand')
         ->with('lh setstaff StaffConsist engineer', Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
-        ->twice()
+        ->once()
         ->andReturn(['success' => true, 'response' => 'Success: staff set', 'error' => null]);
 
     SyncMinecraftPermissions::run($user);

--- a/tests/Feature/Minecraft/MixedAccountScenariosTest.php
+++ b/tests/Feature/Minecraft/MixedAccountScenariosTest.php
@@ -7,6 +7,7 @@ use App\Actions\SyncMinecraftPermissions;
 use App\Enums\MembershipLevel;
 use App\Enums\MinecraftAccountType;
 use App\Enums\StaffDepartment;
+use App\Enums\StaffRank;
 use App\Models\MinecraftAccount;
 use App\Models\User;
 use App\Services\MinecraftRconService;
@@ -75,6 +76,7 @@ test('repair command removes all whitelist entries when a brigged user has multi
 test('repair command syncs staff on all accounts when a staff member has multiple accounts', function () {
     $user = User::factory()->create([
         'membership_level' => MembershipLevel::Traveler,
+        'staff_rank' => StaffRank::CrewMember,
         'staff_department' => StaffDepartment::Engineer,
     ]);
     MinecraftAccount::factory()->for($user)->active()->create(['username' => 'StaffAcct1']);
@@ -186,6 +188,7 @@ test('lifecycle sync and repair command both remove a parent-disabled user from 
 test('lifecycle sync and repair command both handle a staff user via lh syncuser', function () {
     $user = User::factory()->create([
         'membership_level' => MembershipLevel::Traveler,
+        'staff_rank' => StaffRank::CrewMember,
         'staff_department' => StaffDepartment::Engineer,
     ]);
     MinecraftAccount::factory()->for($user)->active()->create(['username' => 'StaffConsist']);

--- a/tests/Feature/Minecraft/MixedAccountScenariosTest.php
+++ b/tests/Feature/Minecraft/MixedAccountScenariosTest.php
@@ -26,19 +26,19 @@ test('repair command repairs all active accounts when a user has multiple', func
     MinecraftAccount::factory()->for($user)->active()->create(['username' => 'MultiAcct2']);
 
     $this->rconMock->shouldReceive('executeCommand')
-        ->with('whitelist add MultiAcct1', Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
+        ->with('lh syncstart', 'sync', null, null, Mockery::any())
         ->once()
-        ->andReturn(['success' => true, 'response' => 'Added', 'error' => null]);
+        ->andReturn(['success' => true, 'response' => 'Success: Backed up and cleared', 'error' => null]);
 
     $this->rconMock->shouldReceive('executeCommand')
-        ->with('whitelist add MultiAcct2', Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
+        ->with('lh syncuser MultiAcct1 traveler none', Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
         ->once()
-        ->andReturn(['success' => true, 'response' => 'Added', 'error' => null]);
+        ->andReturn(['success' => true, 'response' => 'Success: Synced MultiAcct1', 'error' => null]);
 
     $this->rconMock->shouldReceive('executeCommand')
-        ->with(Mockery::pattern('/^lh /'), Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
-        ->times(4) // 2 accounts × (setmember + removestaff)
-        ->andReturn(['success' => true, 'response' => 'Success: done', 'error' => null]);
+        ->with('lh syncuser MultiAcct2 traveler none', Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
+        ->once()
+        ->andReturn(['success' => true, 'response' => 'Success: Synced MultiAcct2', 'error' => null]);
 
     $this->artisan('minecraft:repair-permissions', ['--pace' => '0'])
         ->assertSuccessful()
@@ -72,7 +72,7 @@ test('repair command removes all whitelist entries when a brigged user has multi
         ->expectsOutputToContain('Failures:          0');
 });
 
-test('repair command sets staff on all accounts when a staff member has multiple accounts', function () {
+test('repair command syncs staff on all accounts when a staff member has multiple accounts', function () {
     $user = User::factory()->create([
         'membership_level' => MembershipLevel::Traveler,
         'staff_department' => StaffDepartment::Engineer,
@@ -81,14 +81,20 @@ test('repair command sets staff on all accounts when a staff member has multiple
     MinecraftAccount::factory()->for($user)->active()->create(['username' => 'StaffAcct2']);
 
     $this->rconMock->shouldReceive('executeCommand')
-        ->with('lh setstaff StaffAcct1 engineer', Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
+        ->with('lh syncstart', Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
         ->once()
-        ->andReturn(['success' => true, 'response' => 'Success: staff set', 'error' => null]);
+        ->andReturn(['success' => true, 'response' => 'Success: Backed up and cleared', 'error' => null]);
+
+    // No staff_rank set → crew behavior → engineer_crew
+    $this->rconMock->shouldReceive('executeCommand')
+        ->with('lh syncuser StaffAcct1 traveler engineer_crew', Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
+        ->once()
+        ->andReturn(['success' => true, 'response' => 'Success: Synced StaffAcct1', 'error' => null]);
 
     $this->rconMock->shouldReceive('executeCommand')
-        ->with('lh setstaff StaffAcct2 engineer', Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
+        ->with('lh syncuser StaffAcct2 traveler engineer_crew', Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
         ->once()
-        ->andReturn(['success' => true, 'response' => 'Success: staff set', 'error' => null]);
+        ->andReturn(['success' => true, 'response' => 'Success: Synced StaffAcct2', 'error' => null]);
 
     $this->artisan('minecraft:repair-permissions', ['--pace' => '0'])
         ->assertSuccessful()
@@ -109,14 +115,19 @@ test('repair command handles a user with both java and bedrock accounts', functi
     ]);
 
     $this->rconMock->shouldReceive('executeCommand')
-        ->with('whitelist add JavaUser', Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
+        ->with('lh syncstart', Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
         ->once()
-        ->andReturn(['success' => true, 'response' => 'Added', 'error' => null]);
+        ->andReturn(['success' => true, 'response' => 'Success: Backed up and cleared', 'error' => null]);
 
     $this->rconMock->shouldReceive('executeCommand')
-        ->with('fwhitelist add bedrock-uuid-abcd', Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
+        ->with('lh syncuser JavaUser traveler none', Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
         ->once()
-        ->andReturn(['success' => true, 'response' => 'Added', 'error' => null]);
+        ->andReturn(['success' => true, 'response' => 'Success: Synced JavaUser', 'error' => null]);
+
+    $this->rconMock->shouldReceive('executeCommand')
+        ->with('lh syncuser BedrockUser traveler none -bedrock bedrock-uuid-abcd', Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
+        ->once()
+        ->andReturn(['success' => true, 'response' => 'Success: Synced BedrockUser', 'error' => null]);
 
     $this->artisan('minecraft:repair-permissions', ['--pace' => '0'])
         ->assertSuccessful()
@@ -126,31 +137,15 @@ test('repair command handles a user with both java and bedrock accounts', functi
 
 // ─── Consistency: lifecycle sync and repair agree ─────────────────────────────
 
-test('lifecycle sync and repair command both handle an eligible user', function () {
+test('lifecycle sync and repair command both handle an eligible user via lh syncuser', function () {
     $user = User::factory()->create(['membership_level' => MembershipLevel::Traveler]);
     MinecraftAccount::factory()->for($user)->active()->create(['username' => 'ConsistElig']);
 
-    // Lifecycle path uses lh syncuser (once from SyncMinecraftPermissions)
+    // Both paths now use lh syncuser — called twice total
     $this->rconMock->shouldReceive('executeCommand')
         ->with('lh syncuser ConsistElig traveler none', Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
-        ->once()
+        ->twice()
         ->andReturn(['success' => true, 'response' => 'Success: Synced ConsistElig', 'error' => null]);
-
-    // Repair command still uses old three-command sequence (updated in #368)
-    $this->rconMock->shouldReceive('executeCommand')
-        ->with('whitelist add ConsistElig', Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
-        ->once()
-        ->andReturn(['success' => true, 'response' => 'Added', 'error' => null]);
-
-    $this->rconMock->shouldReceive('executeCommand')
-        ->with('lh setmember ConsistElig traveler', Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
-        ->once()
-        ->andReturn(['success' => true, 'response' => 'Success: rank set', 'error' => null]);
-
-    $this->rconMock->shouldReceive('executeCommand')
-        ->with('lh removestaff ConsistElig', Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
-        ->once()
-        ->andReturn(['success' => true, 'response' => 'Success: staff removed', 'error' => null]);
 
     SyncMinecraftPermissions::run($user);
     $this->artisan('minecraft:repair-permissions', ['--pace' => '0'])->assertSuccessful();
@@ -188,24 +183,18 @@ test('lifecycle sync and repair command both remove a parent-disabled user from 
     $this->artisan('minecraft:repair-permissions', ['--pace' => '0'])->assertSuccessful();
 });
 
-test('lifecycle sync and repair command both handle a staff user', function () {
+test('lifecycle sync and repair command both handle a staff user via lh syncuser', function () {
     $user = User::factory()->create([
         'membership_level' => MembershipLevel::Traveler,
         'staff_department' => StaffDepartment::Engineer,
     ]);
     MinecraftAccount::factory()->for($user)->active()->create(['username' => 'StaffConsist']);
 
-    // Lifecycle path uses lh syncuser with _crew suffix (no staff_rank set → crew behavior)
+    // Both paths use lh syncuser with _crew suffix (no staff_rank → crew)
     $this->rconMock->shouldReceive('executeCommand')
         ->with('lh syncuser StaffConsist traveler engineer_crew', Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
-        ->once()
+        ->twice()
         ->andReturn(['success' => true, 'response' => 'Success: Synced StaffConsist', 'error' => null]);
-
-    // Repair command still uses old lh setstaff command (updated in #368)
-    $this->rconMock->shouldReceive('executeCommand')
-        ->with('lh setstaff StaffConsist engineer', Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
-        ->once()
-        ->andReturn(['success' => true, 'response' => 'Success: staff set', 'error' => null]);
 
     SyncMinecraftPermissions::run($user);
     $this->artisan('minecraft:repair-permissions', ['--pace' => '0'])->assertSuccessful();
@@ -226,8 +215,8 @@ test('dry-run correctly reports all planned actions across multiple users and ac
 
     $this->artisan('minecraft:repair-permissions', ['--dry-run' => true])
         ->assertSuccessful()
-        ->expectsOutputToContain('[dry-run] whitelist add DryElig1')
-        ->expectsOutputToContain('[dry-run] whitelist add DryElig2')
+        ->expectsOutputToContain('[dry-run] lh syncuser DryElig1 traveler none')
+        ->expectsOutputToContain('[dry-run] lh syncuser DryElig2 traveler none')
         ->expectsOutputToContain('[dry-run] whitelist remove DryBrig1')
         ->expectsOutputToContain('[dry-run] whitelist remove DryBrig2')
         ->expectsOutputToContain('[dry-run] Whitelist adds:    2')

--- a/tests/Feature/Minecraft/MixedAccountScenariosTest.php
+++ b/tests/Feature/Minecraft/MixedAccountScenariosTest.php
@@ -87,7 +87,7 @@ test('repair command syncs staff on all accounts when a staff member has multipl
         ->once()
         ->andReturn(['success' => true, 'response' => 'Success: Backed up and cleared', 'error' => null]);
 
-    // No staff_rank set → crew behavior → engineer_crew
+    // CrewMember rank is below Officer → engineer_crew suffix
     $this->rconMock->shouldReceive('executeCommand')
         ->with('lh syncuser StaffAcct1 traveler engineer_crew', Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
         ->once()
@@ -193,7 +193,7 @@ test('lifecycle sync and repair command both handle a staff user via lh syncuser
     ]);
     MinecraftAccount::factory()->for($user)->active()->create(['username' => 'StaffConsist']);
 
-    // Both paths use lh syncuser with _crew suffix (no staff_rank → crew)
+    // Both paths use lh syncuser with _crew suffix (CrewMember < Officer)
     $this->rconMock->shouldReceive('executeCommand')
         ->with('lh syncuser StaffConsist traveler engineer_crew', Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
         ->twice()

--- a/tests/Feature/Minecraft/RepairMinecraftPermissionsTest.php
+++ b/tests/Feature/Minecraft/RepairMinecraftPermissionsTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 use App\Enums\MembershipLevel;
 use App\Enums\MinecraftAccountType;
 use App\Enums\StaffDepartment;
+use App\Enums\StaffRank;
 use App\Models\MinecraftAccount;
 use App\Models\User;
 use App\Services\MinecraftRconService;
@@ -26,7 +27,7 @@ test('exits successfully with message when no active accounts exist', function (
 
 // ─── Dry-run behavior ────────────────────────────────────────────────────────
 
-test('dry-run reports planned whitelist add and rank for eligible account', function () {
+test('dry-run reports lh syncuser for eligible account', function () {
     $user = User::factory()->create(['membership_level' => MembershipLevel::Traveler]);
     MinecraftAccount::factory()->for($user)->active()->create(['username' => 'EligiblePlayer']);
 
@@ -34,9 +35,21 @@ test('dry-run reports planned whitelist add and rank for eligible account', func
 
     $this->artisan('minecraft:repair-permissions', ['--dry-run' => true])
         ->assertSuccessful()
-        ->expectsOutputToContain('[dry-run] whitelist add EligiblePlayer')
-        ->expectsOutputToContain('[dry-run] lh setmember EligiblePlayer traveler')
-        ->expectsOutputToContain('[dry-run] lh removestaff EligiblePlayer');
+        ->expectsOutputToContain('[dry-run] lh syncuser EligiblePlayer traveler none');
+});
+
+test('dry-run does not send lh syncstart', function () {
+    $user = User::factory()->create(['membership_level' => MembershipLevel::Traveler]);
+    MinecraftAccount::factory()->for($user)->active()->create(['username' => 'EligiblePlayer']);
+
+    $this->rconMock->shouldReceive('executeCommand')
+        ->with('lh syncstart', Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
+        ->never();
+
+    $this->rconMock->shouldReceive('executeCommand')->never();
+
+    $this->artisan('minecraft:repair-permissions', ['--dry-run' => true])
+        ->assertSuccessful();
 });
 
 test('dry-run reports planned whitelist remove for brigged account', function () {
@@ -77,16 +90,30 @@ test('dry-run reports planned whitelist remove for parent-disabled account', fun
         ->expectsOutputToContain('parent disabled');
 });
 
-test('dry-run reports setstaff command for staff members', function () {
+test('dry-run reports lh syncuser with _crew suffix for crew staff member', function () {
     $user = User::factory()->create([
         'membership_level' => MembershipLevel::Traveler,
+        'staff_rank' => StaffRank::CrewMember,
         'staff_department' => StaffDepartment::Engineer,
     ]);
     MinecraftAccount::factory()->for($user)->active()->create(['username' => 'StaffMember']);
 
     $this->artisan('minecraft:repair-permissions', ['--dry-run' => true])
         ->assertSuccessful()
-        ->expectsOutputToContain('[dry-run] lh setstaff StaffMember engineer');
+        ->expectsOutputToContain('[dry-run] lh syncuser StaffMember traveler engineer_crew');
+});
+
+test('dry-run reports lh syncuser with department for Officer staff member', function () {
+    $user = User::factory()->create([
+        'membership_level' => MembershipLevel::Traveler,
+        'staff_rank' => StaffRank::Officer,
+        'staff_department' => StaffDepartment::Engineer,
+    ]);
+    MinecraftAccount::factory()->for($user)->active()->create(['username' => 'OfficerMember']);
+
+    $this->artisan('minecraft:repair-permissions', ['--dry-run' => true])
+        ->assertSuccessful()
+        ->expectsOutputToContain('[dry-run] lh syncuser OfficerMember traveler engineer');
 });
 
 test('dry-run sends no RCON commands and prints summary', function () {
@@ -104,24 +131,48 @@ test('dry-run sends no RCON commands and prints summary', function () {
 
 // ─── Live execution ───────────────────────────────────────────────────────────
 
-test('live mode sends whitelist, rank, and staff RCON commands for eligible account', function () {
+test('live mode sends lh syncstart once before any per-account commands', function () {
+    $user = User::factory()->create(['membership_level' => MembershipLevel::Traveler]);
+    MinecraftAccount::factory()->for($user)->active()->create(['username' => 'SyncPlayer']);
+
+    $callOrder = [];
+
+    $this->rconMock->shouldReceive('executeCommand')
+        ->with('lh syncstart', 'sync', null, null, Mockery::any())
+        ->once()
+        ->andReturnUsing(function () use (&$callOrder) {
+            $callOrder[] = 'syncstart';
+
+            return ['success' => true, 'response' => 'Success: Backed up and cleared', 'error' => null];
+        });
+
+    $this->rconMock->shouldReceive('executeCommand')
+        ->with(Mockery::pattern('/^lh syncuser /'), Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
+        ->once()
+        ->andReturnUsing(function () use (&$callOrder) {
+            $callOrder[] = 'syncuser';
+
+            return ['success' => true, 'response' => 'Success: Synced SyncPlayer', 'error' => null];
+        });
+
+    $this->artisan('minecraft:repair-permissions', ['--pace' => '0'])->assertSuccessful();
+
+    expect($callOrder)->toBe(['syncstart', 'syncuser']);
+});
+
+test('live mode sends single lh syncuser command for eligible account', function () {
     $user = User::factory()->create(['membership_level' => MembershipLevel::Traveler]);
     MinecraftAccount::factory()->for($user)->active()->create(['username' => 'LivePlayer']);
 
     $this->rconMock->shouldReceive('executeCommand')
-        ->with('whitelist add LivePlayer', 'whitelist', 'LivePlayer', Mockery::any(), Mockery::any())
+        ->with('lh syncstart', 'sync', null, null, Mockery::any())
         ->once()
-        ->andReturn(['success' => true, 'response' => 'Added', 'error' => null]);
+        ->andReturn(['success' => true, 'response' => 'Success: Backed up and cleared', 'error' => null]);
 
     $this->rconMock->shouldReceive('executeCommand')
-        ->with('lh setmember LivePlayer traveler', 'rank', 'LivePlayer', Mockery::any(), Mockery::any())
+        ->with('lh syncuser LivePlayer traveler none', 'sync', 'LivePlayer', Mockery::any(), Mockery::any())
         ->once()
-        ->andReturn(['success' => true, 'response' => 'Success: rank set', 'error' => null]);
-
-    $this->rconMock->shouldReceive('executeCommand')
-        ->with('lh removestaff LivePlayer', 'staff', 'LivePlayer', Mockery::any(), Mockery::any())
-        ->once()
-        ->andReturn(['success' => true, 'response' => 'Success: staff removed', 'error' => null]);
+        ->andReturn(['success' => true, 'response' => 'Success: Synced LivePlayer', 'error' => null]);
 
     $this->artisan('minecraft:repair-permissions', ['--pace' => '0'])
         ->assertSuccessful()
@@ -137,6 +188,11 @@ test('live mode sends whitelist remove for ineligible account', function () {
         'in_brig' => true,
     ]);
     MinecraftAccount::factory()->for($user)->active()->create(['username' => 'BrigPlayer']);
+
+    $this->rconMock->shouldReceive('executeCommand')
+        ->with('lh syncstart', Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
+        ->once()
+        ->andReturn(['success' => true, 'response' => 'Success: Backed up and cleared', 'error' => null]);
 
     $this->rconMock->shouldReceive('executeCommand')
         ->with('whitelist remove BrigPlayer', 'whitelist', 'BrigPlayer', Mockery::any(), Mockery::any())
@@ -179,14 +235,14 @@ test('mixed eligible and ineligible accounts processed correctly in dry-run', fu
 
     $this->artisan('minecraft:repair-permissions', ['--dry-run' => true])
         ->assertSuccessful()
-        ->expectsOutputToContain('[dry-run] whitelist add EligPlayer')
+        ->expectsOutputToContain('[dry-run] lh syncuser EligPlayer traveler none')
         ->expectsOutputToContain('[dry-run] whitelist remove BrigPlayer2')
         ->expectsOutputToContain('[dry-run] whitelist remove DrifterPlayer')
         ->expectsOutputToContain('[dry-run] Whitelist adds:    1')
         ->expectsOutputToContain('[dry-run] Whitelist removes: 2');
 });
 
-test('mixed live run sends correct RCON commands with pace=0', function () {
+test('mixed live run sends lh syncstart then correct commands per account', function () {
     $eligible = User::factory()->create(['membership_level' => MembershipLevel::Traveler]);
     MinecraftAccount::factory()->for($eligible)->active()->create(['username' => 'EligPlayer2']);
 
@@ -194,14 +250,14 @@ test('mixed live run sends correct RCON commands with pace=0', function () {
     MinecraftAccount::factory()->for($ineligible)->active()->create(['username' => 'IneligPlayer']);
 
     $this->rconMock->shouldReceive('executeCommand')
-        ->with('whitelist add EligPlayer2', Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
+        ->with('lh syncstart', 'sync', null, null, Mockery::any())
         ->once()
-        ->andReturn(['success' => true, 'response' => 'Added', 'error' => null]);
+        ->andReturn(['success' => true, 'response' => 'Success: Backed up and cleared', 'error' => null]);
 
     $this->rconMock->shouldReceive('executeCommand')
-        ->with(Mockery::pattern('/^lh /'), Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
-        ->twice()
-        ->andReturn(['success' => true, 'response' => 'Success: done', 'error' => null]);
+        ->with('lh syncuser EligPlayer2 traveler none', Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
+        ->once()
+        ->andReturn(['success' => true, 'response' => 'Success: Synced EligPlayer2', 'error' => null]);
 
     $this->rconMock->shouldReceive('executeCommand')
         ->with('whitelist remove IneligPlayer', Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
@@ -217,7 +273,7 @@ test('mixed live run sends correct RCON commands with pace=0', function () {
 
 // ─── Bedrock account ─────────────────────────────────────────────────────────
 
-test('bedrock account uses fwhitelist command in dry-run', function () {
+test('bedrock account uses lh syncuser with -bedrock suffix in dry-run', function () {
     $user = User::factory()->create(['membership_level' => MembershipLevel::Traveler]);
     MinecraftAccount::factory()->for($user)->active()->create([
         'username' => 'BedrockGuy',
@@ -227,5 +283,5 @@ test('bedrock account uses fwhitelist command in dry-run', function () {
 
     $this->artisan('minecraft:repair-permissions', ['--dry-run' => true])
         ->assertSuccessful()
-        ->expectsOutputToContain('[dry-run] fwhitelist add');
+        ->expectsOutputToContain('[dry-run] lh syncuser BedrockGuy traveler none -bedrock bedrock-uuid-5678');
 });

--- a/tests/Feature/Minecraft/SyncMinecraftAccountTest.php
+++ b/tests/Feature/Minecraft/SyncMinecraftAccountTest.php
@@ -100,6 +100,7 @@ test('eligible user records rank sync and staff activity', function () {
 test('eligible staff user records staff position set activity', function () {
     $user = User::factory()->create([
         'membership_level' => MembershipLevel::Traveler,
+        'staff_rank' => StaffRank::CrewMember,
         'staff_department' => StaffDepartment::Chaplain,
     ]);
     $account = MinecraftAccount::factory()->for($user)->active()->create(['username' => 'Padre']);

--- a/tests/Feature/Minecraft/SyncMinecraftAccountTest.php
+++ b/tests/Feature/Minecraft/SyncMinecraftAccountTest.php
@@ -6,6 +6,7 @@ use App\Actions\SyncMinecraftAccount;
 use App\Enums\MembershipLevel;
 use App\Enums\MinecraftAccountType;
 use App\Enums\StaffDepartment;
+use App\Enums\StaffRank;
 use App\Models\MinecraftAccount;
 use App\Models\User;
 use App\Services\MinecraftRconService;
@@ -19,24 +20,14 @@ beforeEach(function () {
 
 // ─── Eligible user (Traveler+, not in brig, parent allows) ───────────────────
 
-test('eligible user receives whitelist add, rank set, and staff removed', function () {
+test('eligible user receives single lh syncuser command', function () {
     $user = User::factory()->create(['membership_level' => MembershipLevel::Traveler]);
     $account = MinecraftAccount::factory()->for($user)->active()->create(['username' => 'Steve']);
 
     $this->rconMock->shouldReceive('executeCommand')
-        ->with('whitelist add Steve', 'whitelist', 'Steve', Mockery::any(), Mockery::any())
+        ->with('lh syncuser Steve traveler none', 'sync', 'Steve', Mockery::any(), Mockery::any())
         ->once()
-        ->andReturn(['success' => true, 'response' => 'Added Steve to whitelist', 'error' => null]);
-
-    $this->rconMock->shouldReceive('executeCommand')
-        ->with('lh setmember Steve traveler', 'rank', 'Steve', Mockery::any(), Mockery::any())
-        ->once()
-        ->andReturn(['success' => true, 'response' => 'Success: rank set', 'error' => null]);
-
-    $this->rconMock->shouldReceive('executeCommand')
-        ->with('lh removestaff Steve', 'staff', 'Steve', Mockery::any(), Mockery::any())
-        ->once()
-        ->andReturn(['success' => true, 'response' => 'Success: staff removed', 'error' => null]);
+        ->andReturn(['success' => true, 'response' => 'Success: Synced Steve', 'error' => null]);
 
     $result = SyncMinecraftAccount::run($account);
 
@@ -47,23 +38,44 @@ test('eligible user receives whitelist add, rank set, and staff removed', functi
         ->and($result['staff']['action'])->toBe('remove');
 });
 
-test('eligible staff user receives setstaff command', function () {
+test('eligible staff Officer receives lh syncuser with department name (no _crew suffix)', function () {
     $user = User::factory()->create([
         'membership_level' => MembershipLevel::Traveler,
+        'staff_rank' => StaffRank::Officer,
         'staff_department' => StaffDepartment::Engineer,
     ]);
-    $account = MinecraftAccount::factory()->for($user)->active()->create(['username' => 'StaffPlayer']);
+    $account = MinecraftAccount::factory()->for($user)->active()->create(['username' => 'OfficerPlayer']);
 
     $this->rconMock->shouldReceive('executeCommand')
-        ->with('lh setstaff StaffPlayer engineer', 'staff', 'StaffPlayer', Mockery::any(), Mockery::any())
+        ->with('lh syncuser OfficerPlayer traveler engineer', 'sync', 'OfficerPlayer', Mockery::any(), Mockery::any())
         ->once()
-        ->andReturn(['success' => true, 'response' => 'Success: staff set', 'error' => null]);
+        ->andReturn(['success' => true, 'response' => 'Success: Synced OfficerPlayer', 'error' => null]);
 
     $result = SyncMinecraftAccount::run($account);
 
     expect($result['eligible'])->toBeTrue()
         ->and($result['staff']['action'])->toBe('set')
         ->and($result['staff']['department'])->toBe('engineer');
+});
+
+test('eligible staff Crew Member receives lh syncuser with _crew suffix', function () {
+    $user = User::factory()->create([
+        'membership_level' => MembershipLevel::Traveler,
+        'staff_rank' => StaffRank::CrewMember,
+        'staff_department' => StaffDepartment::Engineer,
+    ]);
+    $account = MinecraftAccount::factory()->for($user)->active()->create(['username' => 'CrewPlayer']);
+
+    $this->rconMock->shouldReceive('executeCommand')
+        ->with('lh syncuser CrewPlayer traveler engineer_crew', 'sync', 'CrewPlayer', Mockery::any(), Mockery::any())
+        ->once()
+        ->andReturn(['success' => true, 'response' => 'Success: Synced CrewPlayer', 'error' => null]);
+
+    $result = SyncMinecraftAccount::run($account);
+
+    expect($result['eligible'])->toBeTrue()
+        ->and($result['staff']['action'])->toBe('set')
+        ->and($result['staff']['department'])->toBe('engineer_crew');
 });
 
 test('eligible user records rank sync and staff activity', function () {
@@ -120,7 +132,7 @@ test('user below membership threshold receives whitelist remove', function () {
         ->and($result['staff'])->toBeNull();
 });
 
-test('ineligible user does not receive rank or staff commands', function () {
+test('ineligible user does not receive lh syncuser command', function () {
     $user = User::factory()->create(['membership_level' => MembershipLevel::Drifter]);
     $account = MinecraftAccount::factory()->for($user)->active()->create(['username' => 'Drifter1']);
 
@@ -173,7 +185,7 @@ test('parent-disabled user receives whitelist remove', function () {
 
 // ─── Bedrock account ─────────────────────────────────────────────────────────
 
-test('bedrock account uses fwhitelist add command', function () {
+test('bedrock account uses lh syncuser with -bedrock suffix', function () {
     $user = User::factory()->create(['membership_level' => MembershipLevel::Traveler]);
     $account = MinecraftAccount::factory()->for($user)->active()->create([
         'username' => 'BedrockPlayer',
@@ -182,9 +194,9 @@ test('bedrock account uses fwhitelist add command', function () {
     ]);
 
     $this->rconMock->shouldReceive('executeCommand')
-        ->with(Mockery::pattern('/^fwhitelist add /'), 'whitelist', 'BedrockPlayer', Mockery::any(), Mockery::any())
+        ->with(Mockery::pattern('/^lh syncuser BedrockPlayer traveler none -bedrock /'), 'sync', 'BedrockPlayer', Mockery::any(), Mockery::any())
         ->once()
-        ->andReturn(['success' => true, 'response' => 'Added', 'error' => null]);
+        ->andReturn(['success' => true, 'response' => 'Success: Synced BedrockPlayer', 'error' => null]);
 
     $result = SyncMinecraftAccount::run($account);
 

--- a/tests/Feature/Minecraft/SyncUserCommandTest.php
+++ b/tests/Feature/Minecraft/SyncUserCommandTest.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Enums\StaffDepartment;
+use App\Enums\StaffRank;
+use App\Models\MinecraftAccount;
+use App\Models\User;
+
+// ─── User::minecraftStaffPosition() ──────────────────────────────────────────
+
+test('minecraftStaffPosition returns none when user has no department', function () {
+    $user = User::factory()->create([
+        'staff_department' => null,
+        'staff_rank' => StaffRank::Officer,
+    ]);
+
+    expect($user->minecraftStaffPosition())->toBe('none');
+});
+
+test('minecraftStaffPosition returns department value for Officer', function () {
+    $user = User::factory()->create([
+        'staff_rank' => StaffRank::Officer,
+        'staff_department' => StaffDepartment::Engineer,
+    ]);
+
+    expect($user->minecraftStaffPosition())->toBe('engineer');
+});
+
+test('minecraftStaffPosition returns department_crew for Crew Member', function () {
+    $user = User::factory()->create([
+        'staff_rank' => StaffRank::CrewMember,
+        'staff_department' => StaffDepartment::Engineer,
+    ]);
+
+    expect($user->minecraftStaffPosition())->toBe('engineer_crew');
+});
+
+test('minecraftStaffPosition returns department_crew for Jr Crew', function () {
+    $user = User::factory()->create([
+        'staff_rank' => StaffRank::JrCrew,
+        'staff_department' => StaffDepartment::Engineer,
+    ]);
+
+    expect($user->minecraftStaffPosition())->toBe('engineer_crew');
+});
+
+// ─── MinecraftAccount::syncUserCommand() ─────────────────────────────────────
+
+test('syncUserCommand returns correct string for Java account', function () {
+    $account = MinecraftAccount::factory()->java()->create(['username' => 'TestPlayer']);
+
+    expect($account->syncUserCommand('traveler', 'engineer'))
+        ->toBe('lh syncuser TestPlayer traveler engineer');
+});
+
+test('syncUserCommand returns correct string with none staff position for Java account', function () {
+    $account = MinecraftAccount::factory()->java()->create(['username' => 'TestPlayer']);
+
+    expect($account->syncUserCommand('resident', 'none'))
+        ->toBe('lh syncuser TestPlayer resident none');
+});
+
+test('syncUserCommand returns correct string for Bedrock account with -bedrock suffix', function () {
+    $account = MinecraftAccount::factory()->bedrock()->create([
+        'username' => 'BedrockPlayer',
+        'uuid' => '00000000-0000-0000-0009-01f4c5fb33de',
+    ]);
+
+    expect($account->syncUserCommand('traveler', 'engineer_crew'))
+        ->toBe('lh syncuser BedrockPlayer traveler engineer_crew -bedrock 00000000-0000-0000-0009-01f4c5fb33de');
+});


### PR DESCRIPTION
## What Changed

This PR updates the website's Minecraft sync layer to use two new plugin commands and
corrects staff in-game rank assignments based on staff rank (Officer vs Crew Member).

- **`lh syncuser`**: A single command now handles whitelist add, member rank, and staff group assignment in one RCON call -- replacing the old three-command sequence. All sync paths (promotion, demotion, verification, brig release, parent permission toggle) use this unified command.
- **`lh syncstart`**: The bulk repair command now sends this once at the start of a live run to back up and clear the whitelist before re-adding everyone from scratch.
- **Staff rank differentiation**: Officers now receive their department name as their in-game group (e.g., `engineer`). Crew Members and Jr Crew receive the department name with a `_crew` suffix (e.g., `engineer_crew`).

## How to Test

### Staff rank differentiation

1. Assign a staff member as a Crew Member in the Engineering department
2. Trigger a promotion or brig release to force a sync
3. Check the MC Command Log -- the `lh syncuser` command should end in `engineer_crew`
4. Change their rank to Officer
5. Trigger another sync (e.g., a second promotion or run the repair command)
6. Verify the MC Command Log now shows `engineer` (no `_crew` suffix)

### Unified sync via `lh syncuser`

1. Promote a Traveler with an active Minecraft account to Resident
2. Check MC Command Log -- should show a single `lh syncuser <username> resident none` (or with staff group if they're staff)
3. Put a Traveler in the brig, then release them
4. Verify the release triggers `lh syncuser` (not three separate commands)

### Bulk repair with `lh syncstart`

1. SSH into the application server
2. Run: `php artisan minecraft:repair-permissions --dry-run`
3. Verify the dry-run output shows `[dry-run] lh syncuser ...` per eligible account -- no `lh syncstart` in dry-run
4. Run: `php artisan minecraft:repair-permissions --pace=1`
5. Check MC Command Log -- should show `lh syncstart` as the first entry, followed by `lh syncuser` entries for each eligible account
6. Verify the summary output counts: Whitelist adds, Rank changes, Staff changes, Failures

### Bedrock accounts

1. If any users have Bedrock accounts linked, their `lh syncuser` command in the log should end with `-bedrock <uuid>`

## Things to Watch For

- Staff members should see the correct in-game group based on their rank (Officer vs Crew)
- Non-staff members should see `none` as their staff position in the `lh syncuser` log entry
- Brigged users should still receive `whitelist remove` -- NOT `lh syncuser`
- After bulk repair, the whitelist backup file on the server should exist (from `lh syncstart`)

## Parent PRD

#365

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Permissions sync now uses a single per-account "sync" operation that whitelists, sets membership rank, and applies staff group; Bedrock accounts include an extra identifier. Live bulk repairs run a one-time prep sync before per-account syncs; dry-run shows planned per-account sync commands.

* **Documentation**
  * Updated server ops, repair procedures, and user guides to describe the unified sync flow and staff group mapping (Officers vs. _crew suffix).

* **Tests**
  * Tests updated to expect the unified per-account sync command and new syncstart behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->