### PR TITLE
Enable Parents to restart minecraft verification on behalf of their c…

### DIFF
--- a/app/Actions/ForceDeleteMinecraftAccount.php
+++ b/app/Actions/ForceDeleteMinecraftAccount.php
@@ -26,10 +26,13 @@ class ForceDeleteMinecraftAccount
             ];
         }
 
-        if ($account->status !== MinecraftAccountStatus::Removed && $account->status !== MinecraftAccountStatus::Verifying) {
+        if ($account->status !== MinecraftAccountStatus::Removed
+            && $account->status !== MinecraftAccountStatus::Verifying
+            && $account->status !== MinecraftAccountStatus::Cancelled
+            && $account->status !== MinecraftAccountStatus::Cancelling) {
             return [
                 'success' => false,
-                'message' => 'Only removed or verifying accounts can be permanently deleted.',
+                'message' => 'Only removed, verifying, cancelled, or cancelling accounts can be permanently deleted.',
             ];
         }
 

--- a/app/Actions/ParentRegenerateVerificationCode.php
+++ b/app/Actions/ParentRegenerateVerificationCode.php
@@ -1,0 +1,141 @@
+<?php
+
+namespace App\Actions;
+
+use App\Enums\MinecraftAccountStatus;
+use App\Models\MinecraftAccount;
+use App\Models\MinecraftVerification;
+use App\Models\User;
+use App\Services\MinecraftRconService;
+use Lorisleiva\Actions\Concerns\AsAction;
+
+class ParentRegenerateVerificationCode
+{
+    use AsAction;
+
+    /**
+     * Restart verification for a child's Cancelled or Cancelling MinecraftAccount.
+     *
+     * Validates the parent-child relationship, checks that the child is not in the brig
+     * and that Minecraft access is enabled. Rate-limits against the child's user ID.
+     *
+     * @return array{success:bool, code:string|null, expires_at:\Illuminate\Support\Carbon|null, error:string|null}
+     */
+    public function handle(MinecraftAccount $account, User $parent): array
+    {
+        $child = $account->user;
+
+        if (! $parent->children()->where('child_user_id', $child->id)->exists()) {
+            return ['success' => false, 'code' => null, 'expires_at' => null, 'error' => 'You do not have permission to manage this account.'];
+        }
+
+        if (! in_array($account->status, [MinecraftAccountStatus::Cancelled, MinecraftAccountStatus::Cancelling])) {
+            return ['success' => false, 'code' => null, 'expires_at' => null, 'error' => 'Only cancelled or cancelling accounts can be retried.'];
+        }
+
+        if ($child->isInBrig()) {
+            return ['success' => false, 'code' => null, 'expires_at' => null, 'error' => 'Cannot restart verification while the child is in the brig.'];
+        }
+
+        if (! $child->parent_allows_minecraft) {
+            return ['success' => false, 'code' => null, 'expires_at' => null, 'error' => 'Minecraft access is currently disabled for this child.'];
+        }
+
+        // Rate limiting against child's user ID
+        $rateLimit = config('lighthouse.minecraft_verification_rate_limit_per_hour');
+        $recentVerifications = MinecraftVerification::where('user_id', $child->id)
+            ->where('created_at', '>=', now()->subHour())
+            ->pending()
+            ->count();
+
+        if ($recentVerifications >= $rateLimit) {
+            return ['success' => false, 'code' => null, 'expires_at' => null, 'error' => 'Verification rate limit reached for this child. Please try again later.'];
+        }
+
+        // Generate unique code
+        $allowedCharacters = '2346789ABCDEFGHJKMNPQRTUVWXYZ';
+        $codeLength = 6;
+        $maxAttempts = 100;
+        $attempts = 0;
+
+        do {
+            $code = '';
+            for ($i = 0; $i < $codeLength; $i++) {
+                $index = random_int(0, strlen($allowedCharacters) - 1);
+                $code .= $allowedCharacters[$index];
+            }
+            $attempts++;
+            if ($attempts >= $maxAttempts) {
+                return ['success' => false, 'code' => null, 'expires_at' => null, 'error' => 'Unable to generate a verification code at this time. Please try again later.'];
+            }
+        } while (MinecraftVerification::where('code', $code)->exists());
+
+        $gracePeriodMinutes = config('lighthouse.minecraft_verification_grace_period_minutes');
+        $expiresAt = now()->addMinutes($gracePeriodMinutes);
+
+        // Re-whitelist
+        $rconService = app(MinecraftRconService::class);
+        $whitelistResult = $rconService->executeCommand(
+            $account->whitelistAddCommand(),
+            'whitelist',
+            $account->username,
+            $parent,
+            ['action' => 'parent_retry_verification', 'account_id' => $account->id, 'child_user_id' => $child->id]
+        );
+
+        if (! $whitelistResult['success']) {
+            return ['success' => false, 'code' => null, 'expires_at' => null, 'error' => 'Server is currently offline. Please try again later.'];
+        }
+
+        $originalStatus = $account->status;
+
+        // Set account back to Verifying and create verification record inside try so
+        // rollback covers both mutations if either fails.
+        try {
+            $account->update(['status' => MinecraftAccountStatus::Verifying]);
+
+            MinecraftVerification::create([
+                'user_id' => $child->id,
+                'code' => $code,
+                'account_type' => $account->account_type,
+                'minecraft_username' => $account->username,
+                'minecraft_uuid' => $account->uuid,
+                'status' => 'pending',
+                'expires_at' => $expiresAt,
+                'whitelisted_at' => now(),
+            ]);
+        } catch (\Throwable $e) {
+            \Log::error('Failed to create MinecraftVerification on parent retry', [
+                'parent_id' => $parent->id,
+                'child_id' => $child->id,
+                'account_id' => $account->id,
+                'error' => $e->getMessage(),
+            ]);
+
+            // Rollback: remove whitelist and revert to original status
+            $rconService->executeCommand(
+                $account->whitelistRemoveCommand(),
+                'whitelist',
+                $account->username,
+                $parent,
+                ['action' => 'cleanup_failed_parent_retry']
+            );
+            $account->update(['status' => $originalStatus]);
+
+            return ['success' => false, 'code' => null, 'expires_at' => null, 'error' => 'An error occurred. Please try again later.'];
+        }
+
+        RecordActivity::run(
+            $child,
+            'minecraft_verification_regenerated',
+            "{$parent->name} restarted verification for {$account->account_type->label()} account: {$account->username}"
+        );
+
+        return [
+            'success' => true,
+            'code' => $code,
+            'expires_at' => $expiresAt,
+            'error' => null,
+        ];
+    }
+}

--- a/app/Actions/RemoveChildMinecraftAccount.php
+++ b/app/Actions/RemoveChildMinecraftAccount.php
@@ -26,6 +26,30 @@ class RemoveChildMinecraftAccount
             return ['success' => false, 'message' => 'You do not have permission to manage this account.'];
         }
 
+        // Cancelled/Cancelling accounts are already off the whitelist — hard-delete directly
+        if ($account->status === MinecraftAccountStatus::Cancelled || $account->status === MinecraftAccountStatus::Cancelling) {
+            $username = $account->username;
+            $accountType = $account->account_type;
+            $statusLabel = strtolower($account->status->label());
+            $wasPrimary = $account->is_primary;
+
+            if (! $account->delete()) {
+                return ['success' => false, 'message' => "Failed to remove Minecraft account {$username}."];
+            }
+
+            if ($wasPrimary) {
+                AutoAssignPrimaryAccount::run($child);
+            }
+
+            RecordActivity::run(
+                $child,
+                'minecraft_account_removed_by_parent',
+                "{$parent->name} removed {$statusLabel} {$accountType->label()} account: {$username}"
+            );
+
+            return ['success' => true, 'message' => "Minecraft account {$username} has been removed."];
+        }
+
         if ($account->status !== MinecraftAccountStatus::Active) {
             return ['success' => false, 'message' => 'This account cannot be removed in its current state.'];
         }

--- a/app/Jobs/EscalateUnassignedTickets.php
+++ b/app/Jobs/EscalateUnassignedTickets.php
@@ -45,6 +45,10 @@ class EscalateUnassignedTickets implements ShouldQueue
             ->get()
             ->filter(fn ($user) => $user->can('receive-ticket-escalations'));
 
+        if ($recipients->isEmpty()) {
+            return;
+        }
+
         $systemUser = User::where('email', 'system@lighthouse.local')->first();
 
         foreach ($tickets as $ticket) {

--- a/app/Policies/MinecraftAccountPolicy.php
+++ b/app/Policies/MinecraftAccountPolicy.php
@@ -106,7 +106,9 @@ class MinecraftAccountPolicy
     public function forceDelete(User $user, MinecraftAccount $minecraftAccount): bool
     {
         return ($minecraftAccount->status === MinecraftAccountStatus::Removed
-                || $minecraftAccount->status === MinecraftAccountStatus::Verifying)
+                || $minecraftAccount->status === MinecraftAccountStatus::Verifying
+                || $minecraftAccount->status === MinecraftAccountStatus::Cancelled
+                || $minecraftAccount->status === MinecraftAccountStatus::Cancelling)
             && $user->isAdmin();
     }
 }

--- a/database/factories/MinecraftAccountFactory.php
+++ b/database/factories/MinecraftAccountFactory.php
@@ -98,4 +98,26 @@ class MinecraftAccountFactory extends Factory
             'verified_at' => now()->subDay(),
         ]);
     }
+
+    /**
+     * Indicate that the account has been cancelled (verification never completed).
+     */
+    public function cancelled(): static
+    {
+        return $this->state(fn () => [
+            'status' => MinecraftAccountStatus::Cancelled,
+            'verified_at' => null,
+        ]);
+    }
+
+    /**
+     * Indicate that the account is in the process of being cancelled.
+     */
+    public function cancelling(): static
+    {
+        return $this->state(fn () => [
+            'status' => MinecraftAccountStatus::Cancelling,
+            'verified_at' => null,
+        ]);
+    }
 }

