### PR TITLE
fix: contact inquiry chat UI and back button (PRD #453 test feedback)

### DIFF
--- a/resources/views/livewire/contact/view-inquiry.blade.php
+++ b/resources/views/livewire/contact/view-inquiry.blade.php
@@ -192,7 +192,7 @@ new class extends Component {
                 <span>{{ $thread->created_at->diffForHumans() }}</span>
             </div>
         </div>
-        <flux:button href="{{ route('contact-inquiries.index') }}" variant="ghost" size="sm" wire:navigate>← Back to Inquiries</flux:button>
+        <flux:button href="{{ route('discussions.index', ['filter' => 'contact']) }}" variant="ghost" size="sm" wire:navigate>← Back to Inquiries</flux:button>
     </div>
 
     {{-- Status Management --}}
@@ -210,48 +210,89 @@ new class extends Component {
     </div>
 
     {{-- Messages --}}
-    <div class="flex flex-col gap-4 mb-6">
+    <div class="mx-auto w-full max-w-3xl mb-6">
+    <div class="flex flex-col gap-4">
+        @php $tz = auth()->user()->timezone ?? 'UTC'; @endphp
         @foreach($this->threadMessages as $message)
+            @php $isOwn = $message->user_id === auth()->id(); @endphp
+
             @if($message->kind === MessageKind::InternalNote)
-                {{-- Internal Note --}}
-                <div wire:key="msg-{{ $message->id }}" class="rounded-lg border border-amber-300 dark:border-amber-700 bg-amber-50 dark:bg-amber-950/30 p-4">
-                    <div class="flex items-center gap-2 mb-2">
-                        <flux:badge color="amber" size="sm">Internal Note</flux:badge>
-                        <span class="text-sm font-medium text-zinc-700 dark:text-zinc-300">{{ $message->user?->name ?? 'Staff' }}</span>
-                        <span class="text-xs text-zinc-400 dark:text-zinc-500">{{ $message->created_at->diffForHumans() }}</span>
-                    </div>
-                    <div class="prose prose-sm dark:prose-invert max-w-none">
-                        {!! Str::markdown($message->body, ['html_input' => 'strip', 'allow_unsafe_links' => false]) !!}
+                {{-- Internal Note — always left-aligned, amber --}}
+                <div wire:key="msg-{{ $message->id }}" class="chat-message chat-message-start">
+                    <flux:avatar size="sm" :src="$message->user?->avatarUrl()" :initials="$message->user?->initials() ?? 'S'" class="shrink-0 mt-1" />
+                    <div class="min-w-0">
+                        <div class="flex items-baseline gap-2 mb-1">
+                            <span class="font-semibold text-sm text-zinc-700 dark:text-zinc-300">{{ $message->user?->name ?? 'Staff' }}</span>
+                            <span class="text-xs text-zinc-400 dark:text-zinc-500">{{ $message->created_at->setTimezone($tz)->format('M j, Y g:i A') }}</span>
+                            <flux:badge size="sm" color="amber">Internal Note</flux:badge>
+                        </div>
+                        <div class="chat-bubble chat-bubble-start border border-amber-300 dark:border-amber-700 bg-amber-50 dark:bg-amber-950/30">
+                            <div class="prose prose-sm dark:prose-invert max-w-none">
+                                {!! Str::markdown($message->body, ['html_input' => 'strip', 'allow_unsafe_links' => false]) !!}
+                            </div>
+                        </div>
                     </div>
                 </div>
+
+            @elseif($message->user_id && $isOwn)
+                {{-- Own staff reply — right-aligned, cyan --}}
+                <div wire:key="msg-{{ $message->id }}" class="chat-message chat-message-end">
+                    <flux:avatar size="sm" :src="$message->user?->avatarUrl()" :initials="$message->user?->initials() ?? 'S'" class="shrink-0 mt-1" />
+                    <div class="min-w-0">
+                        <div class="flex items-baseline gap-2 mb-1 justify-end">
+                            <span class="text-xs text-zinc-400 dark:text-zinc-500">{{ $message->created_at->setTimezone($tz)->format('M j, Y g:i A') }}</span>
+                            @if($message->guest_email_sent)
+                                <flux:badge color="blue" size="sm" icon="envelope">Emailed to guest</flux:badge>
+                            @endif
+                        </div>
+                        <div class="chat-bubble chat-bubble-end bg-cyan-50 dark:bg-cyan-950/40 border border-cyan-200 dark:border-cyan-800">
+                            <div class="prose prose-sm dark:prose-invert max-w-none">
+                                {!! Str::markdown($message->body, ['html_input' => 'strip', 'allow_unsafe_links' => false]) !!}
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
             @elseif($message->user_id)
-                {{-- Staff reply --}}
-                <div wire:key="msg-{{ $message->id }}" class="rounded-lg border border-zinc-200 dark:border-zinc-700 bg-zinc-50 dark:bg-zinc-900 p-4">
-                    <div class="flex items-center gap-2 mb-2">
-                        <span class="text-sm font-medium text-zinc-700 dark:text-zinc-300">{{ $message->user?->name ?? 'Staff' }}</span>
-                        <span class="text-xs text-zinc-400 dark:text-zinc-500">{{ $message->created_at->diffForHumans() }}</span>
-                        @if($message->guest_email_sent)
-                            <flux:badge color="blue" size="sm" icon="envelope">Emailed to guest</flux:badge>
-                        @endif
-                    </div>
-                    <div class="prose prose-sm dark:prose-invert max-w-none">
-                        {!! Str::markdown($message->body, ['html_input' => 'strip', 'allow_unsafe_links' => false]) !!}
+                {{-- Other staff reply — left-aligned, neutral --}}
+                <div wire:key="msg-{{ $message->id }}" class="chat-message chat-message-start">
+                    <flux:avatar size="sm" :src="$message->user?->avatarUrl()" :initials="$message->user?->initials() ?? 'S'" class="shrink-0 mt-1" />
+                    <div class="min-w-0">
+                        <div class="flex items-baseline gap-2 mb-1">
+                            <span class="font-semibold text-sm text-blue-600 dark:text-blue-400">{{ $message->user?->name ?? 'Staff' }}</span>
+                            <span class="text-xs text-zinc-400 dark:text-zinc-500">{{ $message->created_at->setTimezone($tz)->format('M j, Y g:i A') }}</span>
+                            @if($message->guest_email_sent)
+                                <flux:badge color="blue" size="sm" icon="envelope">Emailed to guest</flux:badge>
+                            @endif
+                        </div>
+                        <div class="chat-bubble chat-bubble-start bg-zinc-100 dark:bg-zinc-800 border border-zinc-200 dark:border-zinc-700">
+                            <div class="prose prose-sm dark:prose-invert max-w-none">
+                                {!! Str::markdown($message->body, ['html_input' => 'strip', 'allow_unsafe_links' => false]) !!}
+                            </div>
+                        </div>
                     </div>
                 </div>
+
             @else
-                {{-- Guest message --}}
-                <div wire:key="msg-{{ $message->id }}" class="rounded-lg border border-blue-200 dark:border-blue-800 bg-blue-50 dark:bg-blue-950/30 p-4">
-                    <div class="flex items-center gap-2 mb-2">
-                        <flux:badge color="blue" size="sm">Guest</flux:badge>
-                        <span class="text-sm font-medium text-zinc-700 dark:text-zinc-300">{{ $thread->guest_name ?? 'Anonymous' }}</span>
-                        <span class="text-xs text-zinc-400 dark:text-zinc-500">{{ $message->created_at->diffForHumans() }}</span>
-                    </div>
-                    <div class="prose prose-sm dark:prose-invert max-w-none">
-                        {!! Str::markdown($message->body, ['html_input' => 'strip', 'allow_unsafe_links' => false]) !!}
+                {{-- Guest message — left-aligned, blue --}}
+                <div wire:key="msg-{{ $message->id }}" class="chat-message chat-message-start">
+                    <flux:avatar size="sm" :initials="Str::upper(Str::substr($thread->guest_name ?? 'G', 0, 1))" class="shrink-0 mt-1" />
+                    <div class="min-w-0">
+                        <div class="flex items-baseline gap-2 mb-1">
+                            <span class="font-semibold text-sm text-zinc-700 dark:text-zinc-300">{{ $thread->guest_name ?? 'Guest' }}</span>
+                            <span class="text-xs text-zinc-400 dark:text-zinc-500">{{ $message->created_at->setTimezone($tz)->format('M j, Y g:i A') }}</span>
+                            <flux:badge size="sm" color="blue">Guest</flux:badge>
+                        </div>
+                        <div class="chat-bubble chat-bubble-start bg-blue-50 dark:bg-blue-950/30 border border-blue-200 dark:border-blue-800">
+                            <div class="prose prose-sm dark:prose-invert max-w-none">
+                                {!! Str::markdown($message->body, ['html_input' => 'strip', 'allow_unsafe_links' => false]) !!}
+                            </div>
+                        </div>
                     </div>
                 </div>
             @endif
         @endforeach
+    </div>
     </div>
 
     {{-- Reply Composer --}}

--- a/resources/views/livewire/topics/topics-list.blade.php
+++ b/resources/views/livewire/topics/topics-list.blade.php
@@ -9,12 +9,14 @@ use App\Models\Message;
 use App\Models\Thread;
 use Flux\Flux;
 use Livewire\Attributes\Computed;
+use Livewire\Attributes\Url;
 use Livewire\Volt\Component;
 
 new class extends Component
 {
     public bool $showArchive = false;
 
+    #[Url]
     public string $filter = 'active';
 
     #[Computed]


### PR DESCRIPTION
## What Changed

Fixes two UI issues reported during testing of PRD #453 (Public Contact Us Form):

1. **Chat UI consistency** — The staff contact inquiry view now uses the same chat-bubble layout as the Discussions page (avatars, left/right alignment, cyan for own messages, neutral for other staff, blue for guest, amber for internal notes).

2. **Back button** — "Back to Inquiries" now returns to the Discussions page with the Contact Inquiries tab pre-selected (`/discussions?filter=contact`), instead of routing to the standalone `/contact-inquiries` page that staff have no nav link to. The `filter` property in `topics-list` was made URL-aware with `#[Url]` so the query param sets the tab.

## How to Re-Test

### Chat UI
1. Log in as staff with "Contact - Receive Submissions" role
2. Go to Discussions → Contact Inquiries tab
3. Open an inquiry that has both guest messages and staff replies
4. Verify: guest messages appear left-aligned with a blue bubble, own staff replies right-aligned cyan, other staff replies left-aligned neutral, internal notes left-aligned amber — matching the style of regular discussion threads

### Back Button
1. From Discussions → Contact Inquiries tab, open an inquiry
2. Click "← Back to Inquiries"
3. Verify: lands on the Discussions page with the Contact Inquiries tab active (not a 404 or unauthorized page)

## Things to Watch For

- Chat bubble CSS classes (`chat-message`, `chat-bubble-start/end`) must be available in the layout — they are (shared with discussions)
- Guest messages use initial-based avatars since guests have no user record
- `/discussions?filter=contact` URL should be bookmarkable and shareable between staff

## Parent PRD

#453

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced contact inquiry message display with a modern chat layout featuring distinct visual styling for internal notes, staff replies, and guest messages
  * Implemented filter persistence for discussion topics to maintain user preferences during navigation
  * Improved timestamp display with timezone-aware formatting for better global user experience

<!-- end of auto-generated comment: release notes by coderabbit.ai -->