### PR TITLE
feat: ticket escalation for unassigned tickets (PRD #416)

### DIFF
--- a/app/Jobs/EscalateUnassignedTickets.php
+++ b/app/Jobs/EscalateUnassignedTickets.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace App\Jobs;
+
+use App\Enums\MessageKind;
+use App\Enums\ThreadStatus;
+use App\Enums\ThreadType;
+use App\Models\Message;
+use App\Models\SiteConfig;
+use App\Models\Thread;
+use App\Models\User;
+use App\Notifications\TicketEscalationNotification;
+use App\Services\TicketNotificationService;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Queue\Queueable;
+
+class EscalateUnassignedTickets implements ShouldQueue
+{
+    use Queueable;
+
+    public function handle(TicketNotificationService $service): void
+    {
+        $thresholdMinutes = (int) SiteConfig::getValue('ticket_escalation_threshold_minutes', '30');
+
+        $tickets = Thread::where('type', ThreadType::Ticket)
+            ->where('status', ThreadStatus::Open)
+            ->whereNull('assigned_to_user_id')
+            ->whereNull('escalated_at')
+            ->where('created_at', '<=', now()->subMinutes($thresholdMinutes))
+            ->get();
+
+        if ($tickets->isEmpty()) {
+            return;
+        }
+
+        $recipients = User::all()->filter(fn ($user) => $user->can('receive-ticket-escalations'));
+
+        $systemUser = User::where('email', 'system@lighthouse.local')->first();
+
+        foreach ($tickets as $ticket) {
+            foreach ($recipients as $recipient) {
+                $service->send($recipient, new TicketEscalationNotification($ticket), 'staff_alerts');
+            }
+
+            if ($systemUser) {
+                Message::create([
+                    'thread_id' => $ticket->id,
+                    'user_id' => $systemUser->id,
+                    'body' => 'This ticket has been escalated — no staff response was received within the expected timeframe.',
+                    'kind' => MessageKind::System,
+                ]);
+            }
+
+            $ticket->update(['escalated_at' => now()]);
+        }
+    }
+}

--- a/app/Jobs/EscalateUnassignedTickets.php
+++ b/app/Jobs/EscalateUnassignedTickets.php
@@ -22,11 +22,16 @@ class EscalateUnassignedTickets implements ShouldQueue
     {
         $thresholdMinutes = (int) SiteConfig::getValue('ticket_escalation_threshold_minutes', '30');
 
+        if ($thresholdMinutes <= 0) {
+            return;
+        }
+
         $tickets = Thread::where('type', ThreadType::Ticket)
             ->where('status', ThreadStatus::Open)
             ->whereNull('assigned_to_user_id')
             ->whereNull('escalated_at')
             ->where('created_at', '<=', now()->subMinutes($thresholdMinutes))
+            ->with(['createdBy'])
             ->get();
 
         if ($tickets->isEmpty()) {

--- a/app/Jobs/EscalateUnassignedTickets.php
+++ b/app/Jobs/EscalateUnassignedTickets.php
@@ -38,7 +38,12 @@ class EscalateUnassignedTickets implements ShouldQueue
             return;
         }
 
-        $recipients = User::all()->filter(fn ($user) => $user->can('receive-ticket-escalations'));
+        $recipients = User::query()
+            ->whereNotNull('admin_granted_at')
+            ->orWhereHas('staffPosition', fn ($q) => $q->whereNotNull('has_all_roles_at'))
+            ->orWhereHas('staffPosition.roles', fn ($q) => $q->where('name', 'Ticket Escalation - Receiver'))
+            ->get()
+            ->filter(fn ($user) => $user->can('receive-ticket-escalations'));
 
         $systemUser = User::where('email', 'system@lighthouse.local')->first();
 

--- a/app/Models/Thread.php
+++ b/app/Models/Thread.php
@@ -32,6 +32,7 @@ class Thread extends Model
         'is_locked',
         'closed_at',
         'locked_at',
+        'escalated_at',
     ];
 
     protected $casts = [
@@ -45,6 +46,7 @@ class Thread extends Model
         'is_locked' => 'boolean',
         'closed_at' => 'datetime',
         'locked_at' => 'datetime',
+        'escalated_at' => 'datetime',
     ];
 
     public function createdBy(): BelongsTo

--- a/app/Notifications/TicketEscalationNotification.php
+++ b/app/Notifications/TicketEscalationNotification.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace App\Notifications;
+
+use App\Models\Thread;
+use App\Notifications\Channels\DiscordChannel;
+use App\Notifications\Channels\PushoverChannel;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Notifications\Messages\MailMessage;
+use Illuminate\Notifications\Notification;
+
+class TicketEscalationNotification extends Notification implements ShouldQueue
+{
+    use Queueable;
+
+    protected array $allowedChannels = ['mail'];
+
+    protected ?string $pushoverKey = null;
+
+    public function __construct(
+        public Thread $thread
+    ) {}
+
+    public function setChannels(array $channels, ?string $pushoverKey = null): self
+    {
+        $this->allowedChannels = $channels;
+        $this->pushoverKey = $pushoverKey;
+
+        return $this;
+    }
+
+    public function via(object $notifiable): array
+    {
+        $channels = [];
+
+        if (in_array('mail', $this->allowedChannels)) {
+            $channels[] = 'mail';
+        }
+
+        if (in_array('pushover', $this->allowedChannels) && $this->pushoverKey) {
+            $channels[] = PushoverChannel::class;
+        }
+
+        if (in_array('discord', $this->allowedChannels)) {
+            $channels[] = DiscordChannel::class;
+        }
+
+        return $channels;
+    }
+
+    public function toMail(object $notifiable): MailMessage
+    {
+        return (new MailMessage)
+            ->subject('Unassigned Ticket Alert: '.$this->thread->subject)
+            ->markdown('mail.ticket-escalation', [
+                'thread' => $this->thread,
+                'ticketUrl' => route('tickets.show', $this->thread),
+            ]);
+    }
+
+    public function toPushover(object $notifiable): array
+    {
+        return [
+            'title' => 'Unassigned Ticket Alert',
+            'message' => $this->thread->subject,
+            'url' => route('tickets.show', $this->thread),
+        ];
+    }
+
+    public function toDiscord(object $notifiable): string
+    {
+        return "**Unassigned Ticket Alert:** {$this->thread->subject}\n**Department:** {$this->thread->department->label()}\n**From:** {$this->thread->createdBy->name}\n".route('tickets.show', $this->thread);
+    }
+}

--- a/app/Notifications/TicketEscalationNotification.php
+++ b/app/Notifications/TicketEscalationNotification.php
@@ -70,6 +70,9 @@ class TicketEscalationNotification extends Notification implements ShouldQueue
 
     public function toDiscord(object $notifiable): string
     {
-        return "**Unassigned Ticket Alert:** {$this->thread->subject}\n**Department:** {$this->thread->department->label()}\n**From:** {$this->thread->createdBy->name}\n".route('tickets.show', $this->thread);
+        $department = $this->thread->department?->label() ?? 'Unknown';
+        $creator = $this->thread->createdBy?->name ?? 'Unknown';
+
+        return "**Unassigned Ticket Alert:** {$this->thread->subject}\n**Department:** {$department}\n**From:** {$creator}\n".route('tickets.show', $this->thread);
     }
 }

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -214,6 +214,10 @@ class AuthServiceProvider extends ServiceProvider
             return $user->hasRole('Site Config - Manager');
         });
 
