### PR TITLE
fix: address test feedback for PRD: Ministry Finance Tracking System (#466) round 4

### DIFF
--- a/resources/views/livewire/finances/dashboard.blade.php
+++ b/resources/views/livewire/finances/dashboard.blade.php
@@ -206,6 +206,18 @@ new class extends Component
         Flux::modal('record-transaction')->show();
     }
 
+    public function openOrgPickerModal(): void
+    {
+        $this->authorize('financials-treasurer');
+        Flux::modal('org-picker')->show();
+    }
+
+    public function openEditOrgPickerModal(): void
+    {
+        $this->authorize('financials-treasurer');
+        Flux::modal('edit-org-picker')->show();
+    }
+
     // ── Submit new transaction ────────────────────────────────────────────────
 
     public function submitTransaction(): void
@@ -479,7 +491,7 @@ new class extends Component
         @can('financials-manage')
             <flux:button href="{{ route('finances.board-reports') }}" wire:navigate size="sm" icon="chart-bar">Board Reports</flux:button>
             <flux:button href="{{ route('finances.accounts') }}" wire:navigate size="sm" icon="building-library">Accounts</flux:button>
-            <flux:button href="{{ route('finances.categories') }}" wire:navigate size="sm" icon="tag">Categories</flux:button>
+            <flux:button href="{{ route('finances.categories') }}" wire:navigate size="sm" icon="tag">Categories &amp; Tags</flux:button>
         @endcan
     </div>
 
@@ -642,7 +654,7 @@ new class extends Component
                                 <flux:badge>{{ $organizationName }}</flux:badge>
                                 <flux:button size="sm" variant="ghost" wire:click="clearOrganization" icon="x-mark">Clear</flux:button>
                             @else
-                                <flux:button size="sm" wire:click="$flux.modal('org-picker').show()" icon="building-office">Add Organization</flux:button>
+                                <flux:button size="sm" wire:click="openOrgPickerModal" icon="building-office">Add Organization</flux:button>
                             @endif
                         </div>
                     </flux:field>
@@ -911,7 +923,7 @@ new class extends Component
                             <flux:badge>{{ $editOrganizationName }}</flux:badge>
                             <flux:button size="sm" variant="ghost" wire:click="clearEditOrganization" icon="x-mark">Clear</flux:button>
                         @else
-                            <flux:button size="sm" wire:click="$flux.modal('edit-org-picker').show()" icon="building-office">Add Organization</flux:button>
+                            <flux:button size="sm" wire:click="openEditOrgPickerModal" icon="building-office">Add Organization</flux:button>
                         @endif
                     </div>
                 </flux:field>


### PR DESCRIPTION
## What Changed

Fixes based on tester feedback for PRD #466 (Ministry Finance Tracking System), round 4.

## Issues Addressed

- **Add Transaction modal button** — Fixed: the button now correctly opens the modal (was using a broken JS pattern; replaced with a PHP method call)
- **Transfer immutability UX** — The ledger now shows "Transfers cannot be edited — delete and re-enter if needed." instead of showing no button with no explanation
- **Manage Tags removed** — The Manage Tags section has been removed from the Finance Dashboard to reduce clutter

## How to Re-Test

### Add Transaction button
1. Log in as a Financials Treasurer.
2. Go to `/finances/dashboard`.
3. Click **Add Transaction** — the transaction modal should open.

### Transfer rows in ledger
1. Submit a transfer transaction between two accounts.
2. Find the transfer in the ledger — the action column should show explanatory text instead of being blank or broken.

### Dashboard layout
1. Log in as a Financials Manage user.
2. Go to `/finances/dashboard`.
3. The Manage Tags section should no longer appear. The Manage Organizations section should still be present.

## Things to Watch For

- The Add Transaction button was silently broken — no error, just no modal opening. Now calls `openRecordTransactionModal()` PHP method which uses `Flux::modal()->show()`.
- Manage Tags content is still accessible via the Categories & Tags management page; it's just removed from the dashboard.

## Parent PRD

#466

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Removed the "Manage Tags" section from the finances dashboard
  * Transfer transactions in unpublished months now display informational text instead of action buttons
  * Refined "Add Transaction" button interaction handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->