--- a/docs/features/cancelled-minecraft-account-management.md
+++ b/docs/features/cancelled-minecraft-account-management.md
@@ -1,0 +1,742 @@
+# Cancelled Minecraft Account Management -- Technical Documentation
+
+> **Audience:** Project owner, developers, AI agents
+> **Generated:** 2026-03-30
+> **Generator:** `/document-feature` skill
+
+---
+
+## Table of Contents
+
+1. [Overview](#1-overview)
+2. [Database Schema](#2-database-schema)
+3. [Models & Relationships](#3-models--relationships)
+4. [Enums Reference](#4-enums-reference)
+5. [Authorization & Permissions](#5-authorization--permissions)
+6. [Routes](#6-routes)
+7. [User Interface Components](#7-user-interface-components)
+8. [Actions (Business Logic)](#8-actions-business-logic)
+9. [Notifications](#9-notifications)
+10. [Background Jobs](#10-background-jobs)
+11. [Console Commands & Scheduled Tasks](#11-console-commands--scheduled-tasks)
+12. [Services](#12-services)
+13. [Activity Log Entries](#13-activity-log-entries)
+14. [Data Flow Diagrams](#14-data-flow-diagrams)
+15. [Configuration](#15-configuration)
+16. [Test Coverage](#16-test-coverage)
+17. [File Map](#17-file-map)
+18. [Known Issues & Improvement Opportunities](#18-known-issues--improvement-opportunities)
+
+---
+
+## 1. Overview
+
+This feature extends Minecraft account management to handle accounts in `Cancelled` or `Cancelling`
+status — states that arise when the in-game verification flow is abandoned or times out.
+
+Three distinct capabilities are provided:
+
+| Actor | Capability | Mechanism |
+|---|---|---|
+| Admin | Permanently delete (force-delete) a Cancelled/Cancelling account | `ForceDeleteMinecraftAccount` action via admin profile page |
+| Parent | Hard-delete a child's Cancelled/Cancelling account without RCON | `RemoveChildMinecraftAccount` action via parent portal |
+| Parent | Restart verification for a child's Cancelled/Cancelling account | `ParentRegenerateVerificationCode` action via parent portal |
+
+**Why Cancelled/Cancelling accounts are a special case:**
+
+A Cancelled or Cancelling account was never successfully verified. The player was added to
+the whitelist during the verification attempt, but the `/verify` command was never run (or
+the code expired). The server-side whitelist state for these accounts is already cleaned up
+by the time they reach Cancelled status, so neither admin force-delete nor parent hard-delete
+needs to issue a whitelist-remove RCON command. The restart-verification flow, however, must
+re-add the player to the whitelist before creating a new verification record.
+
+---
+
+## 2. Database Schema
+
+### `minecraft_accounts` table
+
+Built up across several migrations from `2026_02_17` through `2026_03_18`.
+
+| Column | Type | Nullable | Notes |
+|---|---|---|---|
+| `id` | bigint (PK) | No | Auto-increment |
+| `user_id` | bigint (FK) | No | References `users.id`, cascade-delete |
+| `username` | varchar | No | Minecraft in-game name; Bedrock names prefixed with `.` |
+| `uuid` | varchar | Yes (unique) | Java UUID or Floodgate UUID for Bedrock |
+| `bedrock_xuid` | varchar | Yes | Bedrock Xbox UID (added `2026_02_28`) |
+| `avatar_url` | varchar | Yes | mc-heads.net avatar URL (added `2026_02_19`) |
+| `account_type` | varchar | No | `java` or `bedrock` (`MinecraftAccountType` enum) |
+| `status` | varchar | No | See Enums Reference; defaults to `active` |
+| `is_primary` | boolean | No | Whether this is the user's primary account (added `2026_02_27`) |
+| `verified_at` | timestamp | Yes | Null for unverified/cancelled accounts |
+| `last_username_check_at` | timestamp | Yes | When username was last synced from Mojang |
+| `created_at` | timestamp | No | |
+| `updated_at` | timestamp | No | |
+
+**Indexes:** `last_username_check_at`, unique on `uuid`.
+
+**Cascade behaviour:** Deleting the parent `users` row cascades-deletes all related
+`minecraft_accounts` rows. Force-deleting an individual `MinecraftAccount` row is a hard
+(permanent) delete — there is no Laravel soft-delete on this model.
+
+---
+
+## 3. Models & Relationships
+
+### `App\Models\MinecraftAccount`
+
+**File:** `app/Models/MinecraftAccount.php`
+
+**Relationships:**
+
+- `user(): BelongsTo` — the `User` who owns this account.
+- `rewards(): HasMany` — `MinecraftReward` records associated with the account.
+
+**Fillable fields:** `user_id`, `username`, `uuid`, `bedrock_xuid`, `avatar_url`,
+`account_type`, `status`, `is_primary`, `verified_at`, `last_username_check_at`.
+
+**Casts:** `account_type` → `MinecraftAccountType`, `status` → `MinecraftAccountStatus`,
+`is_primary` → `boolean`, `verified_at` → `datetime`, `last_username_check_at` → `datetime`.
+
+**Query Scopes:**
+
+| Scope | Filters to |
+|---|---|
+| `scopeActive` | `status = active` |
+| `scopeVerifying` | `status = verifying` |
+| `scopeCancelling` | `status = cancelling` |
+| `scopeCancelled` | `status = cancelled` |
+| `scopeRemoved` | `status = removed` |
+| `scopePrimary` | `is_primary = true` |
+| `scopeCountingTowardLimit` | `status IN (active, verifying, banned)` |
+| `scopeWhereNormalizedUuid` | UUID match ignoring hyphens |
+
+**RCON Command Helpers:**
+
+- `whitelistAddCommand()` — returns `whitelist add <username>` for Java, `fwhitelist add <uuid>` for Bedrock.
+- `whitelistRemoveCommand()` — returns `whitelist remove <username>` for Java, `fwhitelist remove <uuid>` for Bedrock.
+- `syncUserCommand(string $rank, string $staffPosition)` — returns `lh syncuser` command, appending `-bedrock <uuid>` for Bedrock accounts.
+
+---
+
+## 4. Enums Reference
+
+### `App\Enums\MinecraftAccountStatus`
+
+**File:** `app/Enums/MinecraftAccountStatus.php`
+
+Backed enum (`string`).
+
+| Case | Value | Label | Badge Color | Description |
+|---|---|---|---|---|
+| `Verifying` | `verifying` | Pending Verification | `yellow` | Whitelist added; awaiting `/verify` in-game |
+| `Active` | `active` | Active | `green` | Verified and active on the server |
+| `Cancelling` | `cancelling` | Cancelling Verification | `amber` | Verification in the process of being cancelled (transitional) |
+| `Cancelled` | `cancelled` | Cancelled | `red` | Verification was never completed; whitelist cleaned up |
+| `Banned` | `banned` | Banned | `orange` | Account banned from the server |
+| `Removed` | `removed` | Removed | `zinc` | Admin-revoked or user-removed; whitelist removed |
+| `ParentDisabled` | `parent_disabled` | Disabled by Parent | `purple` | Parent toggled Minecraft access off |
+
+**Cancelled/Cancelling vs Removed distinction:**
+
+- `Removed` accounts were once `Active` and have had their whitelist slot removed via the
+  normal revoke or parent-remove flow (RCON `whitelist remove` was issued).
+- `Cancelled`/`Cancelling` accounts never finished verification. Their whitelist entry is
+  already gone (or never fully activated). No RCON call is needed to remove them.
+
+**Account limit counting:** Only `Active`, `Verifying`, and `Banned` statuses count toward
+the per-user `max_minecraft_accounts` limit. `Cancelled`, `Cancelling`, and `Removed`
+accounts do not count against the limit.
+
+---
+
+## 5. Authorization & Permissions
+
+### `App\Policies\MinecraftAccountPolicy`
+
+**File:** `app/Policies/MinecraftAccountPolicy.php`
+
+#### Methods relevant to this feature
+
+**`forceDelete(User $user, MinecraftAccount $minecraftAccount): bool`**
+
+Returns `true` when:
+- The account's status is `Removed`, `Verifying`, `Cancelled`, **or** `Cancelling`
+- AND the authenticated user `isAdmin()`.
+
+```php
+return ($minecraftAccount->status === MinecraftAccountStatus::Removed
+        || $minecraftAccount->status === MinecraftAccountStatus::Verifying
+        || $minecraftAccount->status === MinecraftAccountStatus::Cancelled
+        || $minecraftAccount->status === MinecraftAccountStatus::Cancelling)
+    && $user->isAdmin();
+```
+
+**`revoke(User $user, MinecraftAccount $minecraftAccount): bool`**
+
+Returns `true` when status is `Active` AND user has `User - Manager` role. This is the
+existing admin revoke path for active accounts and is NOT used by this feature.
+
+**`delete(User $user, MinecraftAccount $minecraftAccount): bool`**
+
+Returns `true` when the user owns the account or is an admin. Not directly used for
+Cancelled/Cancelling management (that goes through `forceDelete` for admins or is checked
+inside the Action for parents).
+
+#### Parent portal authorization
+
+Parent-portal operations (`RemoveChildMinecraftAccount`, `ParentRegenerateVerificationCode`)
+are NOT gated through the policy. Instead, each Action performs a direct relationship check:
+
+```php
+if (! $parent->children()->where('child_user_id', $child->id)->exists()) {
+    return ['success' => false, 'message' => 'You do not have permission to manage this account.'];
+}
+```
+
+This check confirms a `parent_child_links` row exists for the pair before proceeding.
+
+#### Permissions matrix
+
+| Operation | Who | Gate / Check |
+|---|---|---|
+| Force-delete Cancelled/Cancelling account | Admin only | `MinecraftAccountPolicy::forceDelete` |
+| Hard-delete child's Cancelled/Cancelling account | Parent only | Inline parent-child relationship check in `RemoveChildMinecraftAccount` |
+| Restart verification for child's Cancelled/Cancelling account | Parent only | Inline parent-child relationship check in `ParentRegenerateVerificationCode` |
+| View parent portal | Authenticated parent | `view-parent-portal` gate |
+| Staff view parent portal | Officer+ staff | `isAtLeastRank(StaffRank::Officer)` check in component mount |
+
+---
+
+## 6. Routes
+
+**File:** `routes/web.php`
+
+```php
+// Parent portal — logged-in parent
+Volt::route('/parent-portal', 'parent-portal.index')
+    ->name('parent-portal.index')
+    ->middleware(['auth', 'verified', 'ensure-dob']);
+
+// Parent portal — staff read-only view of a specific parent
+Volt::route('/parent-portal/{user}', 'parent-portal.index')
+    ->name('parent-portal.show')
+    ->middleware(['auth', 'verified', 'ensure-dob']);
+
+// User profile — admin profile page where force-delete is surfaced
+Route::get('/profile/{user:slug}', [UserController::class, 'show'])
+    ->name('profile.show')
+    ->middleware(['auth', 'can:view,user']);
+```
+
+The profile page (`profile.show`) embeds the `display-basic-details` Volt component which
+renders the Minecraft account list with the admin force-delete button.
+
+---
+
+## 7. User Interface Components
+
+### Admin Profile Page — `display-basic-details`
+
+**File:** `resources/views/livewire/users/display-basic-details.blade.php`
+
+#### Livewire class state (relevant properties)
+
+| Property | Type | Purpose |
+|---|---|---|
+| `$accountToForceDelete` | `?int` | Holds the account ID pending confirmation |
+
+#### Methods
+
+**`confirmForceDelete(int $accountId): void`**
+
+Verifies `@can('forceDelete', $account)` before setting `$accountToForceDelete` and opening
+the `confirm-force-delete-mc-account` modal.
+
+**`forceDeleteMinecraftAccount(): void`**
+
+Re-verifies the policy (`$this->authorize('forceDelete', $account)`), dispatches
+`ForceDeleteMinecraftAccount::run($account, Auth::user())`, closes the modal, refreshes the
+user model, and shows a success or danger toast.
+
+#### Blade rendering logic
+
+Accounts are shown in a list. The rendered button depends on status:
+
+- **`Removed` status:** Shows "Reactivate" (if `@can('reactivate')`) and "Delete" (if
+  `@can('forceDelete')`).
+- **`Cancelled` or `Cancelling` status:** Shows only a "Remove" button (if
+  `@can('forceDelete')`). No reactivation option — these accounts were never verified.
+- **Any other non-Removed status:** Shows a "Revoke" button (if `@can('revoke')`).
+
+The "Remove" label (used for Cancelled/Cancelling) and "Delete" label (used for Removed)
+both call the same `confirmForceDelete()` method and the same underlying action.
+
+#### Modal
+
+`confirm-force-delete-mc-account` — a Flux confirmation modal, opened programmatically by
+`Flux::modal('confirm-force-delete-mc-account')->show()`.
+
+---
+
+### Parent Portal — `parent-portal/index`
+
+**File:** `resources/views/livewire/parent-portal/index.blade.php`
+
+#### Livewire class state (relevant properties)
+
+| Property | Type | Purpose |
+|---|---|---|
+| `$accountToRemoveId` | `?int` | Account ID staged for the confirm-remove modal |
+| `$accountToRemoveName` | `string` | Username shown in confirmation dialog |
+| `$accountToRemoveChildName` | `string` | Child's name shown in confirmation dialog |
+| `$childMcVerificationCodes` | `array` | Keyed by child user ID; holds active code strings |
+| `$childMcExpiresAt` | `array` | Keyed by child user ID; ISO-8601 expiry timestamps |
+| `$isStaffViewing` | `bool` | `#[Locked]`; true when a staff member views another parent's portal |
+
+#### Methods relevant to this feature
+
+**`confirmRemoveChildMcAccount(int $accountId): void`**
+
+Used for Active accounts only. Checks parent-child ownership, then populates
+`$accountToRemoveId`, `$accountToRemoveName`, and `$accountToRemoveChildName` before opening
+the `confirm-remove-mc-account` modal. Blocked in staff-view mode.
+
+**`removeChildMcAccount(): void`**
+
+Called from the confirm modal. Dispatches `RemoveChildMinecraftAccount::run($parent, $accountToRemoveId)`.
+Clears modal state, refreshes `$this->children`, and shows a toast.
+
+**`removeChildCancelledMcAccount(int $accountId): void`**
+
+Directly dispatches `RemoveChildMinecraftAccount::run($parent, $accountId)` without a
+separate confirm modal. The confirmation is handled by a Livewire `wire:confirm` attribute
+on the button itself. Blocked in staff-view mode.
+
+**`restartChildMinecraftVerification(int $accountId): void`**
+
+Dispatches `ParentRegenerateVerificationCode::run($account, $parent)`. On success, stores the
+new code and expiry in `$childMcVerificationCodes[$childId]` and
+`$childMcExpiresAt[$childId]`, resets the `$this->children` computed property, and shows a
+success toast with the `/verify <code>` instruction. On failure, shows a danger toast with
+the error message. Blocked in staff-view mode.
+
+#### Blade rendering logic (Cancelled/Cancelling accounts)
+
+In the Linked Accounts section for each child, each Minecraft account row is rendered based
+on status:
+
+- **`Active` status:** Shows an X-mark remove button (calls `confirmRemoveChildMcAccount`).
+- **`Cancelled` or `Cancelling` status:** Shows two buttons side-by-side:
+  - "Restart" (arrow-path icon) — calls `restartChildMinecraftVerification({{ $mc->id }})`.
+  - X-mark remove button — calls `removeChildCancelledMcAccount({{ $mc->id }})` with a
+    `wire:confirm` native confirmation dialog.
+- Staff-view mode hides all action buttons for all statuses.
+
+#### Modal
+
+`confirm-remove-mc-account` — used for removing Active accounts. Cancelled/Cancelling
+account removal bypasses this modal and uses `wire:confirm` inline instead.
+
+---
+
+## 8. Actions (Business Logic)
+
+All actions use `Lorisleiva\Actions\Concerns\AsAction` and are invoked via `ClassName::run(...)`.
+
+---
+
+### `App\Actions\ForceDeleteMinecraftAccount`
+
+**File:** `app/Actions/ForceDeleteMinecraftAccount.php`
+
+**Signature:** `handle(MinecraftAccount $account, User $admin): array`
+
+**Return shape:** `['success' => bool, 'message' => string]`
+
+**Business rules:**
+
+1. The `$admin` must pass `isAdmin()` — returns failure if not.
+2. The account status must be `Removed`, `Verifying`, `Cancelled`, or `Cancelling` — returns
+   failure for any other status (e.g., Active, Banned).
+3. Captures `$username`, `$accountType`, and `$affectedUser` before deletion (the model will
+   be gone after delete).
+4. Calls `$account->delete()`. This is a hard delete (no soft-delete trait).
+5. Records activity on the affected user (`minecraft_account_permanently_deleted`).
+6. Returns success with the message "Minecraft account permanently deleted. The UUID is now released."
+
+**No RCON call is made.** Cancelled/Cancelling accounts no longer hold a whitelist slot;
+Removed and Verifying accounts have already had RCON cleanup performed earlier in their
+lifecycle.
+
+**Effect:** The row is permanently removed from `minecraft_accounts`. The UUID is released
+and can be registered by any user.
+
+---
+
+### `App\Actions\RemoveChildMinecraftAccount`
+
+**File:** `app/Actions/RemoveChildMinecraftAccount.php`
+
+**Signature:** `handle(User $parent, int $accountId): array`
+
+**Return shape:** `['success' => bool, 'message' => string]`
+
+**Business rules:**
+
+1. Finds the account with `MinecraftAccount::findOrFail($accountId)`.
+2. Verifies the parent-child relationship via `$parent->children()->where('child_user_id', $child->id)->exists()`.
+3. **Cancelled/Cancelling fast path:** If the account status is `Cancelled` or `Cancelling`,
+   hard-deletes directly without any RCON call. Records activity
+   (`minecraft_account_removed_by_parent`) and returns success.
+4. **Active path:** If status is not `Active`, returns failure ("current state"). Otherwise:
+   - Calls `MinecraftRconService::executeCommand($account->whitelistRemoveCommand(), ...)`.
+   - If RCON fails, returns failure without changing any state.
+   - On RCON success, resets rank via `lh setmember <username> default`.
+   - Sets status to `Removed` and saves.
+   - If the account was `is_primary`, clears the flag and calls `AutoAssignPrimaryAccount::run($child)`.
+   - Records activity (`minecraft_account_removed_by_parent`).
+
+**Note:** The Cancelled/Cancelling fast path does not touch RCON at all, since those accounts
+are already off the whitelist.
+
+---
+
+### `App\Actions\ParentRegenerateVerificationCode`
+
+**File:** `app/Actions/ParentRegenerateVerificationCode.php`
+
+**Signature:** `handle(MinecraftAccount $account, User $parent): array`
+
+**Return shape:** `['success' => bool, 'code' => string|null, 'expires_at' => Carbon|null, 'error' => string|null]`
+
+**Business rules (in order):**
+
+1. Verifies parent-child relationship. Returns error if not found.
+2. Checks status is `Cancelled` or `Cancelling`. Returns error for any other status.
+3. Checks `$child->isInBrig()`. Returns error if true.
+4. Checks `$child->parent_allows_minecraft`. Returns error if false.
+5. **Rate limit:** Counts pending `MinecraftVerification` records for the child's `user_id`
+   created in the last hour. If count >= `lighthouse.minecraft_verification_rate_limit_per_hour`,
+   returns error. Rate limit is scoped to the child, not the parent.
+6. **Code generation:** Generates a 6-character alphanumeric code from the charset
+   `2346789ABCDEFGHJKMNPQRTUVWXYZ` (visually unambiguous — no 0, O, 1, I, L, 5, S).
+   Retries up to 100 times to ensure uniqueness. Returns error if 100 attempts are exhausted.
+7. Computes `$expiresAt = now()->addMinutes(lighthouse.minecraft_verification_grace_period_minutes)`.
+8. **Re-whitelist via RCON:** Calls `$rconService->executeCommand($account->whitelistAddCommand(), ...)`.
+   If RCON fails (server offline), returns error without changing any state.
+9. Updates account status to `Verifying`.
+10. Creates a `MinecraftVerification` record with the new code, scoped to the child's `user_id`.
+11. **Rollback on DB failure:** If either the status update or `MinecraftVerification::create()` throws, logs the error,
+    issues a RCON `whitelist remove`, reverts account to its original status (`Cancelled` or `Cancelling`), and returns error.
+12. Records activity on the child (`minecraft_verification_regenerated`).
+13. Returns success with `code` and `expires_at`.
+
+---
+
+## 9. Notifications
+
+This feature does not send any notifications. No `TicketNotificationService` calls or
+`Notification::send()` calls are made by any of the three actions or the UI components.
+
+---
+
+## 10. Background Jobs
+
+This feature does not dispatch any background jobs. All operations are synchronous within
+the Livewire request lifecycle.
+
+---
+
+## 11. Console Commands & Scheduled Tasks
+
+This feature does not introduce any Artisan console commands or scheduled tasks.
+
+---
+
+## 12. Services
+
+### `App\Services\MinecraftRconService`
+
+**File:** `app/Services/MinecraftRconService.php`
+
+Used by `RemoveChildMinecraftAccount` (active-account path only) and
+`ParentRegenerateVerificationCode` (whitelist add, and rollback whitelist remove on failure).
+`ForceDeleteMinecraftAccount` does not use RCON at all.
+
+**Method:** `executeCommand(string $command, string $commandType, ?string $target, ?User $user, array $meta): array`
+
+- Connects to the Minecraft server via RCON (`thedudeguy/rcon` library).
+- Logs every command attempt to `MinecraftCommandLog` (initial status `failed`; updated after
+  the connection attempt completes).
+- For `lh` commands, success is determined by the response starting with `"Success:"`.
+- For all other commands (whitelist, fwhitelist), any successful connection is treated as success.
+- Returns `['success' => bool, 'response' => string|null, 'error' => string|null]`.
+
+**Used commands in this feature:**
+
+| Command | Used by | When |
+|---|---|---|
+| `whitelist add <username>` / `fwhitelist add <uuid>` | `ParentRegenerateVerificationCode` | Re-whitelisting on verification restart |
+| `whitelist remove <username>` / `fwhitelist remove <uuid>` | `ParentRegenerateVerificationCode` | Rollback only, if `MinecraftVerification::create()` fails |
+| `whitelist remove <username>` / `fwhitelist remove <uuid>` | `RemoveChildMinecraftAccount` (active path) | Removing an Active account |
+| `lh setmember <username> default` | `RemoveChildMinecraftAccount` (active path) | Rank reset after whitelist removal |
+
+---
+
+## 13. Activity Log Entries
+
+All entries are written via `RecordActivity::run($model, 'action_key', 'Description.')` and
+stored in the `activity_logs` table.
+
+| Action key | Subject | Description template | Triggered by |
+|---|---|---|---|
+| `minecraft_account_permanently_deleted` | Affected user (`$affectedUser`) | `Admin {admin->name} permanently deleted {accountType->label()} account: {username}` | `ForceDeleteMinecraftAccount` |
+| `minecraft_account_removed_by_parent` | Child user | `{parent->name} removed cancelled {accountType->label()} account: {username}` (Cancelled path) or `{parent->name} removed {accountType->label()} account: {username}` (Active path) | `RemoveChildMinecraftAccount` |
+| `minecraft_verification_regenerated` | Child user | `{parent->name} restarted verification for {accountType->label()} account: {username}` | `ParentRegenerateVerificationCode` |
+
+---
+
+## 14. Data Flow Diagrams
+
+### Flow 1 — Admin Force-Delete (Cancelled/Cancelling account)
+
+```text
+Admin visits /profile/{slug}
+  └─► display-basic-details renders Minecraft account list
+        └─► Account with status Cancelled/Cancelling shows "Remove" button
+              (@can('forceDelete', $account) → MinecraftAccountPolicy::forceDelete)
+  └─► Admin clicks "Remove"
+        └─► confirmForceDelete($accountId)
+              └─► Policy check passes → $accountToForceDelete = $accountId
+              └─► Flux::modal('confirm-force-delete-mc-account')->show()
+  └─► Admin confirms modal
+        └─► forceDeleteMinecraftAccount()
+              └─► $this->authorize('forceDelete', $account)
+              └─► ForceDeleteMinecraftAccount::run($account, Auth::user())
+                    └─► isAdmin() check
+                    └─► Status check (Removed/Verifying/Cancelled/Cancelling)
+                    └─► $account->delete() [hard delete, no RCON]
+                    └─► RecordActivity: minecraft_account_permanently_deleted
+                    └─► return ['success' => true, ...]
+              └─► Flux::modal close
+              └─► $user->refresh()
+              └─► Flux::toast success
+```
+
+### Flow 2 — Parent Remove Cancelled/Cancelling Account
+
+```text
+Parent visits /parent-portal
+  └─► index.blade.php renders children list
+        └─► Each Minecraft account row checks status
+              └─► Cancelled/Cancelling: shows Restart + X-mark buttons
+  └─► Parent clicks X-mark (remove)
+        └─► wire:confirm dialog (browser native)
+  └─► Parent confirms
+        └─► removeChildCancelledMcAccount($accountId)
+              └─► RemoveChildMinecraftAccount::run($parent, $accountId)
+                    └─► findOrFail($accountId)
+                    └─► Parent-child relationship check
+                    └─► Status is Cancelled/Cancelling → fast path
+                          └─► $account->delete() [hard delete, NO RCON]
+                          └─► RecordActivity: minecraft_account_removed_by_parent
+                          └─► return ['success' => true, ...]
+              └─► unset($this->children) [re-query]
+              └─► Flux::toast success
+```
+
+### Flow 3 — Parent Restart Verification (Cancelled/Cancelling account)
+
+```text
+Parent visits /parent-portal
+  └─► index.blade.php renders children list
+        └─► Cancelled/Cancelling account shows "Restart" button
+  └─► Parent clicks "Restart"
+        └─► restartChildMinecraftVerification($accountId)
+              └─► MinecraftAccount::findOrFail($accountId)
+              └─► ParentRegenerateVerificationCode::run($account, $parent)
+                    └─► Parent-child relationship check
+                    └─► Status check (Cancelled/Cancelling only)
+                    └─► isInBrig() check
+                    └─► parent_allows_minecraft check
+                    └─► Rate limit check (child's pending verifications in last hour)
+                    └─► Generate unique 6-char code (up to 100 attempts)
+                    └─► Compute expiresAt = now() + grace_period_minutes
+                    └─► RCON: whitelist add (or fwhitelist add for Bedrock)
+                          └─► If RCON fails → return error (no state change)
+                    └─► $account->update(['status' => Verifying])
+                    └─► MinecraftVerification::create([...])
+                          └─► If DB create fails:
+                                └─► RCON: whitelist remove (rollback)
+                                └─► $account->update(['status' => Cancelled])
+                                └─► Log error
+                                └─► return error
+                    └─► RecordActivity: minecraft_verification_regenerated
+                    └─► return ['success' => true, 'code' => ..., 'expires_at' => ...]
+              └─► $childMcVerificationCodes[$childId] = $result['code']
+              └─► $childMcExpiresAt[$childId] = ...
+              └─► unset($this->children) [re-query]
+              └─► Flux::toast: "Verification restarted! Have the child run /verify {code} in-game."
+              └─► Code box displayed in portal for parent to relay
+```
+
+---
+
+## 15. Configuration
+
+**File:** `config/lighthouse.php`
+
+| Key | Env variable | Default | Description |
+|---|---|---|---|
+| `lighthouse.minecraft_verification_grace_period_minutes` | `MINECRAFT_VERIFICATION_GRACE_PERIOD_MINUTES` | `30` | How long a verification code remains valid (minutes). Used when computing `expires_at` for new `MinecraftVerification` records. |
+| `lighthouse.minecraft_verification_rate_limit_per_hour` | `MINECRAFT_VERIFICATION_RATE_LIMIT_PER_HOUR` | `10` | Maximum number of pending verification attempts a child user may have in any rolling 60-minute window. Applies to the `ParentRegenerateVerificationCode` action. |
+
+---
+
+## 16. Test Coverage
+
+### `ForceDeleteMinecraftAccount`
+
+**File:** `tests/Feature/Minecraft/ForceDeleteMinecraftAccountTest.php`
+
+| Test | Verifies |
+|---|---|
+| `admin can permanently delete a removed account` | Success path for Removed status |
+| `regular user cannot permanently delete` | Non-admin blocked |
+| `cannot permanently delete an active account` | Active status blocked |
+| `records activity log for permanent deletion` | `minecraft_account_permanently_deleted` written |
+| `releases UUID so it can be re-registered` | Row deleted from `minecraft_accounts` |
+| `admin can permanently delete a cancelled account` | Success path for Cancelled status |
+| `admin can permanently delete a cancelling account` | Success path for Cancelling status |
+| `non-admin cannot permanently delete a cancelled account` | Non-admin blocked for Cancelled status |
+
+### `RemoveChildMinecraftAccount`
+
+**File:** `tests/Feature/Actions/Actions/RemoveChildMinecraftAccountTest.php`
+
+| Test | Verifies |
+|---|---|
+| `removes an active minecraft account` | Active path: RCON called, status set to Removed |
+| `rejects removal by non-parent` | Non-parent blocked |
+| `rejects removal of non-active account` | Banned/other status blocked (non-Cancelled/Cancelling) |
+| `fails gracefully when whitelist removal fails` | RCON failure → no state change |
+| `records activity after removal` | `minecraft_account_removed_by_parent` written |
+| `hard-deletes a cancelled child minecraft account without rcon` | Cancelled fast path: row deleted, no RCON, activity written |
+| `hard-deletes a cancelling child minecraft account without rcon` | Cancelling fast path: row deleted |
+| `rejects cancelled account removal by non-parent` | Non-parent blocked even for Cancelled status |
+| `active account path is unaffected by cancelled account changes` | Active path still works correctly |
+
+### `ParentRegenerateVerificationCode`
+
+**File:** `tests/Feature/Minecraft/ParentRegenerateVerificationCodeTest.php`
+
+| Test | Verifies |
+|---|---|
+| `parent can restart verification for a cancelled child account` | Cancelled → Verifying, code returned, MinecraftVerification row created |
+| `parent can restart verification for a cancelling child account` | Cancelling → Verifying |
+| `records activity on child account after restart` | `minecraft_verification_regenerated` written |
+| `fails when parent-child relationship does not exist` | Non-parent blocked |
+| `fails when child is in brig` | Brig check blocks restart |
+| `fails when minecraft access is parent-disabled` | `parent_allows_minecraft = false` blocks restart |
+| `applies rate limiting against child user id not parent` | Rate limit is child-scoped, not parent-scoped |
+| `does not change account state when server is offline` | RCON failure → status unchanged, no verification row |
+
+All tests use Pest (`uses()->group(...)`) and mock `MinecraftRconService` where RCON
+calls are expected.
+
+---
+
+## 17. File Map
+
+```text
+app/
+  Actions/
+    ForceDeleteMinecraftAccount.php        # Admin force-delete action
+    RemoveChildMinecraftAccount.php        # Parent remove child account action
+    ParentRegenerateVerificationCode.php   # Parent restart verification action
+  Enums/
+    MinecraftAccountStatus.php             # All status cases + label() + color()
+  Models/
+    MinecraftAccount.php                   # Model, scopes, RCON helpers
+  Policies/
+    MinecraftAccountPolicy.php             # forceDelete, revoke, delete, reactivate
+  Services/
+    MinecraftRconService.php               # RCON bridge; used by Restart and Active-path Remove
+
+config/
+  lighthouse.php                           # minecraft_verification_* settings
+
+database/
+  factories/
+    MinecraftAccountFactory.php            # cancelled(), cancelling(), active(), etc.
+  migrations/
+    2026_02_17_064252_create_minecraft_accounts_table.php
+    2026_02_19_000001_add_avatar_url_to_minecraft_accounts_table.php
+    2026_02_20_060607_add_status_and_command_id_to_minecraft_accounts_table.php
+    2026_02_20_063640_make_verified_at_nullable_on_minecraft_accounts_table.php
+    2026_02_20_072300_make_verified_at_nullable_on_minecraft_accounts_table.php
+    2026_02_21_100000_add_banned_status_to_minecraft_accounts_table.php
+    2026_02_22_000000_drop_command_id_from_minecraft_accounts_table.php
+    2026_02_26_000000_add_removed_status_to_minecraft_accounts_table.php
+    2026_02_27_100000_add_is_primary_to_minecraft_accounts_table.php
+    2026_02_28_043322_add_bedrock_xuid_to_minecraft_accounts_table.php
+    2026_03_01_000002_add_parent_disabled_status_to_minecraft_accounts_table.php
+    2026_03_18_040000_add_cancelling_status_to_minecraft_accounts_table.php
+
+resources/views/livewire/
+  users/
+    display-basic-details.blade.php        # Admin profile; force-delete button + modal
+  parent-portal/
+    index.blade.php                        # Parent portal; restart + remove buttons
+
+routes/
+  web.php                                  # parent-portal.index, parent-portal.show, profile.show
+
+tests/Feature/
+  Minecraft/
+    ForceDeleteMinecraftAccountTest.php
+    ParentRegenerateVerificationCodeTest.php
+  Actions/Actions/
+    RemoveChildMinecraftAccountTest.php
+```
+
+---
+
+## 18. Known Issues & Improvement Opportunities
+
+1. **`ForceDeleteMinecraftAccount` performs no authorization via policy in the action itself.**
+   The action relies on the Livewire component to check `$this->authorize('forceDelete', $account)`
+   before calling the action. The action only re-checks `isAdmin()` inline. If the action
+   were ever called from a context that does not pre-authorize (e.g., a CLI command or a
+   different component), the admin check inside the action is the only guard. A future
+   improvement could call `$admin->can('forceDelete', $account)` inside `handle()` instead
+   of duplicating the status checks already in the policy.
+
+2. **`removeChildCancelledMcAccount` uses `wire:confirm` (browser native dialog) instead of
+   a Flux modal.** This differs from `confirmRemoveChildMcAccount` (active accounts), which
+   opens a full `confirm-remove-mc-account` Flux modal. The browser native dialog is less
+   visually consistent with the rest of the UI. A Flux confirmation modal would be more
+   consistent.
+
+3. **No notification is sent to the parent or child when verification is restarted.** If the
+   parent is not actively watching the portal, they may not know to relay the new code to
+   the child promptly.
+
+4. **Rate limit is enforced only on `ParentRegenerateVerificationCode`, not on the initial
+   `GenerateVerificationCode` action.** The rate limit protects against repeated restart
+   attempts, but there is no shared enforcement point across both actions. The rate limit
+   configuration key (`minecraft_verification_rate_limit_per_hour`) is the same, suggesting
+   it was intended to be shared, but each action queries the verification table independently.
+
+5. **Code uniqueness check is O(n) sequential.** The `do/while` loop in
+   `ParentRegenerateVerificationCode` (and presumably in `GenerateVerificationCode`) performs
+   up to 100 database queries to confirm uniqueness. At low verification volumes this is
+   inconsequential, but it could be replaced with a unique index constraint + retry-on-
+   constraint-violation approach.
+
+6. **The `Cancelling` status is a transitional state** whose lifecycle is defined elsewhere
+   (likely a scheduled job or the in-game plugin). The documentation for how an account moves
+   from `Verifying` → `Cancelling` → `Cancelled` lives outside this feature's scope.

--- a/docs/features/ticket-escalation.md
+++ b/docs/features/ticket-escalation.md
@@ -239,7 +239,7 @@ The notification follows the exact same channel-selection pattern as `NewTicketN
 
 **Idempotency:** The `escalated_at IS NULL` filter ensures running the job twice in the same minute does not double-notify.
 
-**Performance note:** Step 4 uses `User::all()->filter(...)` — acceptable for a small community application but would need a DB-query approach at scale (see Known Issues).
+**Performance note:** Step 4 pre-filters users at the DB level (admins, all-roles staff, and explicit role holders) before applying the gate check, which limits the in-memory collection. At large scale a fully DB-side query joining `staff_positions`, `role_staff_position`, and `roles` would be more efficient (see Known Issues).
 
 ---
 
@@ -290,7 +290,7 @@ Laravel Scheduler fires every minute
     -> Thread::where(type=Ticket, status=Open, assigned_to_user_id=null,
                      escalated_at=null, created_at <= now()-threshold)->get()
     -> [return if empty]
-    -> User::all()->filter(can('receive-ticket-escalations'))
+    -> User::query()->whereNotNull('admin_granted_at')->orWhereHas(...)->get()->filter(can('receive-ticket-escalations'))
     -> User::where('email','system@lighthouse.local')->first()
     -> foreach ticket:
          foreach recipient:
@@ -431,7 +431,7 @@ Staff clicks "Unassign" in ticket view
 
 ## 18. Known Issues & Improvement Opportunities
 
-1. **`User::all()->filter(...)` in the job** — `EscalateUnassignedTickets` loads all users into memory to filter by gate. For a small community this is fine, but at scale a DB-level query joining `staff_positions`, `role_staff_position`, and `roles` would be more efficient. A HITL issue was noted in PRD #416's out-of-scope section.
+1. **Gate-filtered recipient lookup** — `EscalateUnassignedTickets` pre-filters users at the DB level (admins, all-roles staff, role holders) then applies a gate check in memory. For a small community this is fine, but at scale a fully DB-side query joining `staff_positions`, `role_staff_position`, and `roles` would eliminate the in-memory filter entirely. Noted in PRD #416's out-of-scope section.
 
 2. **No ACP validation for threshold** — The `ticket_escalation_threshold_minutes` config has a `<= 0` guard in the job (returns early, disabling escalation), but there is no validation on the ACP input field itself. An admin could set an unexpectedly large value (e.g., `99999`) with no warning, effectively suppressing escalation without realizing it.
 

--- a/resources/library/books/staff-handbook/05-minecraft/01-account-management/03-removing-cancelled-accounts.md
+++ b/resources/library/books/staff-handbook/05-minecraft/01-account-management/03-removing-cancelled-accounts.md
@@ -1,0 +1,51 @@
+---
+title: 'Removing Cancelled Accounts'
+visibility: staff
+order: 3
+summary: 'How to permanently remove Cancelled or Cancelling Minecraft accounts from a member''s profile.'
+---
+
+## What This Is
+
+A **Cancelled** or **Cancelling Verification** account is one where the member (or their parent) started the linking process but never completed the in-game `/verify` step. These accounts were never fully activated -- they hold no whitelist slot on the server -- and they can accumulate on a member's profile over time.
+
+Admins with the **User - Manager** role can permanently remove these accounts through the member's profile page. This clears the record entirely and frees the UUID for future use.
+
+## Who Can Do This
+
+Only users with the **User - Manager** role can remove Cancelled and Cancelling accounts. This is an admin-only action -- it is not available to standard staff.
+
+## How to Remove a Cancelled Account
+
+1. Go to the member's profile page (search for them in the Admin Control Panel, or navigate to their profile directly).
+2. Scroll down to the **Minecraft Accounts** section.
+3. Find the account showing a **Cancelled** or **Cancelling Verification** status.
+4. Click the **Remove** button next to that account.
+5. A confirmation dialog will appear -- confirm that you want to permanently delete the account.
+6. The account is removed immediately. You'll see a success message, and the account will no longer appear in the list.
+
+## What Happens After
+
+- The account record is **permanently deleted** from the database. This cannot be undone.
+- The Minecraft UUID is released and can be registered again in the future if needed.
+- The deletion is recorded in the member's **activity log** so there's a record of the action.
+- No server (RCON) commands are issued -- Cancelled and Cancelling accounts are already off the whitelist, so no server-side cleanup is needed.
+
+## How This Differs From Revoking
+
+These two actions are easy to mix up:
+
+- **Revoke** -- Used for **Active** accounts. This removes the player from the server whitelist via RCON and sets the account status to Removed. The record stays in the system.
+- **Remove** -- Used for **Cancelled/Cancelling** accounts. This permanently deletes the record. No RCON command is needed because the account was never fully verified.
+
+If you need to remove an Active account, use Revoke instead. The Remove button only appears on Cancelled and Cancelling accounts (as well as Removed accounts, where it shows as "Delete").
+
+## When to Use This
+
+Common reasons to remove a cancelled account:
+
+- A member asks you to clear out a failed linking attempt so they can start fresh.
+- A member's profile has accumulated old cancelled accounts and they want them cleaned up.
+- A child account had a cancelled verification and the parent has already removed it through the Parent Portal, but you're confirming the cleanup is complete.
+
+If a member wants to complete verification rather than remove the account, parents can restart verification from the Parent Portal instead -- they'll see a **Restart** button alongside the Remove button on Cancelled and Cancelling accounts. See [[books/staff-handbook/minecraft/account-management/how-linking-works|How Linking Works]] for background on the verification process. For non-child accounts, the member can start the linking process again themselves.

--- a/resources/library/books/user-handbook/03-website/03-parent-portal/05-cancelled-minecraft-accounts.md
+++ b/resources/library/books/user-handbook/03-website/03-parent-portal/05-cancelled-minecraft-accounts.md
@@ -1,0 +1,52 @@
+---
+title: 'Handling Cancelled Minecraft Accounts'
+visibility: users
+order: 5
+summary: 'What to do when your child''s Minecraft account shows a Cancelled or Cancelling Verification status.'
+---
+
+## What Does "Cancelled" Mean?
+
+When you set up a Minecraft account for your child, they need to join the server and run a `/verify` command with a short code before the account is fully active. If that step doesn't happen -- because the code expires, the child forgets, or something else gets in the way -- the account ends up in a **Cancelled** or **Cancelling Verification** state.
+
+A Cancelled account was never successfully verified, so it's not taking up a whitelist slot on the server. It's essentially a half-finished setup that needs to be either completed or cleared out.
+
+The good news: you have two options right from the Parent Portal.
+
+## Your Two Options
+
+When a child's Minecraft account shows **Cancelled** or **Cancelling Verification** status, two buttons appear next to it:
+
+- **Restart Verification** (the arrow icon) -- Starts the verification process over with a fresh code
+- **Remove** (the X icon) -- Permanently deletes the account record so you can start fresh
+
+Removing the account asks you to confirm before anything happens. Restart Verification runs immediately when you click the button.
+
+## Restarting Verification
+
+If you want your child to verify the account they already set up, use **Restart Verification**. This:
+
+1. Re-adds the Minecraft username to the server whitelist
+2. Generates a new **verification code**
+3. Shows the code in the Parent Portal, just like when you first set up the account
+
+Once you see the new code, have your child:
+
+1. Join the Minecraft server
+2. Type `/verify CODE` in chat (replacing `CODE` with the code shown in the portal)
+
+They have **{{config:lighthouse.minecraft_verification_grace_period_minutes}} minutes** to do this before the code expires.
+
+If the code expires again, you can restart verification as many times as you need. Just be aware that if something is blocking the account -- such as Minecraft access being disabled or your child's account being restricted by staff -- the restart won't work until that's resolved. You'll see a message explaining the reason if that happens.
+
+## Removing the Account
+
+If you'd prefer to start completely fresh -- for example, if the Minecraft username changed or the account was set up by mistake -- use the **Remove** button instead. This permanently deletes the account record.
+
+Because the account was never verified, there's nothing to remove from the server. The process is instant. Once removed, the username is released and can be linked again at any time if needed.
+
+## After Restarting
+
+Once your child successfully runs the `/verify` command in-game, the account status will update to **Active** and everything will work normally from that point on.
+
+If you have trouble getting the account verified and aren't sure what's wrong, open a [[books/user-handbook/website/getting-help/support-tickets|support ticket]] and staff will be happy to help sort it out.

--- a/resources/views/livewire/parent-portal/index.blade.php
+++ b/resources/views/livewire/parent-portal/index.blade.php
@@ -3,6 +3,7 @@
 use App\Actions\CreateChildAccount;
 use App\Actions\GenerateVerificationCode;
 use App\Actions\ReleaseChildToAdult;
+use App\Actions\ParentRegenerateVerificationCode;
 use App\Actions\RemoveChildMinecraftAccount;
 use App\Actions\UpdateChildPermission;
 use App\Enums\MinecraftAccountType;
@@ -445,6 +446,59 @@ new class extends Component {
             Flux::toast($result['message'], 'Error', variant: 'danger');
         }
     }
+
+    public function removeChildCancelledMcAccount(int $accountId): void
+    {
+        if ($this->isStaffViewing) {
+            Flux::toast('This view is read-only.', 'Unauthorized', variant: 'danger');
+            return;
+        }
+
+        $account = \App\Models\MinecraftAccount::findOrFail($accountId);
+        $parent = $this->getTargetUser();
+
+        if (! $parent->children()->where('child_user_id', $account->user_id)->exists()) {
+            Flux::toast('You do not have permission to manage this account.', 'Unauthorized', variant: 'danger');
+            return;
+        }
+
+        if (! in_array($account->status, [\App\Enums\MinecraftAccountStatus::Cancelled, \App\Enums\MinecraftAccountStatus::Cancelling])) {
+            Flux::toast('This account cannot be removed in this way.', 'Error', variant: 'danger');
+            return;
+        }
+
+        $result = RemoveChildMinecraftAccount::run($parent, $accountId);
+
+        if ($result['success']) {
+            unset($this->children);
+            Flux::toast($result['message'], 'Account Removed', variant: 'success');
+        } else {
+            Flux::toast($result['message'], 'Error', variant: 'danger');
+        }
+    }
+
+    public function restartChildMinecraftVerification(int $accountId): void
+    {
+        if ($this->isStaffViewing) {
+            Flux::toast('This view is read-only.', 'Unauthorized', variant: 'danger');
+            return;
+        }
+
+        $account = \App\Models\MinecraftAccount::findOrFail($accountId);
+        $parent = $this->getTargetUser();
+
+        $result = ParentRegenerateVerificationCode::run($account, $parent);
+
+        if ($result['success']) {
+            $childId = $account->user_id;
+            $this->childMcVerificationCodes[$childId] = $result['code'];
+            $this->childMcExpiresAt[$childId] = $result['expires_at']->toIso8601String();
+            unset($this->children);
+            Flux::toast('Verification restarted! Have the child run /verify ' . $result['code'] . ' in-game.', 'Verification Restarted', variant: 'success');
+        } else {
+            Flux::toast($result['error'], 'Error', variant: 'danger');
+        }
+    }
 }; ?>
 
 <div>
@@ -573,6 +627,21 @@ new class extends Component {
                                         @if(! $isStaffViewing && $mc->status === \App\Enums\MinecraftAccountStatus::Active)
                                             <flux:button
                                                 wire:click="confirmRemoveChildMcAccount({{ $mc->id }})"
+                                                variant="ghost"
+                                                size="sm"
+                                                icon="x-mark"
+                                                class="text-red-500"
+                                            />
+                                        @elseif(! $isStaffViewing && ($mc->status === \App\Enums\MinecraftAccountStatus::Cancelled || $mc->status === \App\Enums\MinecraftAccountStatus::Cancelling))
+                                            <flux:button
+                                                wire:click="restartChildMinecraftVerification({{ $mc->id }})"
+                                                variant="ghost"
+                                                size="sm"
+                                                icon="arrow-path"
+                                            >Restart</flux:button>
+                                            <flux:button
+                                                wire:click="removeChildCancelledMcAccount({{ $mc->id }})"
+                                                wire:confirm="Remove {{ $mc->username }} from {{ $child->name }}'s account? This cannot be undone."
                                                 variant="ghost"
                                                 size="sm"
                                                 icon="x-mark"

--- a/resources/views/livewire/users/display-basic-details.blade.php
+++ b/resources/views/livewire/users/display-basic-details.blade.php
@@ -585,7 +585,17 @@ new class extends Component {
                                             </flux:button>
                                         @endcan
                                     </div>
-                                @elseif($account->status !== \App\Enums\MinecraftAccountStatus::Cancelled && $account->status !== \App\Enums\MinecraftAccountStatus::Cancelling && $account->status !== \App\Enums\MinecraftAccountStatus::Removed)
+                                @elseif($account->status === \App\Enums\MinecraftAccountStatus::Cancelled || $account->status === \App\Enums\MinecraftAccountStatus::Cancelling)
+                                    @can('forceDelete', $account)
+                                        <flux:button
+                                            wire:click="confirmForceDelete({{ $account->id }})"
+                                            variant="ghost"
+                                            size="sm"
+                                            class="hover:!text-red-600 dark:hover:!text-red-400 hover:!bg-red-50 dark:hover:!bg-red-950">
+                                            Remove
+                                        </flux:button>
+                                    @endcan
+                                @elseif($account->status !== \App\Enums\MinecraftAccountStatus::Removed)
                                     @can('revoke', $account)
                                         <flux:button
                                             wire:click="confirmRevoke({{ $account->id }})"

--- a/routes/console.php
+++ b/routes/console.php
@@ -62,7 +62,7 @@ Schedule::job(new \App\Jobs\PublishScheduledPosts)
 // Escalate unassigned tickets past the configured threshold
 Schedule::job(new \App\Jobs\EscalateUnassignedTickets)
     ->everyMinute()
-    ->withoutOverlapping()
+    ->withoutOverlapping(5)
     ->onOneServer();
 
 // Cleanup unreferenced blog images monthly

--- a/tests/Feature/Actions/Actions/RemoveChildMinecraftAccountTest.php
+++ b/tests/Feature/Actions/Actions/RemoveChildMinecraftAccountTest.php
@@ -82,3 +82,62 @@ it('records activity after removal', function () {
         'action' => 'minecraft_account_removed_by_parent',
     ]);
 });
+
+it('hard-deletes a cancelled child minecraft account without rcon', function () {
+    $this->mock(MinecraftRconService::class)->shouldNotReceive('executeCommand');
+
+    $parent = User::factory()->adult()->create();
+    $child = User::factory()->minor()->create();
+    ParentChildLink::factory()->create(['parent_user_id' => $parent->id, 'child_user_id' => $child->id]);
+    $account = MinecraftAccount::factory()->cancelled()->create(['user_id' => $child->id]);
+
+    $result = RemoveChildMinecraftAccount::run($parent, $account->id);
+
+    expect($result['success'])->toBeTrue();
+    $this->assertDatabaseMissing('minecraft_accounts', ['id' => $account->id]);
+    $this->assertDatabaseHas('activity_logs', [
+        'subject_type' => User::class,
+        'subject_id' => $child->id,
+        'action' => 'minecraft_account_removed_by_parent',
+    ]);
+});
+
+it('hard-deletes a cancelling child minecraft account without rcon', function () {
+    $this->mock(MinecraftRconService::class)->shouldNotReceive('executeCommand');
+
+    $parent = User::factory()->adult()->create();
+    $child = User::factory()->minor()->create();
+    ParentChildLink::factory()->create(['parent_user_id' => $parent->id, 'child_user_id' => $child->id]);
+    $account = MinecraftAccount::factory()->cancelling()->create(['user_id' => $child->id]);
+
+    $result = RemoveChildMinecraftAccount::run($parent, $account->id);
+
+    expect($result['success'])->toBeTrue();
+    $this->assertDatabaseMissing('minecraft_accounts', ['id' => $account->id]);
+});
+
+it('rejects cancelled account removal by non-parent', function () {
+    $notParent = User::factory()->adult()->create();
+    $child = User::factory()->minor()->create();
+    $account = MinecraftAccount::factory()->cancelled()->create(['user_id' => $child->id]);
+
+    $result = RemoveChildMinecraftAccount::run($notParent, $account->id);
+
+    expect($result['success'])->toBeFalse()
+        ->and($result['message'])->toContain('permission');
+    $this->assertDatabaseHas('minecraft_accounts', ['id' => $account->id]);
+});
+
+it('active account path is unaffected by cancelled account changes', function () {
+    $this->mock(MinecraftRconService::class)->shouldReceive('executeCommand')->twice()->andReturn(['success' => true, 'response' => null, 'error' => null]);
+
+    $parent = User::factory()->adult()->create();
+    $child = User::factory()->minor()->create();
+    ParentChildLink::factory()->create(['parent_user_id' => $parent->id, 'child_user_id' => $child->id]);
+    $account = MinecraftAccount::factory()->active()->create(['user_id' => $child->id]);
+
+    $result = RemoveChildMinecraftAccount::run($parent, $account->id);
+
+    expect($result['success'])->toBeTrue()
+        ->and($account->fresh()->status)->toBe(MinecraftAccountStatus::Removed);
+});

--- a/tests/Feature/Jobs/EscalateUnassignedTicketsTest.php
+++ b/tests/Feature/Jobs/EscalateUnassignedTicketsTest.php
@@ -208,7 +208,11 @@ describe('EscalateUnassignedTickets Job', function () {
     it('posts a system message in the thread when escalating', function () {
         Notification::fake();
 
-        // System user is seeded by migration; the job uses it to post system messages
+        User::firstOrCreate(
+            ['email' => 'system@lighthouse.local'],
+            ['name' => 'System', 'password' => 'n/a']
+        );
+
         User::factory()
             ->withRole('Ticket Escalation - Receiver')
             ->create(['notification_preferences' => ['staff_alerts' => ['email' => true]]]);

--- a/tests/Feature/Livewire/ParentPortalPhase3Test.php
+++ b/tests/Feature/Livewire/ParentPortalPhase3Test.php
@@ -102,3 +102,18 @@ it('blocks MC removal for non-child account', function () {
 
     expect($account->fresh()->status)->toBe(MinecraftAccountStatus::Active);
 });
+
+it('blocks cancelled MC removal for non-child account', function () {
+    $parent = User::factory()->adult()->create();
+    $stranger = User::factory()->create();
+    $account = MinecraftAccount::factory()->cancelled()->create([
+        'user_id' => $stranger->id,
+    ]);
+
+    actingAs($parent);
+
+    Livewire\Volt\Volt::test('parent-portal.index')
+        ->call('removeChildCancelledMcAccount', $account->id);
+
+    $this->assertDatabaseHas('minecraft_accounts', ['id' => $account->id]);
+});

--- a/tests/Feature/Minecraft/ForceDeleteMinecraftAccountTest.php
+++ b/tests/Feature/Minecraft/ForceDeleteMinecraftAccountTest.php
@@ -60,3 +60,30 @@ test('releases UUID so it can be re-registered', function () {
     // UUID should no longer exist in the database
     $this->assertDatabaseMissing('minecraft_accounts', ['uuid' => $uuid]);
 });
+
+test('admin can permanently delete a cancelled account', function () {
+    $account = MinecraftAccount::factory()->for($this->regularUser)->cancelled()->create();
+
+    $result = $this->action->handle($account, $this->admin);
+
+    expect($result['success'])->toBeTrue();
+    $this->assertDatabaseMissing('minecraft_accounts', ['id' => $account->id]);
+});
+
+test('admin can permanently delete a cancelling account', function () {
+    $account = MinecraftAccount::factory()->for($this->regularUser)->cancelling()->create();
+
+    $result = $this->action->handle($account, $this->admin);
+
+    expect($result['success'])->toBeTrue();
+    $this->assertDatabaseMissing('minecraft_accounts', ['id' => $account->id]);
+});
+
+test('non-admin cannot permanently delete a cancelled account', function () {
+    $account = MinecraftAccount::factory()->for($this->regularUser)->cancelled()->create();
+
+    $result = $this->action->handle($account, $this->regularUser);
+
+    expect($result['success'])->toBeFalse();
+    $this->assertDatabaseHas('minecraft_accounts', ['id' => $account->id]);
+});

--- a/tests/Feature/Minecraft/ParentRegenerateVerificationCodeTest.php
+++ b/tests/Feature/Minecraft/ParentRegenerateVerificationCodeTest.php
@@ -1,0 +1,150 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Actions\ParentRegenerateVerificationCode;
+use App\Enums\MinecraftAccountStatus;
+use App\Enums\MinecraftAccountType;
+use App\Models\MinecraftAccount;
+use App\Models\MinecraftVerification;
+use App\Models\ParentChildLink;
+use App\Models\User;
+use App\Services\MinecraftRconService;
+
+uses()->group('parent-portal', 'minecraft');
+
+beforeEach(function () {
+    $this->parent = User::factory()->adult()->create();
+    $this->child = User::factory()->minor()->create();
+    ParentChildLink::factory()->create(['parent_user_id' => $this->parent->id, 'child_user_id' => $this->child->id]);
+
+    $this->mock(MinecraftRconService::class, function ($mock) {
+        $mock->shouldReceive('executeCommand')
+            ->andReturn(['success' => true, 'response' => 'OK']);
+    });
+});
+
+it('parent can restart verification for a cancelled child account', function () {
+    $account = MinecraftAccount::factory()->cancelled()->create([
+        'user_id' => $this->child->id,
+        'username' => 'ChildPlayer',
+        'uuid' => '069a79f4-44e9-4726-a5be-fca90e38aaf5',
+        'account_type' => MinecraftAccountType::Java,
+    ]);
+
+    $result = ParentRegenerateVerificationCode::run($account, $this->parent);
+
+    expect($result['success'])->toBeTrue()
+        ->and($result['code'])->toHaveLength(6)
+        ->and($result['expires_at'])->not->toBeNull()
+        ->and($result['error'])->toBeNull();
+
+    expect($account->fresh()->status)->toBe(MinecraftAccountStatus::Verifying);
+
+    $this->assertDatabaseHas('minecraft_verifications', [
+        'user_id' => $this->child->id,
+        'minecraft_username' => 'ChildPlayer',
+        'status' => 'pending',
+    ]);
+});
+
+it('parent can restart verification for a cancelling child account', function () {
+    $account = MinecraftAccount::factory()->cancelling()->create([
+        'user_id' => $this->child->id,
+    ]);
+
+    $result = ParentRegenerateVerificationCode::run($account, $this->parent);
+
+    expect($result['success'])->toBeTrue();
+    expect($account->fresh()->status)->toBe(MinecraftAccountStatus::Verifying);
+});
+
+it('records activity on child account after restart', function () {
+    $account = MinecraftAccount::factory()->cancelled()->create([
+        'user_id' => $this->child->id,
+    ]);
+
+    ParentRegenerateVerificationCode::run($account, $this->parent);
+
+    $this->assertDatabaseHas('activity_logs', [
+        'subject_type' => User::class,
+        'subject_id' => $this->child->id,
+        'action' => 'minecraft_verification_regenerated',
+    ]);
+});
+
+it('fails when parent-child relationship does not exist', function () {
+    $otherChild = User::factory()->minor()->create();
+    $account = MinecraftAccount::factory()->cancelled()->create([
+        'user_id' => $otherChild->id,
+    ]);
+
+    $result = ParentRegenerateVerificationCode::run($account, $this->parent);
+
+    expect($result['success'])->toBeFalse()
+        ->and($result['error'])->toContain('permission');
+    expect($account->fresh()->status)->toBe(MinecraftAccountStatus::Cancelled);
+});
+
+it('fails when child is in brig', function () {
+    $this->child->update(['in_brig' => true]);
+    $account = MinecraftAccount::factory()->cancelled()->create([
+        'user_id' => $this->child->id,
+    ]);
+
+    $result = ParentRegenerateVerificationCode::run($account, $this->parent);
+
+    expect($result['success'])->toBeFalse()
+        ->and($result['error'])->toContain('brig');
+});
+
+it('fails when minecraft access is parent-disabled', function () {
+    $this->child->update(['parent_allows_minecraft' => false]);
+    $account = MinecraftAccount::factory()->cancelled()->create([
+        'user_id' => $this->child->id,
+    ]);
+
+    $result = ParentRegenerateVerificationCode::run($account, $this->parent);
+
+    expect($result['success'])->toBeFalse()
+        ->and($result['error'])->toContain('disabled');
+});
+
+it('applies rate limiting against child user id not parent', function () {
+    $rateLimit = config('lighthouse.minecraft_verification_rate_limit_per_hour');
+
+    // Create verifications scoped to the child (not the parent)
+    MinecraftVerification::factory()->count($rateLimit)->create([
+        'user_id' => $this->child->id,
+        'status' => 'pending',
+        'expires_at' => now()->addHour(),
+        'created_at' => now()->subMinutes(30),
+    ]);
+
+    $account = MinecraftAccount::factory()->cancelled()->create([
+        'user_id' => $this->child->id,
+    ]);
+
+    $result = ParentRegenerateVerificationCode::run($account, $this->parent);
+
+    expect($result['success'])->toBeFalse()
+        ->and($result['error'])->toContain('rate limit');
+});
+
+it('does not change account state when server is offline', function () {
+    $this->mock(MinecraftRconService::class, function ($mock) {
+        $mock->shouldReceive('executeCommand')
+            ->andReturn(['success' => false, 'response' => null, 'error' => 'Connection refused']);
+    });
+
+    $account = MinecraftAccount::factory()->cancelled()->create([
+        'user_id' => $this->child->id,
+    ]);
+
+    $result = ParentRegenerateVerificationCode::run($account, $this->parent);
+
+    expect($result['success'])->toBeFalse()
+        ->and($result['error'])->toContain('offline');
+    expect($account->fresh()->status)->toBe(MinecraftAccountStatus::Cancelled);
+    $this->assertDatabaseMissing('minecraft_verifications', ['user_id' => $this->child->id]);
+});

--- a/tests/Feature/Tickets/ViewTicketTest.php
+++ b/tests/Feature/Tickets/ViewTicketTest.php
@@ -178,7 +178,7 @@ describe('View Ticket Component', function () {
 
         $thread->refresh();
         expect($thread->assigned_to_user_id)->toBe($assignee->id)
-            ->and($thread->escalated_at)->not->toBeNull();
+            ->and($thread->escalated_at->toDateTimeString())->toBe($escalatedAt->toDateTimeString());
     })->done();
 
     // TODO: Re-enable after PRD #280 completion — command officer no longer bypasses before() hook


### PR DESCRIPTION
…hild (#432)

* PRD: Rank-Based Role Assignments & Role Naming Standardization (#335)

* feat: add rank-based role infrastructure, rename roles to Feature - Tier convention

- Create role_staff_rank pivot table for assigning roles to staff ranks
- Rename 14 existing roles to Feature - Tier naming convention
- Seed 12 new feature-scoped roles (Staff Access, Ticket, Task, Meeting, etc.)
- Extend User::hasRole() with fourth check for rank-based role assignments
- Update all role name references across gates, policies, and tests
- No rank inheritance — each rank gets explicit assignments only

Closes #325



* feat: migrate staff access gates from rank checks to Staff Access role

Replace isAtLeastRank() checks with hasRole('Staff Access') for:
- view-acp, view-ready-room, view-docs-staff, edit-staff-bio
- view-user-discipline-reports (staff view part) Migrate view-docs-officer to hasRole('Officer Docs - Viewer') JrCrew display/privacy checks remain as rank checks per PRD

Closes #326



* docs: update branch naming convention to use hyphen separator

PRD branches use prd-<name> (hyphen) instead of prd/<name> (slash) to avoid git ref hierarchy conflicts with issue sub-branches.



* fix: handle HTML entity encoding in blog community story test

Names with apostrophes (e.g., O'Reilly) are HTML-encoded in rendered output. Use e() to match the encoded form in assertions.



* feat: migrate ticket, task, and meeting policies to role-based checks #327

Replace all isAtLeastRank() checks in ThreadPolicy, MessagePolicy, TaskPolicy, MeetingPolicy, and MeetingNotePolicy with hasRole() checks for the new feature-scoped roles:

- Ticket - User: viewDepartment, createAsStaff, addParticipant, internalNotes, changeStatus, close, createTopic
- Ticket - Manager: assign, reroute, viewFlagged
- Task - Department: create/update with department scoping
- Task - Manager: create/update for any department
- Meeting - Department: edit notes for own department
- Meeting - Secretary: edit notes for all departments
- Staff Access: view meetings (was CrewMember+ rank)

Also updates view-ticket Livewire component rank checks.



* feat: add role-based policy tests and update existing tests for #327

Add comprehensive tests for the new role-based policies:
- TicketRolePolicyTest: 24 tests for Ticket - User and Ticket - Manager
- TaskRolePolicyTest: 9 tests including department scoping
- MeetingRolePolicyTest: 15 tests for all meeting role tiers

Update existing tests to use role-based factories instead of rank-based:
- Add Ticket - User/Manager roles to staff users in ticket tests
- Add Task - Department/Manager roles to staff users in task tests
- Update ThreadAuthorizationTest for role-based assertions
- Update TopicPolicyTest and ViewTopicTest for Ticket - User role
- Update DiscussionFlaggingTest for Ticket - Manager role

Closes #327



* feat: migrate remaining policies/gates to role-based checks #328

- Internal notes: ThreadPolicy and MessagePolicy use Internal Note - Manager
- DisciplineReportPolicy: viewAny/view use Staff Access, create uses Discipline Report - Manager, update removes officer rank fallback
- review-staff-applications gate: Applicant Review - All and Applicant Review - Department with department scoping
- StaffApplicationPolicy: viewAny uses applicant review roles
- PagePolicy: all methods use Page - Editor role only
- CreateDisciplineReport: notification check uses Publisher role
- Library views: use Staff Access and Officer Docs - Viewer roles
- view-report and discipline-reports-card: use Staff Access role



* feat: add role-based tests for notes, discipline, applicant review, pages #328

New test files:
- DisciplineReportRolePolicyTest: 11 tests for Manager/Publisher/Staff Access
- ApplicantReviewRolePolicyTest: 10 tests with department scoping
- PageRolePolicyTest: 12 tests for Page - Editor role
- InternalNoteRolePolicyTest: 5 tests for Internal Note - Manager

Updated existing tests for role-based assertions:
- TicketRolePolicyTest: internal notes now use Internal Note - Manager
- ViewTicketTest/ViewTopicTest: internal note staff checks use new role
- RoleBasedGatesTest: review-staff-applications uses applicant review roles
- DisciplineReportPolicyTest: rank checks replaced with role checks
- StaffApplicationPolicyTest: viewAny uses applicant review roles
- CreateDisciplineReportTest: notification uses Publisher role
- DisciplineReportsCardTest/StaffApplicationReviewTest: updated for roles

Closes #328



* feat: add grouped role picker, rank cards, and rank role management #329

- Create reusable grouped-role-picker Livewire component with collapsible feature groups and toggle-based role selection
- Add Role::group attribute for grouping by feature prefix
- Add three rank cards (Jr Crew, Crew Member, Officer) to staff positions page showing assigned roles per rank
- Add rank role CRUD: admin can add/remove roles from ranks via the grouped picker modal
- Refactor position role assignment to use same grouped picker
- Non-admin staff see rank cards in read-only mode
- Unified event-based role management (onRoleAdded/onRoleRemoved) handles both rank and position role changes

Closes #329



* feat: add rank roles section to profile page #330

- Add distinct rank roles section to staff details card on profile
- Section labeled with rank name (e.g., "Officer Roles", "Crew Member Roles")
- Displays role badges with correct Feature - Tier names, colors, icons
- Section hidden when user has no rank or rank has no assigned roles
- Visibility uses Staff Access role (same as position roles)
- Update existing role visibility check from isAtLeastRank to hasRole
- 5 new tests covering visibility, hiding, admin access, rank labeling

Closes #330



* docs: add technical documentation for rank-based role assignments #307



* docs: update staff handbook for rank-based role assignments #307

- Update "How Roles Work" page for rank roles and Feature - Tier naming
- Rewrite "Role Reference" with all 30+ roles in Feature - Tier format
- Update "Managing Position Roles" for grouped picker UI
- Add new "Managing Rank Roles" page (officer visibility)
- Update section index



* chore: add CodeRabbit config with staging branch auto-review

Enable auto-reviews on PRs targeting staging (not just main). Disable auto-labeling to prevent interference with PRD labels.



* fix: address CodeRabbit review feedback for PRD #307

- view-ticket: replace bare hasRole checks with policy-based can() calls so admin bypass and department scoping work correctly
- PagePolicy: make view() user nullable so guests can view published pages
- admin-manage-staff-positions: validate activeRankValue against StaffRank enum to prevent tampered Livewire payloads
- SubmitBlogPostForReview: include rank-assigned Blog authors in notification recipients (was only checking position roles)
- seed migration down(): exclude pre-existing renamed roles from deletion
- display-basic-details: add wire:key to role badge loops
- Staff docs: fix PII - Viewer description, clarify rank change behavior



* fix: address CodeRabbit round 2 feedback for PRD #307

- TaskPolicy: require staff_department for Task - Department on create
- MeetingNotePolicy: require staff_department for Meeting - Department on create
- Seed migration down(): only skip Discipline Report - Publisher (pre-existing); Staff Access is new and should be deleted on rollback
- Blade template: use tryFrom() instead of from() for defensive rendering



---------



* fix: address test feedback for Rank-Based Role Assignments (#338)

* feat: add rank-based role infrastructure, rename roles to Feature - Tier convention

- Create role_staff_rank pivot table for assigning roles to staff ranks
- Rename 14 existing roles to Feature - Tier naming convention
- Seed 12 new feature-scoped roles (Staff Access, Ticket, Task, Meeting, etc.)
- Extend User::hasRole() with fourth check for rank-based role assignments
- Update all role name references across gates, policies, and tests
- No rank inheritance — each rank gets explicit assignments only

Closes #325



* feat: migrate staff access gates from rank checks to Staff Access role

Replace isAtLeastRank() checks with hasRole('Staff Access') for:
- view-acp, view-ready-room, view-docs-staff, edit-staff-bio
- view-user-discipline-reports (staff view part) Migrate view-docs-officer to hasRole('Officer Docs - Viewer') JrCrew display/privacy checks remain as rank checks per PRD

Closes #326



* docs: update branch naming convention to use hyphen separator

PRD branches use prd-<name> (hyphen) instead of prd/<name> (slash) to avoid git ref hierarchy conflicts with issue sub-branches.



* fix: handle HTML entity encoding in blog community story test

Names with apostrophes (e.g., O'Reilly) are HTML-encoded in rendered output. Use e() to match the encoded form in assertions.



* feat: migrate ticket, task, and meeting policies to role-based checks #327

Replace all isAtLeastRank() checks in ThreadPolicy, MessagePolicy, TaskPolicy, MeetingPolicy, and MeetingNotePolicy with hasRole() checks for the new feature-scoped roles:

- Ticket - User: viewDepartment, createAsStaff, addParticipant, internalNotes, changeStatus, close, createTopic
- Ticket - Manager: assign, reroute, viewFlagged
- Task - Department: create/update with department scoping
- Task - Manager: create/update for any department
- Meeting - Department: edit notes for own department
- Meeting - Secretary: edit notes for all departments
- Staff Access: view meetings (was CrewMember+ rank)

Also updates view-ticket Livewire component rank checks.



* feat: add role-based policy tests and update existing tests for #327

Add comprehensive tests for the new role-based policies:
- TicketRolePolicyTest: 24 tests for Ticket - User and Ticket - Manager
- TaskRolePolicyTest: 9 tests including department scoping
- MeetingRolePolicyTest: 15 tests for all meeting role tiers

Update existing tests to use role-based factories instead of rank-based:
- Add Ticket - User/Manager roles to staff users in ticket tests
- Add Task - Department/Manager roles to staff users in task tests
- Update ThreadAuthorizationTest for role-based assertions
- Update TopicPolicyTest and ViewTopicTest for Ticket - User role
- Update DiscussionFlaggingTest for Ticket - Manager role

Closes #327



* feat: migrate remaining policies/gates to role-based checks #328

- Internal notes: ThreadPolicy and MessagePolicy use Internal Note - Manager
- DisciplineReportPolicy: viewAny/view use Staff Access, create uses Discipline Report - Manager, update removes officer rank fallback
- review-staff-applications gate: Applicant Review - All and Applicant Review - Department with department scoping
- StaffApplicationPolicy: viewAny uses applicant review roles
- PagePolicy: all methods use Page - Editor role only
- CreateDisciplineReport: notification check uses Publisher role
- Library views: use Staff Access and Officer Docs - Viewer roles
- view-report and discipline-reports-card: use Staff Access role



* feat: add role-based tests for notes, discipline, applicant review, pages #328

New test files:
- DisciplineReportRolePolicyTest: 11 tests for Manager/Publisher/Staff Access
- ApplicantReviewRolePolicyTest: 10 tests with department scoping
- PageRolePolicyTest: 12 tests for Page - Editor role
- InternalNoteRolePolicyTest: 5 tests for Internal Note - Manager

Updated existing tests for role-based assertions:
- TicketRolePolicyTest: internal notes now use Internal Note - Manager
- ViewTicketTest/ViewTopicTest: internal note staff checks use new role
- RoleBasedGatesTest: review-staff-applications uses applicant review roles
- DisciplineReportPolicyTest: rank checks replaced with role checks
- StaffApplicationPolicyTest: viewAny uses applicant review roles
- CreateDisciplineReportTest: notification uses Publisher role
- DisciplineReportsCardTest/StaffApplicationReviewTest: updated for roles

Closes #328



* feat: add grouped role picker, rank cards, and rank role management #329

- Create reusable grouped-role-picker Livewire component with collapsible feature groups and toggle-based role selection
- Add Role::group attribute for grouping by feature prefix
- Add three rank cards (Jr Crew, Crew Member, Officer) to staff positions page showing assigned roles per rank
- Add rank role CRUD: admin can add/remove roles from ranks via the grouped picker modal
- Refactor position role assignment to use same grouped picker
- Non-admin staff see rank cards in read-only mode
- Unified event-based role management (onRoleAdded/onRoleRemoved) handles both rank and position role changes

Closes #329



* feat: add rank roles section to profile page #330

- Add distinct rank roles section to staff details card on profile
- Section labeled with rank name (e.g., "Officer Roles", "Crew Member Roles")
- Displays role badges with correct Feature - Tier names, colors, icons
- Section hidden when user has no rank or rank has no assigned roles
- Visibility uses Staff Access role (same as position roles)
- Update existing role visibility check from isAtLeastRank to hasRole
- 5 new tests covering visibility, hiding, admin access, rank labeling

Closes #330



* docs: add technical documentation for rank-based role assignments #307



* docs: update staff handbook for rank-based role assignments #307

- Update "How Roles Work" page for rank roles and Feature - Tier naming
- Rewrite "Role Reference" with all 30+ roles in Feature - Tier format
- Update "Managing Position Roles" for grouped picker UI
- Add new "Managing Rank Roles" page (officer visibility)
- Update section index



* chore: add CodeRabbit config with staging branch auto-review

Enable auto-reviews on PRs targeting staging (not just main). Disable auto-labeling to prevent interference with PRD labels.



* fix: address CodeRabbit review feedback for PRD #307

- view-ticket: replace bare hasRole checks with policy-based can() calls so admin bypass and department scoping work correctly
- PagePolicy: make view() user nullable so guests can view published pages
- admin-manage-staff-positions: validate activeRankValue against StaffRank enum to prevent tampered Livewire payloads
- SubmitBlogPostForReview: include rank-assigned Blog authors in notification recipients (was only checking position roles)
- seed migration down(): exclude pre-existing renamed roles from deletion
- display-basic-details: add wire:key to role badge loops
- Staff docs: fix PII - Viewer description, clarify rank change behavior



* fix: address CodeRabbit round 2 feedback for PRD #307

- TaskPolicy: require staff_department for Task - Department on create
- MeetingNotePolicy: require staff_department for Meeting - Department on create
- Seed migration down(): only skip Discipline Report - Publisher (pre-existing); Staff Access is new and should be deleted on rollback
- Blade template: use tryFrom() instead of from() for defensive rendering



* fix: require Traveler+ to apply for staff positions

Stowaway users could click Apply but saw a rejection message. Now the policy correctly requires Traveler membership level to create an application, hiding the button entirely for lower levels.

Fixes #336



* fix: include rank-assigned roles in Check Role Usage

The unassigned roles check only looked at position role assignments. Now it also checks rank role assignments, so roles assigned to Jr Crew, Crew Member, or Officer ranks are correctly shown as assigned.

Fixes #337



---------



* PRD: Automatic Staff Meeting Lumen Payouts (#345)

* feat: add MeetingPayout model, migration, and SiteConfig seed keys #342

- Creates meeting_payouts table with unique (meeting_id, user_id) constraint
- Seeds meeting_payout_jr_crew/crew_member/officer SiteConfig keys
- Adds MeetingPayout model with meeting/user/minecraftAccount relationships
- Adds payouts() hasMany to Meeting model



* feat: add ProcessMeetingPayouts action and hook into CompleteMeetingConfirmed #342

- ProcessMeetingPayouts evaluates eligibility per rank rules (form submission required for all; attendance also required for Officers)
- Skips users missing MC account, rank payout 0, excluded list, no form, no attendance
- Sends money give RCON command synchronously; marks failed on RCON error without blocking
- Duplicate prevention via unique (meeting_id, user_id) check
- Logs activity with paid/skipped/failed counts
- manage-meeting calls ProcessMeetingPayouts::run() after completeMeeting()



* test: add ProcessMeetingPayouts test coverage #342

Tests all eligibility scenarios: Jr Crew/Crew Member (form), Officer (form+attendance), no MC account, rank disabled, excluded by manager, RCON failure, duplicate prevention, and activity log counts.

Closes #342



* feat: add payout preview component during Finalizing step #343

- New meeting.payout-preview Volt component showing eligibility table with Name, Rank, Form, Attended, MC Account, Amount, and Exclude toggle
- Eligible users default to included (toggle ON); ineligible shown grayed out with skip reason (form not submitted, did not attend, no MC account, rank payout disabled)
- Manager can exclude individual users via toggle; excluded IDs dispatched to parent via payoutExcludedUsersChanged event
- manage-meeting tracks excludedPayoutUserIds and passes them to ProcessMeetingPayouts::run() on CompleteMeetingConfirmed
- Preview hidden entirely when all rank payout amounts are 0
- Toggle gated behind Meeting - Manager policy
- 10 Livewire component tests added

Closes #343



* feat: add payout summary component on completed meeting page #344

- New meeting.payout-summary Volt component showing permanent audit trail of payout results from MeetingPayout records
- Summary header shows X paid (Y Lumens total), Z skipped, W failed
- Detail table shows Name, Amount, Status badge, and skip/fail reason
- Component hidden when no payout records exist (pre-feature meetings)
- Embedded in completed meeting view gated behind isStaffMeeting()
- 9 Livewire component tests added

Closes #344



* docs: add documentation for Staff Meeting Lumen Payouts #341

Technical doc:
- docs/features/Staff Meeting Lumen Payouts.md

User handbook (staff visibility):
- 03-website/08-staff-meetings/_index.md
- 03-website/08-staff-meetings/01-meeting-payouts.md
- 03-website/08-staff-meetings/02-managing-payouts.md

Staff handbook:
- 04-meetings-and-tasks/01-meetings/04-lumen-payouts.md



* fix: detect RCON failures correctly in ProcessMeetingPayouts #341

MinecraftRconService::executeCommand() catches exceptions internally and returns ['success' => bool, 'error' => ...] — it never throws. The previous try-catch around SendMinecraftCommand::run() was therefore unreachable, causing RCON failures to be silently recorded as 'paid'.

Fixed by calling MinecraftRconService::executeCommand() directly and checking $result['success'] before creating the payout record.

Also updated the test mock to return a failure array instead of throwing, and added 'text' language specifiers to data flow code fences in the docs.



* fix: make ProcessMeetingPayouts idempotent against process crashes #341

Persist a 'failed' placeholder MeetingPayout record before firing the RCON command. The unique (meeting_id, user_id) constraint becomes the idempotency guard: if the process crashes after RCON succeeds but before the DB write, a retry finds the existing record via exists() and skips re-firing the command, preventing double-payment.

Added test covering the crash-recovery path (failed placeholder exists, RCON must not be called again).



* fix: address CodeRabbit round 2 feedback for PRD #341

- Add 'pending' to meeting_payouts status enum; use as idempotency placeholder before RCON fires (distinguishes interrupted-before-RCON from a real RCON failure, clearer semantics for admins)
- Clamp SiteConfig payout amounts with max(0,...) and guard with <= 0 to prevent negative values from reaching the money give command
- Show 'Pending' badge and interrupted count in payout summary UI
- Add tests for negative config clamping and pending badge rendering



* fix: address CodeRabbit round 3 feedback for PRD #341

- Track pendingCount separately; pending records are no longer miscounted as failures in the activity log. The exists() guard now fetches the record and counts pending payouts so interrupted runs surface correctly in the summary.
- Add authorize('view', $meeting) to payout-summary mount() so non-staff users cannot view payout data directly via the component.
- Add tests: pending activity log count, unauthorized access (403).



* fix: add MeetingPayoutFactory and use it in tests #341

CodeRabbit: use the factory pattern instead of direct Model::create() in test helpers. Created MeetingPayoutFactory with paid/skipped/failed/ pending states; added HasFactory to MeetingPayout model; updated the addPayout() test helper in PayoutSummaryTest to use the factory.



---------



* fix: address test feedback for PRD #341 — payout preview UI updates (#351)

* feat: update deploy notifier to trigger on PR merge to staging with description

- Trigger changed from push to pull_request closed+merged on staging only
- Include PR title, author, body (description), and PR URL in Discord message
- Pass PR fields through env vars to safely handle special characters

* Ignoring claude scheduled tasks lock file

* fix: update payout preview UI — relabel columns, hide attendance for non-officers, group by department

1. Rename "Form" column to "Staff Update Submitted"
2. Rename "Include" column to "Payout Authorized"
3. Show a dash in the Attended column for Jr Crew and Crew Members (attendance not required for their rank)
4. Group rows by department with rank-descending sort (Officer → Crew Member → Jr Crew) within each group

Fixes #350



* Updated documentation for payment system

* fix: address CodeRabbit feedback for PRD #341 round 2

- Guard ProcessMeetingPayouts to staff meetings only via isStaffMeeting()
- Run payouts before completeMeeting() so failures leave meeting in Finalizing
- Wrap payout call in try/catch with user-facing toast on unexpected error
- Fix docs schema table: add pending to status enum values



---------



* fix: address test feedback for PRD #341 — docs cleanup and toggle persistence (#355)

* docs: remove staff meeting payouts from user handbook, set all pages to public visibility

Staff meetings and payout management are staff-only operations and do not belong in the User Handbook. Remove the 08-staff-meetings section entirely. This content already exists in the Staff Handbook.

Also set all User Handbook pages to public visibility — previously some pages were set to users or staff visibility, and two section indexes were missing a visibility field entirely.

Closes #352



* docs: correct payout exclusion toggle behavior in staff handbook

The documentation incorrectly stated that exclusion toggles reset on the 30-second poll cycle. Livewire component state persists across poll re-renders (mount() is not called on poll). Only a full page refresh resets the toggles.

Remove the misleading poll-reset warning and update the notes to accurately describe the behavior.

Closes #353



* fix: address CodeRabbit round 3 feedback for PRD #341

- Truncate PR_BODY to 1600 chars before Discord webhook to stay within 2000-char limit
- Add --fail flag to curl in deploy-notifier.yml for proper error handling
- Update Known Issues item 7 in tech docs: payout-preview state is NOT lost on Livewire poll (component is outside the wire:poll div); exclusions only reset on full page refresh



* fix: address CodeRabbit round 4 feedback for PRD #341

- Use hyphenated compound modifier: full-page refresh



---------



* PRD: Harden Minecraft lh command reliability and add bulk permission reset (#363)

* feat: harden lh command outcomes and make permission commands synchronous #357

- MinecraftRconService: only mark lh commands as success when response starts with "Success:" — blank or non-confirming responses log as failed
- Extract protected connectAndSend() to enable testable override in tests
- SyncMinecraftRanks: change dispatch() to run(..., false) for immediate synchronous RCON execution
- SyncMinecraftStaff: same change for setstaff and removestaff commands
- Add 8 new tests covering positive/negative lh responses, connection failures, and synchronous execution of rank/staff syncs

Closes #357



* feat: add SyncMinecraftAccount authoritative desired-state action #358

Introduces SyncMinecraftAccount — the single authoritative action that computes and applies the desired Minecraft state for one active account.

Evaluates eligibility from membership level, brig status, and parent Minecraft restrictions:
- Eligible: whitelist add + lh setmember + lh setstaff|removestaff
- Ineligible: whitelist remove only (no rank or staff commands)

Returns structured result array indicating eligible, whitelist, rank, and staff outcomes for use by the upcoming bulk repair command.

9 tests covering normal, brigged, parent-disabled, staff, and Bedrock account scenarios.

Closes #358



* refactor: route lifecycle flows through unified SyncMinecraftAccount #359

- SyncMinecraftPermissions: iterate active accounts, delegate to SyncMinecraftAccount per account (replaces SyncMinecraftRanks + SyncMinecraftStaff)
- CompleteVerification: replace SendMinecraftCommand::dispatch() (async) with SyncMinecraftAccount::run() (synchronous) for immediate permission sync
- ReactivateMinecraftAccount: use SyncMinecraftAccount instead of manual whitelist add + SyncMinecraftRanks + SyncMinecraftStaff sequence
- PromoteUser/DemoteUser: use SyncMinecraftPermissions instead of SyncMinecraftRanks so whitelist and staff state are also kept in sync on level changes
- ReleaseUserFromBrig: use SyncMinecraftAccount per restored account instead of separate whitelist + rank + staff commands
- UpdateChildPermission::toggleMinecraft: use SyncMinecraftAccount per account for both enable and disable paths
- Update CompleteVerificationTest: assert synchronous RCON calls instead of queued MinecraftCommandNotification dispatches



* test: prove lifecycle flows use unified Minecraft sync path #359

11 tests covering SyncMinecraftPermissions, PromoteUser, DemoteUser, ReactivateMinecraftAccount, ReleaseUserFromBrig, and UpdateChildPermission — verifying each uses SyncMinecraftAccount for whitelist + rank + staff and respects brig and parent-permission restrictions.

Closes #359



* feat: add bulk Minecraft repair artisan command with dry-run and pacing #360

Implements the `minecraft:repair-permissions` artisan command that audits all active Minecraft accounts and repairs whitelist, member rank, and staff state. Supports --dry-run mode (reports planned changes without executing RCON commands) and --pace (configurable sleep between live commands).

Closes #360



* test: add mixed-account repair scenario coverage #361

Adds MixedAccountScenariosTest covering:
- Repair command processes all active accounts for multi-account users
- Brigged/parent-disabled users have all accounts removed across multiple accounts
- Staff position is set on every account during repair
- Java + Bedrock mixed account types are each handled with the correct command
- Lifecycle sync (SyncMinecraftPermissions/SyncMinecraftAccount) and the bulk repair command produce identical RCON decisions for the same user state, proving the two code paths stay aligned

Closes #361



* docs: add technical and staff documentation for Minecraft permission hardening

- Technical reference: docs/features/Minecraft Permission Hardening and Bulk Repair.md Covers SyncMinecraftAccount, SyncMinecraftPermissions, RepairMinecraftPermissions command, lh command hardening, lifecycle flow updates, and test coverage.

- Staff handbook: 05-minecraft/02-server-operations/02-repairing-permissions.md Officer-level guide for running minecraft:repair-permissions with dry-run and live execution, plus guidance on reading MC Command Log responses.

- Staff handbook: updated 01-rank-and-staff-syncing.md to note that lh command logs now show actual server response text for easier diagnosis.



* fix: address CodeRabbit round 1 feedback for PRD #354

Remove redundant pre-saves of parent_allows_minecraft in lifecycle sync tests. UpdateChildPermission itself sets the flag before syncing, so the pre-saves were masking whether the action actually toggled the value. Also add assertion that parent_allows_minecraft is true after the action runs.



---------



* feat: lh syncuser command integration and staff rank differentiation (#369)

* feat: add minecraftStaffPosition and syncUserCommand model methods #366

- User::minecraftStaffPosition() returns 'none' for no department, department value (e.g. 'engineer') for Officers, and '<department>_crew' (e.g. 'engineer_crew') for Crew Members and Jr Crew
- MinecraftAccount::syncUserCommand() returns the lh syncuser command string for both Java and Bedrock account types

Closes #366



* feat: consolidate SyncMinecraftAccount to single lh syncuser call #367

Replace the three-command eligible path (whitelist add + lh setmember + lh setstaff/removestaff) with a single lh syncuser RCON call. The return shape is preserved so callers (ReactivateMinecraftAccount etc.) are unaffected. Old commands retained as comments for fallback reference.

Updated SyncMinecraftAccountTest, MinecraftLifecycleSyncTest, MixedAccountScenariosTest, and CompleteVerificationTest to expect lh syncuser. Added Officer vs Crew Member rank differentiation tests.

Closes #367



* feat: add lh syncstart and switch RepairMinecraftPermissions to lh syncuser #368

- Send lh syncstart once before the per-account loop in live mode
- Replace the three-command eligible path with a single lh syncuser call
- Old commands preserved as comments for fallback reference
- Dry-run shows [dry-run] lh syncuser per account; never sends syncstart
- A successful syncuser increments adds, rank_changes, and staff_changes

Updated RepairMinecraftPermissionsTest (16 tests) and MixedAccountScenariosTest (9 tests) to reflect new command structure.

Closes #368



* docs: add technical documentation for lh syncuser command integration #365



* docs: expand staff ranks section in Minecraft ranks handbook page #365



* docs: update staff handbook Minecraft pages for lh syncuser and rank differentiation #365



* fix: address CodeRabbit round 1 feedback for PRD #365

- Warn when lh syncstart fails rather than silently ignoring the result
- Guard minecraftStaffPosition against staff_rank null/None returning _crew
- Clarify lh syncstart is live-run only in staff handbook doc
- Update tests to include staff_rank when testing staff department behavior



* fix: address CodeRabbit round 2 feedback for PRD #365

Update stale test comments — staff_rank is now explicitly set in fixtures so _crew suffix is because CrewMember < Officer, not a missing rank.



---------



* feat: guided onboarding wizard for new Stowaway and Traveler users (#377)

* feat: add onboarding wizard schema and eligibility helpers #372

- Migration adds onboarding_wizard_dismissed_at and onboarding_wizard_completed_at (nullable datetimes) to users table
- Backfill sets dismissed_at for existing users who already have linked Discord or Minecraft accounts (they skip the wizard)
- User::shouldShowOnboardingWizard() — true for Stowaway+ with both columns null
- User::currentOnboardingStep() — derives 'discord' | 'waiting' | 'minecraft' | 'complete' from membership_level, linked accounts, and activity log entries (onboarding_discord_skipped etc.)
- 18 tests covering all eligibility and step-derivation scenarios

Closes #372



* feat: improve dashboard account-linking widget for non-wizard users #373

Replaces the minimal Account Linking card with a more prominent "Complete Your Setup" card that uses indigo styling, shows only the relevant account sections (Discord/Minecraft) based on membership level and parent permission flags, and hides when the onboarding wizard is active.

Closes #373



* feat: wizard dashboard takeover, Discord step, and dismiss action #374

When shouldShowOnboardingWizard() is true (Stowaway or Traveler with no dismissed_at/completed_at), the dashboard hides normal widgets and renders the onboarding wizard component instead. The wizard handles:
- Discord step: explains Discord with Connect/Skip/Continue (disabled) actions
- Skip records onboarding_discord_skipped; Continue-disabled records onboarding_discord_disabled; both advance to the waiting step
- Dismiss sets dismissed_at and records onboarding_wizard_dismissed, then redirects so the normal dashboard is restored

Also scoped shouldShowOnboardingWizard() to Stowaway/Traveler only (Resident+ have completed onboarding) and added a test covering it.

Closes #374



* feat: implement wizard waiting-for-approval step #375

Replaces the minimal waiting step placeholder with warm, reassuring copy explaining the staff review process, what Traveler unlocks (Minecraft, full community features), and when to expect promotion. The step has no action button — it resolves automatically when the user is promoted. Dismiss remains available.

Closes #375



* feat: Minecraft step, completion, welcome modal, and sidebar link #376

Completes the onboarding wizard end-to-end:
- Minecraft step card: Connect Minecraft button, Skip for now, and parent-disabled explanation with Continue button
- Completion action: sets both completed_at and dismissed_at, records onboarding_wizard_completed, and shows the welcome modal
- Auto-completes on mount when currentOnboardingStep() returns 'complete' (e.g., Traveler who linked Minecraft before clicking through the wizard)
- Welcome modal: congratulations, feature highlights (Discussions, Tickets, Community Content), and link to /settings/notifications
- Sidebar: "Resume Account Setup" link visible while wizard is active, hidden after completion or dismissal
- Updated currentOnboardingStep() to show the disabled-Minecraft explanation card (instead of auto-completing), consistent with how Discord handles the parent_allows_discord=false case

Closes #376



* docs: add technical, user, and staff documentation for onboarding wizard #371

- docs/features/Guided Onboarding Wizard.md — full technical reference
- user-handbook: 4 new pages (wizard overview, Discord step, waiting step, Minecraft step/completion)
- staff-handbook: onboarding wizard context page with activity log entry reference and promotion behavior



* fix: correct typo in test name currentOnwardingStep → currentOnboardingStep #371



---------



* fix: address test feedback for Guided Onboarding Wizard (#388)

* fix: update coderabbit.yml issue_enrichment labeling config and CLAUDE.md docs

Fixes #386



* fix: right-align Submit button in Community Question widget

Fixes #387



* fix: add User Handbook link to onboarding wizard waiting step

Gives users something to read while waiting for Quartermaster approval. Minecraft Player Handbook link will be added when #379 is complete.

Fixes #380



---------



* fix: address test feedback for Guided Onboarding Wizard #371 (round 2) (#393)

* fix: update waitlist approval time estimate to a few hours / 24 hours max

Fixes #392



* fix: add return-to-dashboard reminder on Discord and Minecraft wizard steps

Fixes #391



* fix: show persistent My Account card on dashboard when setup is complete

When all accounts are already linked, the Complete Your Setup card is replaced by a small My Account card with links to Discord, Minecraft, and notification settings — so users always have quick access.

Fixes #390



* fix: make server connection info more prominent in Minecraft verification UI

Reorders the verification code card to show server address/port first as a clearly labeled Step 1, then the /verify command as Step 2. Helps users connect to the server before looking for the code.

Fixes #389



* fix: add staff departments page to User Handbook

Adds a high-level overview of the five staff departments (Command, Chaplain, Engineer, Quartermaster, Steward) and the three staff ranks so users know who does what and who to contact for help.

Fixes #381



---------



* feat: Public Policy Manual with last_updated display (#402)

* feat: add last_updated field to library page reader #396

- Add optional lastUpdated field to PageDTO
- Parse last_updated from YAML front matter in buildPage() and buildGuidePage()
- Display "Last updated: [date]" in muted text below page title when present
- Pass lastUpdated prop through page-show and guide-page to reader component

Closes #396



* feat: add Policy Manual book scaffold and part index files #397

Creates the policy-manual book directory with _index.md and four part directories (Community Standards, Safety & Privacy, Moderation, Staff & Operations), each with their own _index.md. All pages use visibility: public so no login is required.

Closes #397



* feat: add Part 1 Community Standards chapters to Policy Manual #398

Creates Code of Conduct and Community Expectations chapters under Part 1, each with a chapter _index.md and a content page with substantive policy text. Both pages are visibility: public with last_updated: 2026-03-26.

Closes #398



* feat: add Part 2 Safety & Privacy chapters to Policy Manual #399

Creates Child Safety Policy and Data Privacy Policy chapters under Part 2, each with a chapter _index.md and a content page with substantive policy text. Both pages are visibility: public with last_updated: 2026-03-26.

Closes #399



* feat: add Part 3 Moderation chapters to Policy Manual #400

Creates Moderation Practices and Discipline System chapters under Part 3, each with a chapter _index.md and a content page with substantive policy text. Both pages are visibility: public with last_updated: 2026-03-26.

Closes #400



* feat: add Part 4 Staff & Operations chapters to Policy Manual #401

Creates Staff Requirements and Operational Policies chapters under Part 4, each with a chapter _index.md and a content page with substantive policy text. Both pages are visibility: public with last_updated: 2026-03-26.

Closes #401



* docs: add technical documentation for Policy Manual feature #395



* docs: add user handbook pages for Policy Manual feature #395



* docs: add staff handbook pages for Policy Manual feature #395

Adds a new Part 09 "Policy Manual" to the Staff Handbook with one chapter and three pages:

- Policy Manual Overview: what the manual contains and how it is organized, with summaries of all eight policy pages.
- Linking to Policies: direct URLs for every policy page and scenarios matching common staff situations to the relevant policy.
- Updating Policy Content: step-by-step guide for editing markdown files, updating the last_updated front matter field, and deploying changes; includes a full file path reference table.



* fix: address CodeRabbit review feedback for PRD #395

- Normalize last_updated field in buildPage() and buildGuidePage() to handle DateTimeInterface values (YAML may parse dates as objects)
- Update docs/features to reflect that last_updated is tested, not untested
- Add text language identifier to unlabeled fenced code blocks in staff handbook policy manual pages (markdownlint MD040)



* fix: address CodeRabbit round 2 feedback for PRD #395

- Update Section 18 in feature docs to reflect last_updated IS tested (was stale — said untested but Section 16 already noted coverage)
- Fix grammar: "different than" → "different from" in staff handbook
- Capitalize "Markdown" as proper noun in staff handbook (two occurrences)



---------



* fix: policy manual content review pass (PRD #395) (#408)

* content: review and revise all policy manual pages #395

- Added Staff Reports page with full content covering severity levels, draft/publish workflow, what members see, and risk score explanation
- Split discipline system: 01-discipline-system.md renamed to 01-the-brig.md, 01-staff-reports.md added as first page in chapter
- Added staff-authority-and-conduct.md to Staff & Operations section
- Revised Code of Conduct, Child Safety Policy, Data Privacy Policy, Staff Requirements, and Operational Policies with reviewer edits



* fix: update broken discipline-system references after file rename #395

The old 01-discipline-system.md was split into 01-staff-reports.md and 01-the-brig.md. Update all documentation references to point to the new files:
- 02-linking-to-policies.md: replace single Discipline System URL with two entries for Staff Reports and The Brig
- 03-updating-policy-content.md: replace old file path reference with both new file paths
- docs/features/Policy Manual.md: update directory tree to show both new files



---------



* fix: address test feedback for PRD #395 (Policy Manual) (#410)

* fix: add last_updated field to all policy manual pages

Eight policy pages were missing the last_updated YAML field, so the "Last updated" date was not showing on their reader views. Added last_updated: '2026-03-26' to all pages that were missing it.

Fixes #406



* fix: require Traveler rank to create child accounts in parent portal

Users at Stowaway level could access the parent portal and create child accounts without being promoted to Traveler. Added a membership level check to createChildAccount() — users must be at least Traveler to add new child accounts. Existing parents who already have children can still manage those accounts.

Fixes #405



---------



* fix: move staff report status indicator to left of avatar #411 (#412)

Move the check/x icon from after the username to before the avatar image so the status is immediately visible at a glance without scanning across each card.

Fixes #411



* fix: simplify Policy Manual navigation — content in chapter overviews (#413)

* fix: simplify policy manual navigation — move content to chapter overviews #395

- For Community Standards, Safety & Privacy, and Moderation: policy content is now in the chapter _index.md rather than a separate sub-page. This eliminates the confusing Part → Chapter → Chapter-named-page pattern where users had to click the same name twice to reach content.
- Replaced 02-discipline-system chapter (with 2 sub-pages) with two separate chapters: 02-staff-reports and 03-the-brig, each containing their content in _index.md.
- Removed empty 03-membership-and-access part (had front matter but no content or chapters).
- Updated staff handbook linking and updating docs to reflect new URL structure (chapters are now the destination, not sub-pages).
- Updated technical docs (docs/features/Policy Manual.md) with correct file tree and data flow diagram.



* fix: address CodeRabbit feedback on PR #413 for PRD #395

- Add lastUpdated field to ChapterDTO and wire it through buildChapter() so last_updated front matter on chapter _index.md files is surfaced
- Add lastUpdated prop to section-listing blade component and render 'Last updated: [date]' beneath the summary, matching reader.blade.php
- Pass chapterData->lastUpdated from chapter-show to section-listing
- Update 03-updating-policy-content.md file path table to use _index.md paths (e.g. 01-code-of-conduct/_index.md) instead of the removed flat .md files



* fix: normalize chapter last_updated consistently with page and guide handling #395

buildChapter() now applies the same DateTimeInterface normalization as buildPage() and buildGuidePage() — if last_updated is a DateTimeInterface (e.g. when YAML parses an unquoted date), it is formatted to Y-m-d; otherwise it is cast to string. Prevents raw DateTime objects from reaching the renderer.



---------



* content: add Membership & Access Policy chapter to Community Standards #395 (#414)



* feat: ticket escalation for unassigned tickets (PRD #416) (#422)

* feat: add escalated_at column to threads table #417

- Migration adds nullable escalated_at timestamp to threads table
- Thread model includes escalated_at in fillable and cast as datetime
- Migration rolls back cleanly

Closes #417



* feat: add Ticket Escalation role, gate, and site config #418

- Seed Ticket Escalation - Receiver role via migration
- Define receive-ticket-escalations gate in AuthServiceProvider
- Seed ticket_escalation_threshold_minutes site config (default: 30)
- Gate tests: grants with role, denies without, admin and allow-all overrides

Closes #418



* feat: reset escalated_at when ticket is unassigned #419

When assignTo(null) is called, also set escalated_at to null so the ticket can re-escalate after the threshold passes. Assigning to a user does not touch escalated_at.

Closes #419



* feat: add escalation job, notification, and system message #420

- TicketEscalationNotification: mail/pushover/discord, subject 'Unassigned Ticket Alert'
- EscalateUnassignedTickets job: queries open unassigned tickets past threshold, notifies all receive-ticket-escalations users via staff_alerts category, posts MessageKind::System in thread, sets escalated_at — idempotent
- Registered in scheduler to run every minute
- mail/ticket-escalation.blade.php mail template
- 12 tests covering all acceptance criteria scenarios

Closes #420



* docs: add technical reference for ticket-escalation feature



* fix: address CodeRabbit round 1 feedback for PRD #416

- Add zero-guard: return early when ticket_escalation_threshold_minutes <= 0
- Eager-load createdBy on Thread query to prevent N+1 queries
- Use null-safe operators in toDiscord() and blade template for department/createdBy
- Add test: threshold=0 disables escalation
- Test comment: system message test relies on migration-seeded system user



* fix: pre-filter escalation recipients in SQL for PRD #416

Replace User::all()->filter() with a targeted query that pre-filters at the database level: admins, users with has_all_roles_at position, or users with the Ticket Escalation - Receiver role. The gate check is kept as a final safety filter. Avoids materializing the full users table on every minute-level scheduler run.



---------



* fix: address CodeRabbit feedback from PR #423 (#425)

* fix: address CodeRabbit feedback from PR #423 on staging

- RecordActivity::handle → ::run in SyncMinecraftAccount (3 calls) and ReleaseUserFromBrig (2 calls)
- Remove stale commented-out three-command fallback from SyncMinecraftAccount
- RepairMinecraftPermissions: return Command::FAILURE when failure count > 0; update test expectation accordingly
- routes/console.php: add withoutOverlapping()->onOneServer() to EscalateUnassignedTickets schedule
- User::shouldShowOnboardingWizard docblock: "Stowaway or above" → "Stowaway or Traveler"
- docs/features/ticket-escalation.md: correct threshold=0 config description, coverage gaps, and Known Issue #2 now that the guard exists; bump test count to 13
- Policy Manual: non-empty summary on staff-authority-and-conduct, "one on one" → "one-on-one", replace "FinalAsgard" with generic reference, "high level" → "high-level"
- User handbook: convert hardcoded duplicated URL slugs to wiki links
- ViewTicketTest: add ->done() to two new escalation tests



* fix: address second round of CodeRabbit feedback on PR #425

- RepairMinecraftPermissions: increment $counts['failures'] when lh syncstart fails so the final Command::FAILURE return reflects the syncstart failure
- docs/features/ticket-escalation.md: update schedule example to include ->withoutOverlapping()->onOneServer() matching actual routes/console.php



* fix: address third round of CodeRabbit feedback on PR #425

- docs/features/ticket-escalation.md: clarify threshold config table to explicitly mention values <= 0 disable escalation (not just 0)
- docs/features/ticket-escalation.md: "very large value" → "unexpectedly large value" with concrete example in Known Issues #2



---------



* chore: merge main into staging to unblock PR #423 (#426)

* Staging (#370)

* PRD: Rank-Based Role Assignments & Role Naming Standardization (#335)

* feat: add rank-based role infrastructure, rename roles to Feature - Tier convention

- Create role_staff_rank pivot table for assigning roles to staff ranks
- Rename 14 existing roles to Feature - Tier naming convention
- Seed 12 new feature-scoped roles (Staff Access, Ticket, Task, Meeting, etc.)
- Extend User::hasRole() with fourth check for rank-based role assignments
- Update all role name references across gates, policies, and tests
- No rank inheritance — each rank gets explicit assignments only

Closes #325



* feat: migrate staff access gates from rank checks to Staff Access role

Replace isAtLeastRank() checks with hasRole('Staff Access') for:
- view-acp, view-ready-room, view-docs-staff, edit-staff-bio
- view-user-discipline-reports (staff view part) Migrate view-docs-officer to hasRole('Officer Docs - Viewer') JrCrew display/privacy checks remain as rank checks per PRD

Closes #326



* docs: update branch naming convention to use hyphen separator

PRD branches use prd-<name> (hyphen) instead of prd/<name> (slash) to avoid git ref hierarchy conflicts with issue sub-branches.



* fix: handle HTML entity encoding in blog community story test

Names with apostrophes (e.g., O'Reilly) are HTML-encoded in rendered output. Use e() to match the encoded form in assertions.



* feat: migrate ticket, task, and meeting policies to role-based checks #327

Replace all isAtLeastRank() checks in ThreadPolicy, MessagePolicy, TaskPolicy, MeetingPolicy, and MeetingNotePolicy with hasRole() checks for the new feature-scoped roles:

- Ticket - User: viewDepartment, createAsStaff, addParticipant, internalNotes, changeStatus, close, createTopic
- Ticket - Manager: assign, reroute, viewFlagged
- Task - Department: create/update with department scoping
- Task - Manager: create/update for any department
- Meeting - Department: edit notes for own department
- Meeting - Secretary: edit notes for all departments
- Staff Access: view meetings (was CrewMember+ rank)

Also updates view-ticket Livewire component rank checks.



* feat: add role-based policy tests and update existing tests for #327

Add comprehensive tests for the new role-based policies:
- TicketRolePolicyTest: 24 tests for Ticket - User and Ticket - Manager
- TaskRolePolicyTest: 9 tests including department scoping
- MeetingRolePolicyTest: 15 tests for all meeting role tiers

Update existing tests to use role-based factories instead of rank-based:
- Add Ticket - User/Manager roles to staff users in ticket tests
- Add Task - Department/Manager roles to staff users in task tests
- Update ThreadAuthorizationTest for role-based assertions
- Update TopicPolicyTest and ViewTopicTest for Ticket - User role
- Update DiscussionFlaggingTest for Ticket - Manager role

Closes #327



* feat: migrate remaining policies/gates to role-based checks #328

- Internal notes: ThreadPolicy and MessagePolicy use Internal Note - Manager
- DisciplineReportPolicy: viewAny/view use Staff Access, create uses Discipline Report - Manager, update removes officer rank fallback
- review-staff-applications gate: Applicant Review - All and Applicant Review - Department with department scoping
- StaffApplicationPolicy: viewAny uses applicant review roles
- PagePolicy: all methods use Page - Editor role only
- CreateDisciplineReport: notification check uses Publisher role
- Library views: use Staff Access and Officer Docs - Viewer roles
- view-report and discipline-reports-card: use Staff Access role



* feat: add role-based tests for notes, discipline, applicant review, pages #328

New test files:
- DisciplineReportRolePolicyTest: 11 tests for Manager/Publisher/Staff Access
- ApplicantReviewRolePolicyTest: 10 tests with department scoping
- PageRolePolicyTest: 12 tests for Page - Editor role
- InternalNoteRolePolicyTest: 5 tests for Internal Note - Manager

Updated existing tests for role-based assertions:
- TicketRolePolicyTest: internal notes now use Internal Note - Manager
- ViewTicketTest/ViewTopicTest: internal note staff checks use new role
- RoleBasedGatesTest: review-staff-applications uses applicant review roles
- DisciplineReportPolicyTest: rank checks replaced with role checks
- StaffApplicationPolicyTest: viewAny uses applicant review roles
- CreateDisciplineReportTest: notification uses Publisher role
- DisciplineReportsCardTest/StaffApplicationReviewTest: updated for roles

Closes #328



* feat: add grouped role picker, rank cards, and rank role management #329

- Create reusable grouped-role-picker Livewire component with collapsible feature groups and toggle-based role selection
- Add Role::group attribute for grouping by feature prefix
- Add three rank cards (Jr Crew, Crew Member, Officer) to staff positions page showing assigned roles per rank
- Add rank role CRUD: admin can add/remove roles from ranks via the grouped picker modal
- Refactor position role assignment to use same grouped picker
- Non-admin staff see rank cards in read-only mode
- Unified event-based role management (onRoleAdded/onRoleRemoved) handles both rank and position role changes

Closes #329



* feat: add rank roles section to profile page #330

- Add distinct rank roles section to staff details card on profile
- Section labeled with rank name (e.g., "Officer Roles", "Crew Member Roles")
- Displays role badges with correct Feature - Tier names, colors, icons
- Section hidden when user has no rank or rank has no assigned roles
- Visibility uses Staff Access role (same as position roles)
- Update existing role visibility check from isAtLeastRank to hasRole
- 5 new tests covering visibility, hiding, admin access, rank labeling

Closes #330



* docs: add technical documentation for rank-based role assignments #307



* docs: update staff handbook for rank-based role assignments #307

- Update "How Roles Work" page for rank roles and Feature - Tier naming
- Rewrite "Role Reference" with all 30+ roles in Feature - Tier format
- Update "Managing Position Roles" for grouped picker UI
- Add new "Managing Rank Roles" page (officer visibility)
- Update section index



* chore: add CodeRabbit config with staging branch auto-review

Enable auto-reviews on PRs targeting staging (not just main). Disable auto-labeling to prevent interference with PRD labels.



* fix: address CodeRabbit review feedback for PRD #307

- view-ticket: replace bare hasRole checks with policy-based can() calls so admin bypass and department scoping work correctly
- PagePolicy: make view() user nullable so guests can view published pages
- admin-manage-staff-positions: validate activeRankValue against StaffRank enum to prevent tampered Livewire payloads
- SubmitBlogPostForReview: include rank-assigned Blog authors in notification recipients (was only checking position roles)
- seed migration down(): exclude pre-existing renamed roles from deletion
- display-basic-details: add wire:key to role badge loops
- Staff docs: fix PII - Viewer description, clarify rank change behavior



* fix: address CodeRabbit round 2 feedback for PRD #307

- TaskPolicy: require staff_department for Task - Department on create
- MeetingNotePolicy: require staff_department for Meeting - Department on create
- Seed migration down(): only skip Discipline Report - Publisher (pre-existing); Staff Access is new and should be deleted on rollback
- Blade template: use tryFrom() instead of from() for defensive rendering



---------



* fix: address test feedback for Rank-Based Role Assignments (#338)

* feat: add rank-based role infrastructure, rename roles to Feature - Tier convention

- Create role_staff_rank pivot table for assigning roles to staff ranks
- Rename 14 existing roles to Feature - Tier naming convention
- Seed 12 new feature-scoped roles (Staff Access, Ticket, Task, Meeting, etc.)
- Extend User::hasRole() with fourth check for rank-based role assignments
- Update all role name references across gates, policies, and tests
- No rank inheritance — each rank gets explicit assignments only

Closes #325



* feat: migrate staff access gates from rank checks to Staff Access role

Replace isAtLeastRank() checks with hasRole('Staff Access') for:
- view-acp, view-ready-room, view-docs-staff, edit-staff-bio
- view-user-discipline-reports (staff view part) Migrate view-docs-officer to hasRole('Officer Docs - Viewer') JrCrew display/privacy checks remain as rank checks per PRD

Closes #326

Co-Authored-By: Claude Opus 4.6…

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Parents can now restart Minecraft verification and directly remove cancelled or cancelling accounts from the Parent Portal.
  * Admins can force-delete cancelled or cancelling accounts from member profiles.

* **Documentation**
  * Added comprehensive guides for users on handling cancelled Minecraft accounts.
  * Added staff documentation for removing cancelled accounts.
  * Added technical documentation for cancelled account management workflows.

* **Bug Fixes**
  * Fixed ticket escalation job to skip processing when no eligible recipients exist.

* **Tests**
  * Added comprehensive test coverage for new account removal and verification restart flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->