+        Gate::define('receive-ticket-escalations', function ($user) {
+            return $user->hasRole('Ticket Escalation - Receiver');
+        });
+
         Gate::define('manage-blog', function ($user) {
             return $user->hasRole('Blog - Author');
         });

--- a/database/migrations/2026_03_29_131834_add_escalated_at_to_threads_table.php
+++ b/database/migrations/2026_03_29_131834_add_escalated_at_to_threads_table.php
@@ -1,0 +1,25 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('threads', function (Blueprint $table) {
+            $table->timestamp('escalated_at')->nullable()->after('locked_at');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('threads', function (Blueprint $table) {
+            $table->dropColumn('escalated_at');
+        });
+    }
+};

--- a/database/migrations/2026_03_29_141401_seed_ticket_escalation_receiver_role.php
+++ b/database/migrations/2026_03_29_141401_seed_ticket_escalation_receiver_role.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        $exists = DB::table('roles')->where('name', 'Ticket Escalation - Receiver')->exists();
+
+        if (! $exists) {
+            DB::table('roles')->insert([
+                'name' => 'Ticket Escalation - Receiver',
+                'description' => 'Receive escalation notifications when a ticket goes unassigned past the configured threshold',
+                'color' => 'orange',
+                'icon' => 'bell-alert',
+                'created_at' => now(),
+                'updated_at' => now(),
+            ]);
+        }
+    }
+
+    public function down(): void
+    {
+        DB::table('roles')->where('name', 'Ticket Escalation - Receiver')->delete();
+    }
+};

--- a/database/migrations/2026_03_29_141421_seed_ticket_escalation_threshold_site_config.php
+++ b/database/migrations/2026_03_29_141421_seed_ticket_escalation_threshold_site_config.php
@@ -1,0 +1,20 @@
+<?php
+
+use App\Models\SiteConfig;
+use Illuminate\Database\Migrations\Migration;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        SiteConfig::setValue('ticket_escalation_threshold_minutes', '30');
+        SiteConfig::query()->where('key', 'ticket_escalation_threshold_minutes')->update([
+            'description' => 'Minutes before an unassigned open ticket is escalated to Ticket Escalation - Receiver role holders (0 to disable)',
+        ]);
+    }
+
+    public function down(): void
+    {
+        SiteConfig::query()->where('key', 'ticket_escalation_threshold_minutes')->delete();
+    }
+};

