### PR TITLE
content: add Membership & Access Policy to Community Standards

### DIFF
--- a/resources/library/books/policy-manual/01-community-standards/03-membership-and-access-policy/_index.md
+++ b/resources/library/books/policy-manual/01-community-standards/03-membership-and-access-policy/_index.md
@@ -1,0 +1,140 @@
+---
+title: 'Membership & Access Policy'
+visibility: public
+order: 3
+summary: 'The policies governing how members join and maintain their standing in the Lighthouse community.'
+---
+
+Lighthouse uses a structured membership system to ensure a safe, consistent, and well-managed community experience across all platforms (website, Discord, and Minecraft).
+
+This policy outlines how users gain access to the community, how membership levels work, and what is required to participate fully in Lighthouse.
+
+---
+
+## Purpose
+
+The membership system exists to:
+
+- Maintain a safe environment for all members, especially minors  
+- Ensure accountability across all platforms  
+- Provide a clear path for becoming a trusted member of the community  
+- Recognize members who contribute positively and consistently  
+
+Access to Lighthouse community spaces is not automatic and is granted based on this structured process.
+
+---
+
+## Website Account Requirement
+
+A Lighthouse website account is required for full participation in the community.
+
+Users must have an approved website account in order to:
+
+- Be promoted to **Traveler**  
+- Gain full access to the Discord server  
+- Be added to the Minecraft whitelist  
+
+This ensures that Lighthouse can manage identity, permissions, and safety consistently across all platforms.
+
+---
+
+## Membership Levels
+
+Lighthouse membership progresses through the following levels:
+
+### Stowaway
+
+**Stowaway** is a temporary onboarding stage for users who have agreed to the community Rules and are awaiting staff review.
+
+To become a Stowaway, a user must:
+
+- Register for a website account  
+- Agree to the community Rules  
+
+Stowaways are granted limited access while awaiting approval:
+
+- Access to the **#foyer** channel in Discord to interact with the community  
+- Limited access to the website  
+- No access to the Minecraft server  
+
+This stage allows users to begin engaging with the community while staff completes their review. Active participation during this stage may help expedite approval.
+
+---
+
+### Traveler
+
+**Traveler** is the first level of full community access.
+
+To become a Traveler, a user must:
+
+- Be reviewed and approved by staff  
+
+Upon approval, users are automatically promoted to Traveler and granted access to:
+
+- The Lighthouse Discord server  
+- The Minecraft server  
+- Full website functionality  
+
+Travelers may have minor restrictions in certain areas, but these are generally not disruptive to normal participation.
+
+---
+
+### Resident
+
+**Resident** is a full member in good standing within the community.
+
+Promotion to Resident is based on:
+
+- Consistent positive participation  
+- Respect for community rules and values  
+- Demonstrated trustworthiness over time  
+
+Residents receive full access to community spaces and are considered established members of Lighthouse.
+
+---
+
+### Citizen
+
+**Citizen** is a recognition level for members who go above and beyond in the community.
+
+Citizens are members who:
+
+- Consistently represent Lighthouse well  
+- Contribute positively to the community culture  
+- Demonstrate maturity, leadership, and reliability  
+
+This level is not a part of the normal player experience on Lighthouse and is only granted at the discretion of staff.
+
+Citizen status reflects trust and recognition, not authority.
+
+---
+
+## Platform Access & Identity
+
+Lighthouse manages access across platforms through the website.
+
+- Discord and Minecraft access are tied to a user’s website account  
+- Account linking (Discord and Minecraft) is required for full participation  
+- Permissions and roles are managed centrally through the website  
+
+Users who do not complete account setup or linking may have limited or no access to certain community features.
+
+---
+
+## Loss or Restriction of Access
+
+Access to Lighthouse community spaces may be restricted or removed if:
+
+- A user violates community policies and is placed in the Brig
+- A user’s account is incomplete or no longer meets requirements  
+- A parent restricts access or certain features to children accounts they manage
+
+Access decisions are made by staff in accordance with Lighthouse policies.
+
+---
+
+## Guiding Principle
+
+Lighthouse is a community built on trust.
+
+Access is not just about joining — it is about participating in a way that builds trust with others and contributes to a safe and welcoming environment for everyone.


### PR DESCRIPTION
## What Changed

Added the Membership & Access Policy chapter to the Community Standards part of the Policy Manual. This is a new public-facing policy page covering how users join Lighthouse, the membership levels (Stowaway, Traveler, Resident, Citizen), platform access requirements, and what can cause access to be restricted.

## How to Test

1. Navigate to `/library/books/policy-manual`.
2. Click **Community Standards** in the sidebar.
3. Verify **Membership & Access Policy** appears as the third chapter (after Code of Conduct and Community Expectations).
4. Click it — verify the full policy content loads, including sections for Purpose, Website Account Requirement, Membership Levels, Platform Access & Identity, Loss or Restriction of Access, and Guiding Principle.
5. Verify the "Last updated: March 27, 2026" date appears beneath the chapter title.
6. Confirm the page is accessible without logging in (public visibility).

## Things to Watch For

- The chapter should appear third in the Community Standards nav, after Code of Conduct and Community Expectations.
- No sub-pages should appear — all content is in the chapter overview.

## Parent PRD

#395

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new "Membership & Access Policy" page that outlines the community's membership structure and access requirements, including the four membership levels (Stowaway, Traveler, Resident, Citizen), account linking requirements across platforms, and conditions for access restrictions or removal.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->