### PR TITLE
fix: address test feedback for Guided Onboarding Wizard #371 (round 2)

### DIFF
--- a/resources/library/books/user-handbook/03-website/08-staff-team/01-staff-departments.md
+++ b/resources/library/books/user-handbook/03-website/08-staff-team/01-staff-departments.md
@@ -1,0 +1,33 @@
+---
+title: 'Staff Departments'
+visibility: public
+order: 1
+summary: 'An overview of the Lighthouse staff departments and what each one does.'
+---
+
+The Lighthouse staff team is organized into five departments. Each department covers a different area of community life. If you need help with something, this guide will point you to the right people.
+
+## Departments
+
+| Department | What They Do |
+|---|---|
+| **Command** | Overall leadership and strategic direction. Command oversees the other departments, manages the website, and makes decisions about the community's future. |
+| **Chaplain** | Spiritual leadership of the community. The Chaplain department runs Bible studies and prayer meetings and encourages Biblical discussions across the community. |
+| **Engineer** | Technical operations of the Minecraft server. Engineers look after the server infrastructure, manage plugins, and keep things running smoothly. |
+| **Quartermaster** | Member management — reviewing new users, processing promotions, and moderating community spaces. Quartermasters are the ones who approve Stowaway accounts. |
+| **Steward** | In-game community engagement through events, community builds, and keeping things active and welcoming on the server. |
+
+## Staff Ranks
+
+Within each department, staff members hold one of three ranks:
+
+- **Junior Crew Member** — New or younger staff members. They can handle tickets and access the Ready Room, but have limited profile visibility.
+- **Crew Member** — Established staff with full access to their department's responsibilities and the Admin Control Panel.
+- **Officer** — Department leaders with the highest level of access and responsibility.
+
+## Who to Contact
+
+- **Need help with your account or have a question?** Open a [Support Ticket](/tickets/create) — any staff member can help.
+- **Waiting for your account to be approved?** The Quartermaster department handles that. Approvals typically happen within a few hours.
+- **Technical issues with the Minecraft server?** The Engineer department manages server operations.
+- **Want to join the staff team?** Check out the [Staff Applications](/applications) page.

--- a/resources/library/books/user-handbook/03-website/08-staff-team/_index.md
+++ b/resources/library/books/user-handbook/03-website/08-staff-team/_index.md
@@ -1,0 +1,8 @@
+---
+title: 'The Staff Team'
+visibility: public
+order: 8
+summary: 'Who the Lighthouse staff are and how the team is organized.'
+---
+
+Meet the people who keep Lighthouse running.

--- a/resources/views/dashboard.blade.php
+++ b/resources/views/dashboard.blade.php
@@ -69,6 +69,22 @@
                                 @endif
                             </div>
                         </flux:card>
+                    @else
+                        <flux:card>
+                            <flux:heading size="sm">My Account</flux:heading>
+                            <flux:separator variant="subtle" class="my-3" />
+                            <div class="flex flex-col gap-2">
+                                <flux:button href="{{ route('settings.discord-account') }}" size="xs" variant="ghost" class="justify-start">
+                                    Discord Account
+                                </flux:button>
+                                <flux:button href="{{ route('settings.minecraft-accounts') }}" size="xs" variant="ghost" class="justify-start">
+                                    Minecraft Accounts
+                                </flux:button>
+                                <flux:button href="{{ route('settings.notifications') }}" size="xs" variant="ghost" class="justify-start">
+                                    Notification Preferences
+                                </flux:button>
+                            </div>
+                        </flux:card>
                     @endif
 
                     <flux:card>

--- a/resources/views/livewire/onboarding/wizard.blade.php
+++ b/resources/views/livewire/onboarding/wizard.blade.php
@@ -104,6 +104,7 @@ new class extends Component
                     </flux:text>
                     <flux:text variant="subtle" class="text-sm mb-4">
                         You'll be redirected to your account settings to complete the link.
+                        Once connected, <strong>return to the dashboard</strong> to continue your setup.
                     </flux:text>
 
                     <div class="flex items-center justify-between">