--- a/docs/features/ticket-escalation.md
+++ b/docs/features/ticket-escalation.md
@@ -1,0 +1,442 @@
+# Ticket Escalation — Technical Documentation
+
+> **Audience:** Project owner, developers, AI agents
+> **Generated:** 2026-03-29
+> **Generator:** `/document-feature` skill
+
+---
+
+## Table of Contents
+
+1. [Overview](#1-overview)
+2. [Database Schema](#2-database-schema)
+3. [Models & Relationships](#3-models--relationships)
+4. [Enums Reference](#4-enums-reference)
+5. [Authorization & Permissions](#5-authorization--permissions)
+6. [Routes](#6-routes)
+7. [User Interface Components](#7-user-interface-components)
+8. [Actions (Business Logic)](#8-actions-business-logic)
+9. [Notifications](#9-notifications)
+10. [Background Jobs](#10-background-jobs)
+11. [Console Commands & Scheduled Tasks](#11-console-commands--scheduled-tasks)
+12. [Services](#12-services)
+13. [Activity Log Entries](#13-activity-log-entries)
+14. [Data Flow Diagrams](#14-data-flow-diagrams)
+15. [Configuration](#15-configuration)
+16. [Test Coverage](#16-test-coverage)
+17. [File Map](#17-file-map)
+18. [Known Issues & Improvement Opportunities](#18-known-issues--improvement-opportunities)
+
+---
+
+## 1. Overview
+
+The Ticket Escalation feature automatically alerts designated staff members when a support ticket goes unassigned for longer than a configurable threshold. Without this feature, unassigned tickets are only visible to staff who actively check the dashboard — time-sensitive requests (e.g., new members awaiting server access) can sit ignored for hours.
+
+The system runs a background job every minute. For each open, unassigned ticket whose `created_at` exceeds the configured threshold (default 30 minutes), it sends a `TicketEscalationNotification` to every user holding the `Ticket Escalation - Receiver` role, posts a visible system message in the ticket thread so participants know action is being taken, and stamps `escalated_at` on the thread to prevent repeat notifications.
+
+Escalation recipients are staff members who have been explicitly assigned the `Ticket Escalation - Receiver` role — typically Command officers, who receive it automatically via their "All Roles" staff position. The role can also be granted temporarily to other staff (e.g., a Quartermaster covering Engineering). The threshold and role are both configurable without code changes.
+
+Key concepts:
+- **Escalation threshold:** The number of minutes before a ticket is considered overdue. Configured via `ticket_escalation_threshold_minutes` in Site Config (default: 30).
+- **Escalation lock:** The `escalated_at` column on `threads`. Null = not yet escalated; populated = already escalated. Reset to null when a ticket is unassigned, allowing re-escalation.
+- **`Ticket Escalation - Receiver` role:** The permission role that determines who receives escalation notifications.
+- **`receive-ticket-escalations` gate:** The authorization gate used to query eligible recipients.
+
+---
+
+## 2. Database Schema
+
+### `threads` table (escalation-related columns)
+
+| Column | Type | Nullable | Default | Notes |
+|--------|------|----------|---------|-------|
+| `escalated_at` | timestamp | YES | NULL | Populated when escalation fires; null means not yet escalated or has been reset |
+
+All other `threads` columns pre-exist this feature. The `assigned_to_user_id` column (also on `threads`) controls whether a ticket is eligible for escalation (must be NULL).
+
+**Migration:** `database/migrations/2026_03_29_131834_add_escalated_at_to_threads_table.php`
+
+### `roles` table (escalation role)
+
+| Column | Value |
+|--------|-------|
+| `name` | `Ticket Escalation - Receiver` |
+| `description` | `Receive escalation notifications when a ticket goes unassigned past the configured threshold` |
+| `color` | `orange` |
+| `icon` | `bell-alert` |
+
+**Migration:** `database/migrations/2026_03_29_141401_seed_ticket_escalation_receiver_role.php`
+
+### `site_config` table (escalation threshold)
+
+| Key | Default Value | Description |
+|-----|--------------|-------------|
+| `ticket_escalation_threshold_minutes` | `30` | Minutes before an unassigned open ticket is escalated to Ticket Escalation - Receiver role holders (0 to disable) |
+
+**Migration:** `database/migrations/2026_03_29_141421_seed_ticket_escalation_threshold_site_config.php`
+
+---
+
+## 3. Models & Relationships
+
+### Thread (`app/Models/Thread.php`)
+
+The `Thread` model is the primary entity modified by this feature. Only escalation-relevant fields are documented here; the full model has many additional columns.
+
+**Escalation-relevant `$fillable` fields:**
+- `escalated_at`
+
+**Escalation-relevant `$casts`:**
+- `escalated_at` => `datetime`
+
+**Escalation-relevant columns:**
+- `assigned_to_user_id` — must be `NULL` for a ticket to be eligible for escalation
+- `escalated_at` — null until first escalation fires; reset to null on unassign; set to `now()` after escalation
+
+No new relationships were added for this feature.
+
+---
+
+## 4. Enums Reference
+
+No new enums were added for this feature. Existing enums used:
+
+### ThreadStatus (`app/Enums/ThreadStatus.php`)
+
+| Case | Value | Notes |
+|------|-------|-------|
+| `Open` | `open` | Only Open tickets are eligible for escalation |
+| `Pending` | `pending` | Not eligible |
+| `Resolved` | `resolved` | Not eligible |
+| `Closed` | `closed` | Not eligible |
+
+### ThreadType (`app/Enums/ThreadType.php`)
+
+| Case | Value | Notes |
+|------|-------|-------|
+| `Ticket` | `ticket` | Only Ticket-type threads are escalated |
+| Others | various | Not eligible |
+
+### MessageKind (`app/Enums/MessageKind.php`)
+
+| Case | Notes |
+|------|-------|
+| `System` | Used for the escalation system message posted in the thread |
+
+---
+
+## 5. Authorization & Permissions
+
+### Gates (from `AuthServiceProvider`)
+
+| Gate Name | Who Can Pass | Logic Summary |
+|-----------|-------------|---------------|
+| `receive-ticket-escalations` | Users with `Ticket Escalation - Receiver` role | `$user->hasRole('Ticket Escalation - Receiver')` — also passes for admins and users with "All Roles" staff position |
+
+The `receive-ticket-escalations` gate is **not enforced on a request** — it is used internally by `EscalateUnassignedTickets` to filter the recipient list at notification time.
+
+### Role Assignment
+
+The `Ticket Escalation - Receiver` role is assigned to users via the standard role assignment UI (ACP → Staff Management). Officers with "All Roles" positions (`has_all_roles_at IS NOT NULL`) pass the gate automatically without explicit role assignment.
+
+### Policies
+
+Not applicable — no new policy was added for this feature.
+
+### Permissions Matrix
+
+| User Type | Receives escalation notification | Passes `receive-ticket-escalations` gate | Can configure threshold |
+|-----------|----------------------------------|------------------------------------------|------------------------|
+| Regular user / Stowaway | No | No | No |
+| Staff (no role) | No | No | No |
+| Staff with `Ticket Escalation - Receiver` role | Yes | Yes | No |
+| Officer (All Roles position) | Yes | Yes | No |
+| Admin | Yes | Yes | Yes (via ACP) |
+| Site Config - Manager role | No* | No* | Yes (via ACP) |
+
+*Site Config managers can change the threshold but won't receive notifications unless they also hold the Ticket Escalation - Receiver role.
+
+---
+
+## 6. Routes
+
+No new routes were added for this feature. Escalation is entirely driven by a background job. The existing ticket view route (`GET /tickets/{thread}`) is referenced in notification payloads.
+
+| Method | URL | Handler | Route Name |
+|--------|-----|---------|------------|
+| GET | `/tickets/{thread}` | Volt: `ready-room.tickets.view-ticket` | `tickets.show` |
+
+---
+
+## 7. User Interface Components
+
+### View Ticket (`resources/views/livewire/ready-room/tickets/view-ticket.blade.php`)
+
+This component was modified — the `assignTo(?int $userId)` method now also clears `escalated_at` when a ticket is unassigned.
+
+**Change:** When `$userId === null` (unassign), the update call is:
+```php
+$this->thread->update(['assigned_to_user_id' => null, 'escalated_at' => null]);
+```
+
+**Reason:** Resetting `escalated_at` allows a re-orphaned ticket to escalate again once the threshold passes. Without this reset, a ticket that was escalated, then assigned, then unassigned again would never escalate a second time.
+
+**No UI changes** — this modification is purely server-side. The escalation system message posted in the thread is visible to all participants in the ticket view as a `MessageKind::System` message.
+
+### Admin Control Panel — Site Config
+**File:** `resources/views/livewire/admin-manage-site-configs-page.blade.php`
+
+The `ticket_escalation_threshold_minutes` config key is automatically surfaced in the ACP's Site Settings table (no code changes needed — the table renders all `SiteConfig` rows). Administrators with the `manage-site-config` gate can click the edit button to update the threshold value.
+
+---
+
+## 8. Actions (Business Logic)
+
+No new Action classes were created for this feature. Logic lives in the job directly. The escalation reset on unassign is a one-liner in the Volt component.
+
+Not applicable for standalone actions.
+
+---
+
+## 9. Notifications
+
+### TicketEscalationNotification (`app/Notifications/TicketEscalationNotification.php`)
+
+**Triggered by:** `EscalateUnassignedTickets::handle()` — once per eligible ticket per run
+**Recipient:** All users who pass the `receive-ticket-escalations` gate
+**Channels:** mail, Pushover (if user has key), Discord (if user has linked account)
+**Category:** `staff_alerts` (respects each user's Staff Alerts channel preferences)
+**Mail subject:** `Unassigned Ticket Alert: {thread.subject}`
+**Mail template:** `resources/views/mail/ticket-escalation.blade.php`
+**Mail content:** Thread subject, department label, creator name, "View Ticket" button
+**Pushover title:** `Unassigned Ticket Alert`
+**Pushover message:** Thread subject with URL
+**Discord message:** `**Unassigned Ticket Alert:** {subject}\n**Department:** {dept}\n**From:** {creator}\n{url}`
+**Queued:** Yes (`ShouldQueue`)
+
+The notification follows the exact same channel-selection pattern as `NewTicketNotification`, delegating channel determination to `TicketNotificationService::send()`.
+
+---
+
+## 10. Background Jobs
+
+### EscalateUnassignedTickets (`app/Jobs/EscalateUnassignedTickets.php`)
+
+**Triggered by:** Laravel scheduler — every minute (see `routes/console.php`)
+**Queue:** Default queue via `ShouldQueue`
+
+**Step-by-step logic:**
+1. Reads `ticket_escalation_threshold_minutes` from `SiteConfig` (default: `30`)
+2. Queries `threads` for: `type = Ticket`, `status = Open`, `assigned_to_user_id IS NULL`, `escalated_at IS NULL`, `created_at <= now() - threshold`
+3. If no matching tickets, returns immediately (no DB queries for users)
+4. Fetches all users and filters to those passing `receive-ticket-escalations` gate
+5. Fetches the system user (`email = system@lighthouse.local`)
+6. For each eligible ticket:
+   a. Sends `TicketEscalationNotification` to each recipient via `staff_alerts` category
+   b. If system user exists: creates a `MessageKind::System` message in the thread
+   c. Sets `escalated_at = now()` on the ticket (prevents re-escalation)
+
+**Idempotency:** The `escalated_at IS NULL` filter ensures running the job twice in the same minute does not double-notify.
+
+**Performance note:** Step 4 uses `User::all()->filter(...)` — acceptable for a small community application but would need a DB-query approach at scale (see Known Issues).
+
+---
+
+## 11. Console Commands & Scheduled Tasks
+
+No new Artisan commands were added. The job is registered directly in the scheduler.
+
+### Scheduled Job: `EscalateUnassignedTickets`
+**File:** `routes/console.php`
+**Schedule:** Every minute (`everyMinute()`)
+**Registration:**
+```php
+Schedule::job(new \App\Jobs\EscalateUnassignedTickets)
+    ->everyMinute();
+```
+
+---
+
+## 12. Services
+
+### TicketNotificationService (`app/Services/TicketNotificationService.php`)
+
+This pre-existing service is called by `EscalateUnassignedTickets` with the `staff_alerts` category. No changes were made to the service itself.
+
+**Relevant method:**
+- `send(User $user, Notification $notification, string $category = 'tickets'): void` — determines channels based on user preferences for the given category, increments Pushover count if needed, and dispatches the notification.
+
+---
+
+## 13. Activity Log Entries
+
+No new activity log entries are created by this feature. The existing `assignment_changed` activity log entry (from `RecordActivity::run()` in `view-ticket.blade.php`) is unchanged — the escalation reset on unassign does not add a new log entry.
+
+Not applicable for escalation-specific activity logging.
+
+---
+
+## 14. Data Flow Diagrams
+
+### Escalation Job (Automatic — every minute)
+
+```
+Laravel Scheduler fires every minute
+  -> EscalateUnassignedTickets::handle(TicketNotificationService)
+    -> SiteConfig::getValue('ticket_escalation_threshold_minutes', '30')
+    -> Thread::where(type=Ticket, status=Open, assigned_to_user_id=null,
+                     escalated_at=null, created_at <= now()-threshold)->get()
+    -> [return if empty]
+    -> User::all()->filter(can('receive-ticket-escalations'))
+    -> User::where('email','system@lighthouse.local')->first()
+    -> foreach ticket:
+         foreach recipient:
+           -> TicketNotificationService::send($recipient,
+                new TicketEscalationNotification($ticket), 'staff_alerts')
+             -> determineChannels($user, 'staff_alerts')
+             -> $notification->setChannels([...])
+             -> $user->notify($notification)  [queued]
+               -> toMail() -> "Unassigned Ticket Alert: {subject}" email
+               -> toPushover() -> push to user's Pushover key
+               -> toDiscord() -> DM in user's linked Discord
+         -> Message::create([thread_id, user_id=systemUser, body='...escalated...', kind=System])
+         -> $ticket->update(['escalated_at' => now()])
+```
+
+### Unassign Reset (Staff action in ticket view)
+
+```
+Staff clicks "Unassign" in ticket view
+  -> POST /livewire/update (Livewire request)
+    -> view-ticket@assignTo(null)
+      -> $this->authorize('assign', $this->thread)
+      -> $this->thread->update(['assigned_to_user_id' => null, 'escalated_at' => null])
+      -> RecordActivity::run($thread, 'assignment_changed', 'Assignment removed: ...')
+      -> [cache clearing for all participants]
+      -> Flux::toast('Ticket unassigned successfully!', variant: 'success')
+  -> Thread now eligible for re-escalation once threshold passes again
+```
+
+---
+
+## 15. Configuration
+
+| Key | Location | Default | Purpose |
+|-----|----------|---------|---------|
+| `ticket_escalation_threshold_minutes` | `site_config` table / ACP | `30` | Minutes before an unassigned open ticket triggers escalation. Set to 0 to effectively disable (no ticket is old enough within 0 minutes — actually this would escalate immediately; see Known Issues). |
+
+---
+
+## 16. Test Coverage
+
+### Test Files
+
+| File | Tests | What It Covers |
+|------|-------|----------------|
+| `tests/Feature/Jobs/EscalateUnassignedTicketsTest.php` | 12 | Full job behavior |
+| `tests/Feature/Tickets/ViewTicketTest.php` | 2 (new) | `escalated_at` reset on unassign |
+| `tests/Feature/Gates/RoleBasedGatesTest.php` | 4 (new) | `receive-ticket-escalations` gate |
+
+### Test Case Inventory
+
+**`EscalateUnassignedTicketsTest.php`:**
+- `it sends escalation notification to users with Ticket Escalation - Receiver role`
+- `it sets escalated_at after sending notification`
+- `it does not escalate already-assigned tickets`
+- `it does not escalate closed tickets`
+- `it does not escalate resolved tickets`
+- `it does not re-escalate already-escalated tickets`
+- `it does not escalate tickets created within the threshold window`
+- `it respects the ticket_escalation_threshold_minutes site config`
+- `it sends to multiple recipients when multiple users have the role`
+- `it posts a system message in the thread when escalating`
+- `it is idempotent — running twice does not double-escalate`
+- `it does not escalate non-ticket thread types`
+
+**`ViewTicketTest.php` (new tests):**
+- `it resets escalated_at to null when ticket is unassigned #419`
+- `it does not reset escalated_at when ticket is assigned to a user #419`
+
+**`RoleBasedGatesTest.php` (new tests):**
+- `it grants receive-ticket-escalations to user with Ticket Escalation - Receiver role`
+- `it denies receive-ticket-escalations without Ticket Escalation - Receiver role`
+- `it grants receive-ticket-escalations to admin`
+- `it grants receive-ticket-escalations to user with allow-all position`
+
+### Coverage Gaps
+
+- **`ticket_escalation_threshold_minutes = 0`** — behavior when threshold is 0 is untested. Mathematically `now()->subMinutes(0)` equals `now()`, so nearly all tickets would immediately qualify. This is a potential footgun if an admin accidentally sets it to 0.
+- **No test for "zero recipients"** — if no user holds the `Ticket Escalation - Receiver` role, the job silently sends nothing. This is correct behavior but not explicitly tested.
+- **Pending ticket status** — not tested explicitly (the job only targets `Open`). This is covered implicitly by the closed/resolved tests but `Pending` is a distinct status.
+
+---
+
+## 17. File Map
+
+**Models:**
+- `app/Models/Thread.php` (modified: `escalated_at` added to `$fillable` and `$casts`)
+- `app/Models/SiteConfig.php` (unchanged, used for threshold lookup)
+- `app/Models/User.php` (unchanged, `hasRole()` drives gate)
+- `app/Models/Message.php` (unchanged, system message created via `Message::create()`)
+
+**Enums:**
+- `app/Enums/ThreadStatus.php` (used, unchanged)
+- `app/Enums/ThreadType.php` (used, unchanged)
+- `app/Enums/MessageKind.php` (used, unchanged)
+
+**Actions:** None added.
+
+**Policies:** None added.
+
+**Gates:** `app/Providers/AuthServiceProvider.php` — gate: `receive-ticket-escalations`
+
+**Notifications:**
+- `app/Notifications/TicketEscalationNotification.php` (new)
+
+**Jobs:**
+- `app/Jobs/EscalateUnassignedTickets.php` (new)
+
+**Services:**
+- `app/Services/TicketNotificationService.php` (used, unchanged)
+
+**Controllers:** None.
+
+**Volt Components:**
+- `resources/views/livewire/ready-room/tickets/view-ticket.blade.php` (modified: `escalated_at` reset on unassign)
+- `resources/views/livewire/admin-manage-site-configs-page.blade.php` (unchanged, surfaces config automatically)
+
+**Routes:**
+- `routes/console.php` (modified: `EscalateUnassignedTickets` registered every minute)
+- `routes/web.php` (unchanged, `tickets.show` route used in notification URLs)
+
+**Migrations:**
+- `database/migrations/2026_03_29_131834_add_escalated_at_to_threads_table.php` (new)
+- `database/migrations/2026_03_29_141401_seed_ticket_escalation_receiver_role.php` (new)
+- `database/migrations/2026_03_29_141421_seed_ticket_escalation_threshold_site_config.php` (new)
+
+**Mail views:**
+- `resources/views/mail/ticket-escalation.blade.php` (new)
+
+**Tests:**
+- `tests/Feature/Jobs/EscalateUnassignedTicketsTest.php` (new, 12 tests)
+- `tests/Feature/Tickets/ViewTicketTest.php` (modified, +2 tests)
+- `tests/Feature/Gates/RoleBasedGatesTest.php` (modified, +4 tests)
+
+**Config:** `ticket_escalation_threshold_minutes` in `site_config` table (managed via ACP)
+
+---
+
+## 18. Known Issues & Improvement Opportunities
+
+1. **`User::all()->filter(...)` in the job** — `EscalateUnassignedTickets` loads all users into memory to filter by gate. For a small community this is fine, but at scale a DB-level query joining `staff_positions`, `role_staff_position`, and `roles` would be more efficient. A HITL issue was noted in PRD #416's out-of-scope section.
+
+2. **Threshold value `0` is not safe** — If `ticket_escalation_threshold_minutes` is set to `0`, `now()->subMinutes(0)` equals `now()`, meaning every newly-created open unassigned ticket would escalate on the very next job run. There is no guard for this edge case, and no validation on the ACP input field.
+
+3. **No Pending status escalation** — Tickets with `status = Pending` are not escalated even if they are unassigned and old. The PRD explicitly targets `Open` status only; this is intentional design, not a bug, but worth noting for future reviewers.
+
+4. **System message requires system user** — If `User::where('email', 'system@lighthouse.local')->first()` returns null (e.g., on a fresh install without running `seed_system_user` migration), the escalation system message is silently skipped. The notification is still sent. This is consistent with how other features handle missing system user.
+
+5. **No escalation history UI** — Once `escalated_at` is set, there is no UI to see when a ticket was escalated or how many times it has been re-escalated after unassign/reassign cycles. This is listed as out-of-scope in PRD #416.
+
+6. **Escalation resets on any unassign, not just staff unassigns** — The escalation reset in `view-ticket.blade.php` fires whenever `assignTo(null)` is called. If the unassign path is ever called programmatically (e.g., by a future action), escalation would reset without the operator intending it.

--- a/resources/views/livewire/ready-room/tickets/view-ticket.blade.php
+++ b/resources/views/livewire/ready-room/tickets/view-ticket.blade.php
@@ -393,7 +393,7 @@ new class extends Component
         // Allow unassigning (setting to null)
         if ($userId === null) {
             $oldAssignee = $this->thread->assignedTo;
-            $this->thread->update(['assigned_to_user_id' => null]);
+            $this->thread->update(['assigned_to_user_id' => null, 'escalated_at' => null]);
 
             \App\Actions\RecordActivity::run(
                 $this->thread,

--- a/resources/views/mail/ticket-escalation.blade.php
+++ b/resources/views/mail/ticket-escalation.blade.php
@@ -3,9 +3,9 @@ A ticket has gone unassigned past the expected response window.
 
 **Subject:** {{ $thread->subject }}
 
-**Department:** {{ $thread->department->label() }}
+**Department:** {{ $thread->department?->label() ?? 'Unknown' }}
 
-**From:** {{ $thread->createdBy->name }}
+**From:** {{ $thread->createdBy?->name ?? 'Unknown' }}
 
 <x-mail::button :url="$ticketUrl">
 View Ticket

--- a/resources/views/mail/ticket-escalation.blade.php
+++ b/resources/views/mail/ticket-escalation.blade.php
@@ -1,0 +1,15 @@
+<x-mail::message>
+A ticket has gone unassigned past the expected response window.
+
+**Subject:** {{ $thread->subject }}
+
+**Department:** {{ $thread->department->label() }}
+
+**From:** {{ $thread->createdBy->name }}
+
+<x-mail::button :url="$ticketUrl">
+View Ticket
+</x-mail::button>
+
+Thank you for your service!
+</x-mail::message>

--- a/routes/console.php
+++ b/routes/console.php
@@ -59,6 +59,10 @@ Schedule::command('messages:purge-images')
 Schedule::job(new \App\Jobs\PublishScheduledPosts)
     ->everyMinute();
 
+// Escalate unassigned tickets past the configured threshold
+Schedule::job(new \App\Jobs\EscalateUnassignedTickets)
+    ->everyMinute();
+
 // Cleanup unreferenced blog images monthly
 Schedule::job(new \App\Jobs\CleanupUnreferencedBlogImages)
     ->monthly();

--- a/tests/Feature/Gates/RoleBasedGatesTest.php
+++ b/tests/Feature/Gates/RoleBasedGatesTest.php
@@ -539,6 +539,35 @@ it('denies view-community-content to user in brig (unchanged)', function () {
     expect($user->can('view-community-content'))->toBeFalse();
 });
 
+// == receive-ticket-escalations == //
+
+it('grants receive-ticket-escalations to user with Ticket Escalation - Receiver role', function () {
+    $user = User::factory()->withRole('Ticket Escalation - Receiver')->create();
+
+    expect($user->can('receive-ticket-escalations'))->toBeTrue();
+});
+
+it('denies receive-ticket-escalations without Ticket Escalation - Receiver role', function () {
+    $user = User::factory()
+        ->withStaffPosition(StaffDepartment::Command, StaffRank::Officer)
+        ->create();
+
+    expect($user->can('receive-ticket-escalations'))->toBeFalse();
+});
+
+it('grants receive-ticket-escalations to admin', function () {
+    $user = User::factory()->admin()->create();
+
+    expect($user->can('receive-ticket-escalations'))->toBeTrue();
+});
+
+it('grants receive-ticket-escalations to user with allow-all position', function () {
+    $user = User::factory()->create();
+    StaffPosition::factory()->assignedTo($user->id)->create(['has_all_roles_at' => now()]);
+
+    expect($user->fresh()->can('receive-ticket-escalations'))->toBeTrue();
+});
+
 // == Allow All positions pass all role-based gates == //
 
 it('grants all role-based gates to user with allow-all position', function () {
@@ -563,7 +592,8 @@ it('grants all role-based gates to user with allow-all position', function () {
         ->and($user->can('manage-application-questions'))->toBeTrue()
         ->and($user->can('view-acp'))->toBeTrue()
         ->and($user->can('view-ready-room'))->toBeTrue()
-        ->and($user->can('edit-staff-bio'))->toBeTrue();
+        ->and($user->can('edit-staff-bio'))->toBeTrue()
+        ->and($user->can('receive-ticket-escalations'))->toBeTrue();
 });
 
 // == Admin override works for all role-based gates == //
@@ -593,5 +623,6 @@ it('grants all role-based gates to admin user', function () {
         ->and($user->can('view-ready-room-steward'))->toBeTrue()
         ->and($user->can('view-acp'))->toBeTrue()
         ->and($user->can('view-ready-room'))->toBeTrue()
-        ->and($user->can('edit-staff-bio'))->toBeTrue();
+        ->and($user->can('edit-staff-bio'))->toBeTrue()
+        ->and($user->can('receive-ticket-escalations'))->toBeTrue();
 });

--- a/tests/Feature/Jobs/EscalateUnassignedTicketsTest.php
+++ b/tests/Feature/Jobs/EscalateUnassignedTicketsTest.php
@@ -1,0 +1,275 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Enums\MessageKind;
+use App\Enums\ThreadStatus;
+use App\Enums\ThreadType;
+use App\Jobs\EscalateUnassignedTickets;
+use App\Models\Message;
+use App\Models\SiteConfig;
+use App\Models\Thread;
+use App\Models\User;
+use App\Notifications\TicketEscalationNotification;
+use App\Services\TicketNotificationService;
+use Illuminate\Support\Facades\Notification;
+
+describe('EscalateUnassignedTickets Job', function () {
+    it('sends escalation notification to users with Ticket Escalation - Receiver role', function () {
+        Notification::fake();
+
+        $recipient = User::factory()
+            ->withRole('Ticket Escalation - Receiver')
+            ->create(['notification_preferences' => ['staff_alerts' => ['email' => true]]]);
+
+        $ticket = Thread::factory()->create([
+            'type' => ThreadType::Ticket,
+            'status' => ThreadStatus::Open,
+            'assigned_to_user_id' => null,
+            'escalated_at' => null,
+            'created_at' => now()->subMinutes(35),
+        ]);
+
+        (new EscalateUnassignedTickets)->handle(app(TicketNotificationService::class));
+
+        Notification::assertSentTo($recipient, TicketEscalationNotification::class);
+    });
+
+    it('sets escalated_at after sending notification', function () {
+        Notification::fake();
+
+        User::factory()
+            ->withRole('Ticket Escalation - Receiver')
+            ->create(['notification_preferences' => ['staff_alerts' => ['email' => true]]]);
+
+        $ticket = Thread::factory()->create([
+            'type' => ThreadType::Ticket,
+            'status' => ThreadStatus::Open,
+            'assigned_to_user_id' => null,
+            'escalated_at' => null,
+            'created_at' => now()->subMinutes(35),
+        ]);
+
+        (new EscalateUnassignedTickets)->handle(app(TicketNotificationService::class));
+
+        $ticket->refresh();
+        expect($ticket->escalated_at)->not->toBeNull();
+    });
+
+    it('does not escalate already-assigned tickets', function () {
+        Notification::fake();
+
+        $assignee = User::factory()->create();
+        User::factory()
+            ->withRole('Ticket Escalation - Receiver')
+            ->create(['notification_preferences' => ['staff_alerts' => ['email' => true]]]);
+
+        Thread::factory()->create([
+            'type' => ThreadType::Ticket,
+            'status' => ThreadStatus::Open,
+            'assigned_to_user_id' => $assignee->id,
+            'escalated_at' => null,
+            'created_at' => now()->subMinutes(35),
+        ]);
+
+        (new EscalateUnassignedTickets)->handle(app(TicketNotificationService::class));
+
+        Notification::assertNothingSent();
+    });
+
+    it('does not escalate closed tickets', function () {
+        Notification::fake();
+
+        User::factory()
+            ->withRole('Ticket Escalation - Receiver')
+            ->create(['notification_preferences' => ['staff_alerts' => ['email' => true]]]);
+
+        Thread::factory()->create([
+            'type' => ThreadType::Ticket,
+            'status' => ThreadStatus::Closed,
+            'assigned_to_user_id' => null,
+            'escalated_at' => null,
+            'created_at' => now()->subMinutes(35),
+        ]);
+
+        (new EscalateUnassignedTickets)->handle(app(TicketNotificationService::class));
+
+        Notification::assertNothingSent();
+    });
+
+    it('does not escalate resolved tickets', function () {
+        Notification::fake();
+
+        User::factory()
+            ->withRole('Ticket Escalation - Receiver')
+            ->create(['notification_preferences' => ['staff_alerts' => ['email' => true]]]);
+
+        Thread::factory()->create([
+            'type' => ThreadType::Ticket,
+            'status' => ThreadStatus::Resolved,
+            'assigned_to_user_id' => null,
+            'escalated_at' => null,
+            'created_at' => now()->subMinutes(35),
+        ]);
+
+        (new EscalateUnassignedTickets)->handle(app(TicketNotificationService::class));
+
+        Notification::assertNothingSent();
+    });
+
+    it('does not re-escalate already-escalated tickets', function () {
+        Notification::fake();
+
+        User::factory()
+            ->withRole('Ticket Escalation - Receiver')
+            ->create(['notification_preferences' => ['staff_alerts' => ['email' => true]]]);
+
+        Thread::factory()->create([
+            'type' => ThreadType::Ticket,
+            'status' => ThreadStatus::Open,
+            'assigned_to_user_id' => null,
+            'escalated_at' => now()->subMinutes(10),
+            'created_at' => now()->subMinutes(45),
+        ]);
+
+        (new EscalateUnassignedTickets)->handle(app(TicketNotificationService::class));
+
+        Notification::assertNothingSent();
+    });
+
+    it('does not escalate tickets created within the threshold window', function () {
+        Notification::fake();
+
+        User::factory()
+            ->withRole('Ticket Escalation - Receiver')
+            ->create(['notification_preferences' => ['staff_alerts' => ['email' => true]]]);
+
+        Thread::factory()->create([
+            'type' => ThreadType::Ticket,
+            'status' => ThreadStatus::Open,
+            'assigned_to_user_id' => null,
+            'escalated_at' => null,
+            'created_at' => now()->subMinutes(10), // within 30-minute threshold
+        ]);
+
+        (new EscalateUnassignedTickets)->handle(app(TicketNotificationService::class));
+
+        Notification::assertNothingSent();
+    });
+
+    it('respects the ticket_escalation_threshold_minutes site config', function () {
+        Notification::fake();
+
+        SiteConfig::setValue('ticket_escalation_threshold_minutes', '60');
+
+        User::factory()
+            ->withRole('Ticket Escalation - Receiver')
+            ->create(['notification_preferences' => ['staff_alerts' => ['email' => true]]]);
+
+        // Created 45 minutes ago — past default 30 but within custom 60
+        Thread::factory()->create([
+            'type' => ThreadType::Ticket,
+            'status' => ThreadStatus::Open,
+            'assigned_to_user_id' => null,
+            'escalated_at' => null,
+            'created_at' => now()->subMinutes(45),
+        ]);
+
+        (new EscalateUnassignedTickets)->handle(app(TicketNotificationService::class));
+
+        Notification::assertNothingSent();
+    });
+
+    it('sends to multiple recipients when multiple users have the role', function () {
+        Notification::fake();
+
+        $recipient1 = User::factory()
+            ->withRole('Ticket Escalation - Receiver')
+            ->create(['notification_preferences' => ['staff_alerts' => ['email' => true]]]);
+
+        $recipient2 = User::factory()
+            ->withRole('Ticket Escalation - Receiver')
+            ->create(['notification_preferences' => ['staff_alerts' => ['email' => true]]]);
+
+        Thread::factory()->create([
+            'type' => ThreadType::Ticket,
+            'status' => ThreadStatus::Open,
+            'assigned_to_user_id' => null,
+            'escalated_at' => null,
+            'created_at' => now()->subMinutes(35),
+        ]);
+
+        (new EscalateUnassignedTickets)->handle(app(TicketNotificationService::class));
+
+        Notification::assertSentTo($recipient1, TicketEscalationNotification::class);
+        Notification::assertSentTo($recipient2, TicketEscalationNotification::class);
+    });
+
+    it('posts a system message in the thread when escalating', function () {
+        Notification::fake();
+
+        User::factory()
+            ->withRole('Ticket Escalation - Receiver')
+            ->create(['notification_preferences' => ['staff_alerts' => ['email' => true]]]);
+
+        $ticket = Thread::factory()->create([
+            'type' => ThreadType::Ticket,
+            'status' => ThreadStatus::Open,
+            'assigned_to_user_id' => null,
+            'escalated_at' => null,
+            'created_at' => now()->subMinutes(35),
+        ]);
+
+        (new EscalateUnassignedTickets)->handle(app(TicketNotificationService::class));
+
+        $systemMessage = Message::where('thread_id', $ticket->id)
+            ->where('kind', MessageKind::System)
+            ->first();
+
+        expect($systemMessage)->not->toBeNull()
+            ->and($systemMessage->body)->toContain('escalated');
+    });
+
+    it('is idempotent — running twice does not double-escalate', function () {
+        Notification::fake();
+
+        $recipient = User::factory()
+            ->withRole('Ticket Escalation - Receiver')
+            ->create(['notification_preferences' => ['staff_alerts' => ['email' => true]]]);
+
+        Thread::factory()->create([
+            'type' => ThreadType::Ticket,
+            'status' => ThreadStatus::Open,
+            'assigned_to_user_id' => null,
+            'escalated_at' => null,
+            'created_at' => now()->subMinutes(35),
+        ]);
+
+        $job = new EscalateUnassignedTickets;
+        $service = app(TicketNotificationService::class);
+
+        $job->handle($service);
+        $job->handle($service);
+
+        Notification::assertSentToTimes($recipient, TicketEscalationNotification::class, 1);
+    });
+
+    it('does not escalate non-ticket thread types', function () {
+        Notification::fake();
+
+        User::factory()
+            ->withRole('Ticket Escalation - Receiver')
+            ->create(['notification_preferences' => ['staff_alerts' => ['email' => true]]]);
+
+        Thread::factory()->topic()->create([
+            'status' => ThreadStatus::Open,
+            'assigned_to_user_id' => null,
+            'escalated_at' => null,
+            'created_at' => now()->subMinutes(35),
+        ]);
+
+        (new EscalateUnassignedTickets)->handle(app(TicketNotificationService::class));
+
+        Notification::assertNothingSent();
+    });
+});

--- a/tests/Feature/Jobs/EscalateUnassignedTicketsTest.php
+++ b/tests/Feature/Jobs/EscalateUnassignedTicketsTest.php
@@ -208,6 +208,7 @@ describe('EscalateUnassignedTickets Job', function () {
     it('posts a system message in the thread when escalating', function () {
         Notification::fake();
 
+        // System user is seeded by migration; the job uses it to post system messages
         User::factory()
             ->withRole('Ticket Escalation - Receiver')
             ->create(['notification_preferences' => ['staff_alerts' => ['email' => true]]]);
@@ -252,6 +253,28 @@ describe('EscalateUnassignedTickets Job', function () {
         $job->handle($service);
 
         Notification::assertSentToTimes($recipient, TicketEscalationNotification::class, 1);
+    });
+
+    it('does not escalate when threshold is set to 0 (escalation disabled)', function () {
+        Notification::fake();
+
+        SiteConfig::setValue('ticket_escalation_threshold_minutes', '0');
+
+        User::factory()
+            ->withRole('Ticket Escalation - Receiver')
+            ->create(['notification_preferences' => ['staff_alerts' => ['email' => true]]]);
+
+        Thread::factory()->create([
+            'type' => ThreadType::Ticket,
+            'status' => ThreadStatus::Open,
+            'assigned_to_user_id' => null,
+            'escalated_at' => null,
+            'created_at' => now()->subMinutes(5),
+        ]);
+
+        (new EscalateUnassignedTickets)->handle(app(TicketNotificationService::class));
+
+        Notification::assertNothingSent();
     });
 
     it('does not escalate non-ticket thread types', function () {

--- a/tests/Feature/Tickets/ViewTicketTest.php
+++ b/tests/Feature/Tickets/ViewTicketTest.php
@@ -127,6 +127,60 @@ describe('View Ticket Component', function () {
         expect($thread->assigned_to_user_id)->toBe($assignee->id);
     })->done();
 
+    it('resets escalated_at to null when ticket is unassigned #419', function () {
+        $officer = User::factory()
+            ->withStaffPosition(StaffDepartment::Chaplain, StaffRank::Officer)
+            ->withRole('Ticket - User')
+            ->withRole('Ticket - Manager')
+            ->create();
+
+        $assignee = User::factory()
+            ->withStaffPosition(StaffDepartment::Chaplain, StaffRank::CrewMember)
+            ->create();
+
+        $thread = Thread::factory()->withDepartment(StaffDepartment::Chaplain)->create([
+            'assigned_to_user_id' => $assignee->id,
+            'escalated_at' => now()->subMinutes(5),
+        ]);
+
+        actingAs($officer);
+
+        Volt::test('ready-room.tickets.view-ticket', ['thread' => $thread])
+            ->call('assignTo', null)
+            ->assertHasNoErrors();
+
+        $thread->refresh();
+        expect($thread->assigned_to_user_id)->toBeNull()
+            ->and($thread->escalated_at)->toBeNull();
+    });
+
+    it('does not reset escalated_at when ticket is assigned to a user #419', function () {
+        $officer = User::factory()
+            ->withStaffPosition(StaffDepartment::Chaplain, StaffRank::Officer)
+            ->withRole('Ticket - User')
+            ->withRole('Ticket - Manager')
+            ->create();
+
+        $assignee = User::factory()
+            ->withStaffPosition(StaffDepartment::Chaplain, StaffRank::CrewMember)
+            ->create();
+
+        $escalatedAt = now()->subMinutes(10);
+        $thread = Thread::factory()->withDepartment(StaffDepartment::Chaplain)->create([
+            'escalated_at' => $escalatedAt,
+        ]);
+
+        actingAs($officer);
+
+        Volt::test('ready-room.tickets.view-ticket', ['thread' => $thread])
+            ->call('assignTo', $assignee->id)
+            ->assertHasNoErrors();
+
+        $thread->refresh();
+        expect($thread->assigned_to_user_id)->toBe($assignee->id)
+            ->and($thread->escalated_at)->not->toBeNull();
+    });
+
     // TODO: Re-enable after PRD #280 completion — command officer no longer bypasses before() hook
     it('allows admin to assign tickets to staff from different departments', function () {
         $admin = User::factory()->admin()->create();


### PR DESCRIPTION
## What Changed

Adds automatic ticket escalation for unassigned support tickets. When a ticket has been open and unassigned for longer than a configurable threshold (default: 30 minutes), the system automatically notifies all users with the **Ticket Escalation - Receiver** role via their Staff Alerts channel preferences (email, Pushover, Discord). A system message is also posted in the ticket thread so the member knows their ticket is getting attention.

Key behaviors:
- Escalation runs every minute via the Laravel scheduler
- Each ticket only escalates once — reassigning it resets the flag so it can escalate again if needed
- Closed, resolved, and already-assigned tickets are never escalated
- A new `Ticket Escalation - Receiver` role controls who receives these alerts
- The threshold (default 30 minutes) is configurable in Site Config

## How to Test

### Setup
1. In the ACP → Roles, assign the **Ticket Escalation - Receiver** role to a test staff account
2. Ensure that account has Staff Alerts → Email enabled in notification preferences

### Basic escalation
1. As a regular member, create a new support ticket
2. Do **not** assign it to anyone
3. Wait for the scheduler to run (or manually trigger the job in Tinker: `(new \App\Jobs\EscalateUnassignedTickets)->handle(app(\App\Services\TicketNotificationService::class))`)
4. Verify the Ticket Escalation - Receiver user receives an email with the ticket subject, department, creator name, and a link
5. Open the ticket — verify a system message appears: "This ticket has been escalated — no staff response was received within the expected timeframe."
6. Verify the ticket does NOT escalate again if you run the job a second time

### Already-assigned ticket
1. Create a ticket and assign it to a staff member before the threshold
2. Run the job — verify no escalation notification is sent

### Unassign reset
1. Create and escalate a ticket (step 3 above)
2. Assign the ticket to someone, then unassign them
3. Run the job — the ticket should escalate again (since `escalated_at` was reset on unassign)

### Threshold respects site config
1. In ACP → Site Config, change `ticket_escalation_threshold_minutes` to `60`
2. Create a ticket 45 minutes old (adjust `created_at` in Tinker if needed)
3. Run the job — ticket should NOT escalate (45 min < 60 min threshold)

## Things to Watch For

- The **Ticket Escalation - Receiver** role needs to be manually assigned to the right staff; no one receives escalations by default (except Admins, who pass all permission checks)
- The system message in the ticket is visible to the member — confirm the wording is appropriate
- Escalation notifications use the **Staff Alerts** preference, not ticket reply preferences — verify the right notification category is respected
- If no staff have the role, the system message will still be posted in the thread (since the system user exists) but no email alerts will go out

## Parent PRD

#416

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic escalation of unassigned, open tickets after a configurable threshold (default 30 minutes)
  * Scheduled background job runs every minute to evaluate and notify recipients via email/Discord/Pushover
  * New role/gate to designate escalation recipients and queued escalation notifications
  * System messages posted to escalated tickets and a mail template for escalation notices

* **Database**
  * Added timestamp to track when a thread was escalated and seeded threshold/role defaults

* **Bug Fixes**
  * Unassigning a ticket now clears escalation state so it can re-escalate later

* **Documentation**
  * Added comprehensive ticket escalation feature docs

* **Tests**
  * End-to-end, gate, and idempotency tests for escalation behavior
<!-- end of auto-generated comment: release notes by coderabbit.ai -->