### PR TITLE
fix: address test feedback for PRD: Ministry Finance Tracking System (#466)

### DIFF
--- a/resources/views/livewire/parent-portal/index.blade.php
+++ b/resources/views/livewire/parent-portal/index.blade.php
@@ -2,8 +2,8 @@
 
 use App\Actions\CreateChildAccount;
 use App\Actions\GenerateVerificationCode;
-use App\Actions\ReleaseChildToAdult;
 use App\Actions\ParentRegenerateVerificationCode;
+use App\Actions\ReleaseChildToAdult;
 use App\Actions\RemoveChildMinecraftAccount;
 use App\Actions\UpdateChildPermission;
 use App\Enums\MinecraftAccountType;
@@ -19,7 +19,8 @@ use Livewire\Attributes\Computed;
 use Livewire\Attributes\Locked;
 use Livewire\Volt\Component;
 
-new class extends Component {
+new class extends Component
+{
     #[Locked]
     public int $targetUserId = 0;
 
@@ -27,20 +28,29 @@ new class extends Component {
     public bool $isStaffViewing = false;
 
     public string $newChildName = '';
+
     public string $newChildEmail = '';
+
     public string $newChildDob = '';
 
     public ?int $accountToRemoveId = null;
+
     public string $accountToRemoveName = '';
+
     public string $accountToRemoveChildName = '';
 
     public array $childMcUsernames = [];
+
     public array $childMcAccountTypes = [];
+
     public array $childMcVerificationCodes = [];
+
     public array $childMcExpiresAt = [];
+
     public array $childMcErrors = [];
 
     public ?int $editingChildId = null;
+
     public array $editChildData = [
         'name' => '',
         'email' => '',
@@ -56,7 +66,7 @@ new class extends Component {
             if (! Auth::user()->isAtLeastRank(\App\Enums\StaffRank::Officer)) {
                 abort(403);
             }
-            $targetUser = $user instanceof User ? $user : User::findOrFail($user);
+            $targetUser = $user instanceof User ? $user : User::where('slug', $user)->firstOrFail();
             $this->targetUserId = $targetUser->id;
             $this->isStaffViewing = true;
         } else {
@@ -147,6 +157,7 @@ new class extends Component {
 
         if (! $parent->children()->where('child_user_id', $child->id)->exists()) {
             Flux::toast('You do not have permission to manage this account.', 'Unauthorized', variant: 'danger');
+
             return;
         }
 
@@ -209,6 +220,7 @@ new class extends Component {
         } catch (\Throwable $e) {
             \Illuminate\Support\Facades\Log::error('Failed to create child account', ['error' => $e->getMessage()]);
             Flux::toast('Could not create child account. Please try again.', 'Error', variant: 'danger');
+
             return;
         }
 
@@ -229,11 +241,13 @@ new class extends Component {
 
         if (! $parent->children()->where('child_user_id', $child->id)->exists()) {
             Flux::toast('You do not have permission to manage this account.', 'Unauthorized', variant: 'danger');
+
             return;
         }
 
         if ($child->age() === null || $child->age() < 17) {
             Flux::toast('Child must be at least 17 to be released to an adult account.', 'Not Eligible', variant: 'danger');
+
             return;
         }
 
@@ -376,6 +390,7 @@ new class extends Component {
 
         if (! $parent->children()->where('child_user_id', $child->id)->exists()) {
             Flux::toast('You do not have permission to edit this account.', 'Unauthorized', variant: 'danger');
+
             return;
         }
 
@@ -403,6 +418,7 @@ new class extends Component {
         $childAge = \Carbon\Carbon::parse($this->editChildData['date_of_birth'])->age;
         if ($childAge > 16) {
             $this->addError('editChildData.date_of_birth', 'Child accounts are intended for ages 16 and under.');
+
             return;
         }
 
@@ -411,6 +427,7 @@ new class extends Component {
 
         if (! $parent->children()->where('child_user_id', $child->id)->exists()) {
             Flux::toast('You do not have permission to edit this account.', 'Unauthorized', variant: 'danger');
+
             return;
         }
 
@@ -453,6 +470,7 @@ new class extends Component {
     {
         if ($this->isStaffViewing) {
             Flux::toast('This view is read-only.', 'Unauthorized', variant: 'danger');
+
             return;
         }
 
@@ -462,6 +480,7 @@ new class extends Component {
         // Verify the parent owns this child before exposing account info
         if (! $parent->children()->where('child_user_id', $account->user_id)->exists()) {
             Flux::toast('You do not have permission to manage this account.', 'Unauthorized', variant: 'danger');
+
             return;
         }
 
@@ -498,6 +517,7 @@ new class extends Component {
     {
         if ($this->isStaffViewing) {
             Flux::toast('This view is read-only.', 'Unauthorized', variant: 'danger');
+
             return;
         }
 
@@ -506,11 +526,13 @@ new class extends Component {
 
         if (! $parent->children()->where('child_user_id', $account->user_id)->exists()) {
             Flux::toast('You do not have permission to manage this account.', 'Unauthorized', variant: 'danger');
+
             return;
         }
 
         if (! in_array($account->status, [\App\Enums\MinecraftAccountStatus::Cancelled, \App\Enums\MinecraftAccountStatus::Cancelling])) {
             Flux::toast('This account cannot be removed in this way.', 'Error', variant: 'danger');
+
             return;
         }
 
@@ -528,6 +550,7 @@ new class extends Component {
     {
         if ($this->isStaffViewing) {
             Flux::toast('This view is read-only.', 'Unauthorized', variant: 'danger');
+
             return;
         }
 
@@ -541,7 +564,7 @@ new class extends Component {
             $this->childMcVerificationCodes[$childId] = $result['code'];
             $this->childMcExpiresAt[$childId] = $result['expires_at']->toIso8601String();
             unset($this->children);
-            Flux::toast('Verification restarted! Have the child run /verify ' . $result['code'] . ' in-game.', 'Verification Restarted', variant: 'success');
+            Flux::toast('Verification restarted! Have the child run /verify '.$result['code'].' in-game.', 'Verification Restarted', variant: 'success');
         } else {
             Flux::toast($result['error'], 'Error', variant: 'danger');
         }


### PR DESCRIPTION
## What Changed

Fixes based on tester feedback for PRD #466.

## Issues Addressed

- #481: Parent portal crashed when a staff admin tried to view a child user's portal — the component was calling `User::findOrFail($user)` where `$user` is a slug string (since `getRouteKeyName()` returns `'slug'`). Fixed to `User::where('slug', $user)->firstOrFail()`.

## How to Re-Test

### Parent Portal Crash Fix (#481)
1. Log in as a staff admin (Admin role).
2. Navigate to a user profile where the user has a parent linked, or a parent who has linked children.
3. Click the **Parent Portal** link or navigate to `/parent-portal/{slug}` for a child user.
4. Expected: The parent portal page loads normally.
5. Previously: A `500` error from trying to cast a username string as a bigint.

## Things to Watch For

- The fix is limited to one `firstOrFail()` call in `resources/views/livewire/parent-portal/index.blade.php` — verify the rest of the parent portal still works end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated user lookup mechanism in the parent portal for improved resolution accuracy.

* **Style**
  * Reformatted code structure and adjusted string formatting for consistency.

* **Chores**
  * Reorganized import declarations and added formatting improvements throughout the parent portal component.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->