### PR TITLE
fix: address test feedback for PRD: Public Policy Manual

### DIFF
--- a/resources/views/livewire/meeting/department-report-cards.blade.php
+++ b/resources/views/livewire/meeting/department-report-cards.blade.php
@@ -68,15 +68,15 @@ new class extends Component {
                     wire:click="viewReport({{ $member->id }})"
                     class="w-72 flex items-center gap-2 p-2 rounded-lg border border-zinc-200 dark:border-zinc-700 hover:bg-zinc-100 dark:hover:bg-zinc-700 hover:shadow-sm transition-all cursor-pointer text-left"
                 >
-                    <flux:avatar size="xs" :src="$member->avatarUrl()" />
-                    <div class="min-w-0 flex-1">
-                        <p class="text-xs font-medium truncate">{{ $member->name }}</p>
-                    </div>
                     @if($hasSubmitted)
                         <flux:icon name="check-circle" variant="solid" class="w-4 h-4 text-green-500 shrink-0" />
                     @else
                         <flux:icon name="x-circle" variant="solid" class="w-4 h-4 text-red-400 shrink-0" />
                     @endif
+                    <flux:avatar size="xs" :src="$member->avatarUrl()" />
+                    <div class="min-w-0 flex-1">
+                        <p class="text-xs font-medium truncate">{{ $member->name }}</p>
+                    </div>
                 </button>
             @endforeach
         </div>


### PR DESCRIPTION
## What Changed

One UI tweak based on tester feedback for PRD #395 (Public Policy Manual).

## Issues Addressed

- **#411**: On the staff meeting page, the staff report status indicator (✓/✗ icon) was on the right side of each card, creating a large gap between the member's name and the status. Moved the indicator to the left side, just before the avatar, so the layout reads: `[Status icon] [Avatar] [Username]`. The status is now immediately visible without scanning across the card.

## How to Re-Test

### Staff Report Status Indicator Position (#411)
1. Log in as a staff member (any rank).
2. Navigate to an upcoming staff meeting page.
3. Scroll to the **Staff Report Status** section.
4. Verify each member card shows the status icon on the **left**, immediately before their avatar image.
5. Confirm the order reads: status icon → avatar → name (left to right).
6. Check both submitted (green ✓) and not-submitted (red ✗) cards.

## Things to Watch For

- Clicking a card should still open the staff report detail modal — verify that still works.
- Cards for staff who have submitted should show the green check icon on the left.
- Cards for staff who haven't submitted should show the red X icon on the left.

## Parent PRD

#395

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Reorganized the layout of staff member cards in department reports to improve visual hierarchy and information organization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->