@@ -172,6 +173,7 @@ new class extends Component
                     </flux:text>
                     <flux:text variant="subtle" class="text-sm mb-4">
                         You'll be redirected to your account settings to complete the link.
+                        Once connected, <strong>return to the dashboard</strong> to continue your setup.
                     </flux:text>
 
                     <div class="flex items-center justify-between">

--- a/resources/views/livewire/onboarding/wizard.blade.php
+++ b/resources/views/livewire/onboarding/wizard.blade.php
@@ -130,7 +130,7 @@ new class extends Component
 
                 <flux:text class="mb-3">
                     A staff member will review your account and promote you to Traveler.
-                    This usually happens within a day or two — hang tight!
+                    This usually happens within a few hours — 24 hours at most. Hang tight!
                 </flux:text>
                 <flux:text variant="subtle" class="text-sm mb-4">
                     Once you're a Traveler you'll be able to link your Minecraft account and join

--- a/resources/views/livewire/settings/minecraft-accounts.blade.php
+++ b/resources/views/livewire/settings/minecraft-accounts.blade.php
@@ -554,44 +554,41 @@ new class extends Component {
             <flux:heading size="lg" class="mb-4">Active Verification Code</flux:heading>
 
             <div class="space-y-4">
+                @php
+                    $serverName = config('lighthouse.minecraft.server_name');
+                    $serverHost = config('lighthouse.minecraft.server_host');
+                    $serverPort = $accountType === 'bedrock'
+                        ? config('lighthouse.minecraft.server_port_bedrock')
+                        : config('lighthouse.minecraft.server_port_java');
+                @endphp
+
+                {{-- Step 1: Server connection info (shown prominently first) --}}
+                <div class="p-3 bg-blue-100 dark:bg-blue-900 rounded-lg border border-blue-300 dark:border-blue-700">
+                    <flux:text class="font-semibold text-sm mb-1">Step 1 — Join the server</flux:text>
+                    <flux:text class="text-sm font-medium">{{ $serverName }}</flux:text>
+                    <code class="block mt-1 px-2 py-1 bg-zinc-200 dark:bg-zinc-700 rounded text-sm">
+                        {{ $serverHost }}:{{ $serverPort }}
+                    </code>
+                </div>
+
+                {{-- Step 2: Verification code --}}
                 <div>
-                    <flux:text class="text-sm text-zinc-600 dark:text-zinc-400 mb-2">Your verification code:</flux:text>
+                    <flux:text class="font-semibold text-sm mb-1">Step 2 — Run this command in chat</flux:text>
                     <div class="font-mono text-3xl font-bold text-blue-600 dark:text-blue-400 tracking-wider">
-                        {{ $verificationCode }}
+                        /verify {{ $verificationCode }}
                     </div>
+                    <flux:text class="text-sm mt-2">
+                        @php
+                            $tz = auth()->user()->timezone ?? 'UTC';
+                            $expiresAtInTz = $expiresAt->copy()->setTimezone($tz);
+                        @endphp
+                        Code expires {{ $expiresAtInTz->diffForHumans() }} ({{ $expiresAtInTz->format('g:i A T') }})
+                    </flux:text>
                 </div>
 
-                <flux:text class="text-sm">
-                    @php
-                        $tz = auth()->user()->timezone ?? 'UTC';
-                        $expiresAtInTz = $expiresAt->copy()->setTimezone($tz);
-                    @endphp
-                    Expires {{ $expiresAtInTz->diffForHumans() }} ({{ $expiresAtInTz->format('g:i A T') }})
+                <flux:text class="text-sm text-zinc-600 dark:text-zinc-400">
+                    This page will update automatically once verification is complete.
                 </flux:text>
-
-                <flux:separator />
-
-                <div class="space-y-2">
-                    <flux:text class="font-semibold">Instructions:</flux:text>
-                    @php
-                        $serverName = config('lighthouse.minecraft.server_name');
-                        $serverHost = config('lighthouse.minecraft.server_host');
-                        $serverPort = $accountType === 'bedrock'
-                            ? config('lighthouse.minecraft.server_port_bedrock')
-                            : config('lighthouse.minecraft.server_port_java');
-                    @endphp
-                    <ol class="flex flex-col gap-1 list-decimal list-inside text-sm text-zinc-700 dark:text-zinc-300">
-                        <li>
-                            Join the Minecraft server: <strong>{{ $serverName }}</strong>
-                            <br>
-                            <code class="px-2 py-1 bg-zinc-200 dark:bg-zinc-700 rounded">
-                                {{ $serverHost }}:{{ $serverPort }}
-                            </code>
-                        </li>
-                        <li>Type in chat: <code class="px-2 py-1 bg-zinc-200 dark:bg-zinc-700 rounded">/verify {{ $verificationCode }}</code></li>
-                        <li>Wait for confirmation (this page will update automatically)</li>
-                    </ol>
-                </div>
 
                 <div class="flex justify-between items-center pt-2">
                     @if(app()->isLocal())


### PR DESCRIPTION
## What Changed

Fixes based on tester feedback for PRD #371 (Guided Onboarding Wizard).

## Issues Addressed

- #392: Updated the waitlist waiting step copy — changed "within a day or two" to "within a few hours — 24 hours at most" for more accurate expectations.
- #391: Added a return-to-dashboard reminder on the Discord and Minecraft wizard steps, so users know to come back after completing the link in settings.
- #390: Added a persistent "My Account" card on the dashboard for users who have finished setup (no accounts left to link) — shows quick links to Discord Account, Minecraft Accounts, and Notification Preferences settings.
- #389: Reordered the Minecraft verification UI so the server address/port appears as Step 1 (in a highlighted box), and the verification code command appears as Step 2. Previously the code was shown first, before users knew what server to join.
- #381: Added a Staff Departments page to the User Handbook (under "The Staff Team") explaining all five departments, their three ranks, and who to contact for common needs.

## How to Re-Test

### Waitlist step copy (#392)
1. Log in as a Stowaway user (one who hasn't been promoted to Traveler yet).
2. Go to the dashboard — the wizard should show the waiting/waitlist step.
3. The timing text should read "within a few hours — 24 hours at most" (not "within a day or two").

### Return-to-dashboard reminder (#391)
1. Log in as a new user who still needs to complete Discord or Minecraft setup.
2. On the Discord wizard step, confirm there is a note telling the user to return to the dashboard after completing the link.
3. On the Minecraft wizard step, confirm the same return-to-dashboard reminder is shown.

### My Account card on dashboard (#390)
1. Log in as a Traveler+ user who has already linked both Discord and Minecraft accounts.
2. Go to the dashboard (wizard should not be showing).
3. A "My Account" card should appear in the Community widget grid with links to Discord Account, Minecraft Accounts, and Notification Preferences.

### Minecraft verification step order (#389)
1. Log in as a Traveler user with no linked Minecraft account.
2. Go to Settings → Minecraft Accounts and start a verification.
3. When the verification code is active, the UI should show:
   - **Step 1** (highlighted box): the server address and port to connect to
   - **Step 2**: the `/lh verify <code>` command to run in chat

### Staff Departments handbook page (#381)
1. Go to Library → User Handbook.
2. Under "The Staff Team" section, a "Staff Departments" page should exist.
3. It should describe the 5 departments (Command, Chaplain, Engineer, Quartermaster, Steward), 3 staff ranks, and a "Who to Contact" guidance section.

## Things to Watch For

- The My Account card should only appear when the user has no accounts left to link — verify it does NOT appear when Discord or Minecraft are still unlinked (the "Complete Your Setup" card should show instead).
- The staff departments page is public visibility — verify it's accessible without being logged in.

## Parent PRD

#371

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added new staff departments documentation and team organizational structure guide.

* **New Features**
  * Dashboard now displays account management navigation card when setup is complete.

* **Improvements**
  * Redesigned Minecraft account verification with clearer two-step instructions.
  * Updated onboarding guidance to clarify dashboard navigation and revised waitlist timeframes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->