### PR TITLE
fix: address test feedback for PRD: Ministry Finance Tracking System (#466) round 7

### DIFF
--- a/app/Actions/PublishPeriodReport.php
+++ b/app/Actions/PublishPeriodReport.php
@@ -9,6 +9,7 @@ use App\Models\FinancialTransaction;
 use App\Models\MonthlyBudget;
 use App\Models\User;
 use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\DB;
 use Lorisleiva\Actions\Concerns\AsAction;
 
 class PublishPeriodReport
@@ -17,6 +18,33 @@ class PublishPeriodReport
 
     public function handle(string $monthStart, User $publishedBy): FinancialPeriodReport
     {
+        // Reject publishing if earlier months with transactions haven't been published
+        $ymExpr = match (DB::getDriverName()) {
+            'pgsql' => "to_char(transacted_at, 'YYYY-MM')",
+            'mysql' => "DATE_FORMAT(transacted_at, '%Y-%m')",
+            default => "strftime('%Y-%m', transacted_at)",
+        };
+
+        $priorMonthsWithTransactions = FinancialTransaction::where('transacted_at', '<', $monthStart)
+            ->selectRaw("{$ymExpr} as ym")
+            ->groupByRaw($ymExpr)
+            ->pluck('ym');
+
+        if ($priorMonthsWithTransactions->isNotEmpty()) {
+            $publishedMonths = FinancialPeriodReport::whereNotNull('published_at')
+                ->get()
+                ->map(fn ($r) => Carbon::parse($r->month)->format('Y-m'))
+                ->all();
+
+            $hasUnpublishedPrior = $priorMonthsWithTransactions->filter(
+                fn ($ym) => ! in_array($ym, $publishedMonths)
+            )->isNotEmpty();
+
+            if ($hasUnpublishedPrior) {
+                throw new \RuntimeException('Cannot publish this month — there are earlier months with transactions that have not been published yet.');
+            }
+        }
+
         // Reject double-publish
         $existing = FinancialPeriodReport::whereDate('month', $monthStart)->first();
         if ($existing && $existing->isPublished()) {

--- a/resources/views/livewire/finances/dashboard.blade.php
+++ b/resources/views/livewire/finances/dashboard.blade.php
@@ -76,6 +76,8 @@ new class extends Component
 
     public string $editOrganizationSearch = '';
 
+    public string $editTagSearch = '';
+
     // ── Tag management ────────────────────────────────────────────────────────
     public string $newTagName = '';
 
@@ -216,6 +218,48 @@ new class extends Component
         Flux::modal('edit-org-picker')->show();
     }
 
+    public function openEditTagPickerModal(): void
+    {
+        $this->authorize('financials-treasurer');
+        Flux::modal('edit-tag-picker')->show();
+    }
+
+    public function selectEditTag(int $id): void
+    {
+        $this->authorize('financials-treasurer');
+        if (! in_array($id, $this->editTagIds)) {
+            $this->editTagIds[] = $id;
+        }
+        $this->editTagSearch = '';
+        Flux::modal('edit-tag-picker')->close();
+    }
+
+    public function removeEditTag(int $id): void
+    {
+        $this->authorize('financials-treasurer');
+        $this->editTagIds = array_values(array_filter($this->editTagIds, fn ($t) => $t !== $id));
+    }
+
+    public function createEditTagInline(): void
+    {
+        $this->authorize('financials-treasurer');
+
+        $this->validate([
+            'editTagSearch' => 'required|string|max:100|unique:financial_tags,name',
+        ]);
+
+        $tag = CreateFinancialTag::run($this->editTagSearch, auth()->user());
+        $this->selectEditTag($tag->id);
+    }
+
+    public function filteredEditTags(): \Illuminate\Database\Eloquent\Collection
+    {
+        return FinancialTag::where('is_archived', false)
+            ->when($this->editTagSearch !== '', fn ($q) => $q->where('name', 'like', '%'.$this->editTagSearch.'%'))
+            ->orderBy('name')
+            ->get();
+    }
+
     // ── Submit new transaction ────────────────────────────────────────────────
 
     public function submitTransaction(): void
@@ -307,6 +351,7 @@ new class extends Component
         $this->editOrganizationId = null;
         $this->editOrganizationName = '';
         $this->editOrganizationSearch = '';
+        $this->editTagSearch = '';
 
         if ($tx->financial_category_id !== null) {
             $this->editCategoryId = (string) $tx->financial_category_id;
@@ -359,7 +404,7 @@ new class extends Component
 
         Flux::modal('edit-tx-modal')->close();
         Flux::toast('Transaction updated.', 'Success', variant: 'success');
-        $this->reset(['editTxId', 'editType', 'editAccountId', 'editAmount', 'editDate', 'editCategoryId', 'editNotes', 'editTagIds', 'editOrganizationId', 'editOrganizationName', 'editOrganizationSearch']);
+        $this->reset(['editTxId', 'editType', 'editAccountId', 'editAmount', 'editDate', 'editCategoryId', 'editNotes', 'editTagIds', 'editOrganizationId', 'editOrganizationName', 'editOrganizationSearch', 'editTagSearch']);
         $this->editType = 'expense';
     }
 
@@ -870,31 +915,36 @@ new class extends Component
                     <flux:error name="editCategoryId" />
                 </flux:field>
 
-                <flux:field>
-                    <flux:label>Tags</flux:label>
-                    <div class="flex flex-wrap gap-2 mt-1">
-                        @foreach ($this->tags as $tag)
-                            <label class="flex items-center gap-1 text-sm cursor-pointer">
-                                <input type="checkbox" wire:model="editTagIds" value="{{ $tag->id }}"
-                                    class="rounded border-zinc-600" />
-                                {{ $tag->name }}
-                            </label>
-                        @endforeach
-                    </div>
-                    <flux:error name="editTagIds" />
-                </flux:field>
+                <div class="grid grid-cols-2 gap-4">
+                    <flux:field>
+                        <flux:label>Tags</flux:label>
+                        <div class="flex flex-wrap gap-1 mb-1">
+                            @foreach ($this->editTagIds as $tagId)
+                                @php $tag = $this->filteredEditTags()->firstWhere('id', $tagId) ?? \App\Models\FinancialTag::find($tagId); @endphp
+                                @if ($tag)
+                                    <flux:badge>
+                                        {{ $tag->name }}
+                                        <button type="button" wire:click="removeEditTag({{ $tag->id }})" class="ml-1 opacity-70 hover:opacity-100">&times;</button>
+                                    </flux:badge>
+                                @endif
+                            @endforeach
+                        </div>
+                        <flux:button size="sm" wire:click="openEditTagPickerModal" icon="tag">Add Tag</flux:button>
+                        <flux:error name="editTagIds" />
+                    </flux:field>
 
-                <flux:field>
-                    <flux:label>Organization</flux:label>
-                    <div class="flex gap-2 items-center">
-                        @if ($editOrganizationId)
-                            <flux:badge>{{ $editOrganizationName }}</flux:badge>
-                            <flux:button size="sm" variant="ghost" wire:click="clearEditOrganization" icon="x-mark">Clear</flux:button>
-                        @else
-                            <flux:button size="sm" wire:click="openEditOrgPickerModal" icon="building-office">Add Organization</flux:button>
-                        @endif
-                    </div>
-                </flux:field>
+                    <flux:field>
+                        <flux:label>Organization</flux:label>
+                        <div class="flex gap-2 items-center mt-1">
+                            @if ($editOrganizationId)
+                                <flux:badge>{{ $editOrganizationName }}</flux:badge>
+                                <flux:button size="sm" variant="ghost" wire:click="clearEditOrganization" icon="x-mark">Clear</flux:button>
+                            @else
+                                <flux:button size="sm" wire:click="openEditOrgPickerModal" icon="building-office">Add Organization</flux:button>
+                            @endif
+                        </div>
+                    </flux:field>
+                </div>
 
                 <flux:field>
                     <flux:label>Notes</flux:label>
@@ -938,6 +988,38 @@ new class extends Component
                 <flux:error name="editOrganizationSearch" />
             @else
                 <flux:text variant="subtle">No organizations yet. Type a name to create one.</flux:text>
+            @endif
+        </flux:modal>
+
+        {{-- Tag Picker Modal (for edit transaction) --}}
+        <flux:modal name="edit-tag-picker" class="w-full max-w-lg space-y-4">
+            <flux:heading size="lg">Select Tag</flux:heading>
+
+            <flux:field>
+                <flux:label>Search</flux:label>
+                <flux:input wire:model.live="editTagSearch" placeholder="Type to search…" />
+            </flux:field>
+
+            @php $editTagsFiltered = $this->filteredEditTags(); @endphp
+
+            @if ($editTagsFiltered->isNotEmpty())
+                <div class="space-y-1 max-h-64 overflow-y-auto">
+                    @foreach ($editTagsFiltered as $tag)
+                        <button type="button"
+                            wire:click="selectEditTag({{ $tag->id }})"
+                            class="w-full text-left px-3 py-2 rounded hover:bg-zinc-100 dark:hover:bg-zinc-700 text-sm">
+                            {{ $tag->name }}
+                        </button>
+                    @endforeach
+                </div>
+            @elseif ($editTagSearch !== '')
+                <flux:text variant="subtle">No match found.</flux:text>
+                <flux:button wire:click="createEditTagInline" variant="primary" size="sm" icon="plus">
+                    Create "{{ $editTagSearch }}"
+                </flux:button>
+                <flux:error name="editTagSearch" />
+            @else
+                <flux:text variant="subtle">Start typing to search or create a tag.</flux:text>
             @endif
         </flux:modal>
     @endcan

--- a/resources/views/livewire/finances/dashboard.blade.php
+++ b/resources/views/livewire/finances/dashboard.blade.php
@@ -778,7 +778,9 @@ new class extends Component
                                     <div class="flex gap-2">
                                         @if ($tx->type === 'transfer')
                                             <flux:tooltip content="Transfers cannot be edited — delete and re-enter if needed.">
-                                                <flux:button size="sm" icon="pencil-square" disabled>Edit</flux:button>
+                                                <span class="inline-flex">
+                                                    <flux:button size="sm" icon="pencil-square" disabled class="pointer-events-none">Edit</flux:button>
+                                                </span>
                                             </flux:tooltip>
                                         @else
                                             <flux:button size="sm" icon="pencil-square" wire:click="openEditModal({{ $tx->id }})">Edit</flux:button>

--- a/resources/views/livewire/finances/reports.blade.php
+++ b/resources/views/livewire/finances/reports.blade.php
@@ -1,27 +1,13 @@
 <?php
 
-use App\Actions\PublishPeriodReport;
-use App\Models\FinancialAccount;
-use App\Models\FinancialCategory;
 use App\Models\FinancialPeriodReport;
 use App\Models\FinancialTransaction;
-use App\Models\MonthlyBudget;
-use Flux\Flux;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\DB;
-use Livewire\Attributes\Locked;
 use Livewire\Volt\Component;
 
 new class extends Component
 {
-    // ── Publish modal state ───────────────────────────────────────────────────
-    #[Locked]
-    public ?string $publishMonth = null;
-
-    // ── View detail modal state ───────────────────────────────────────────────
-    #[Locked]
-    public ?string $viewMonth = null;
-
     // ── Report list ───────────────────────────────────────────────────────────
 
     public function months(): array
@@ -108,150 +94,6 @@ new class extends Component
 
         return $result;
     }
-
-    // ── Pre-publish summary ───────────────────────────────────────────────────
-
-    public function summaryForMonth(string $monthStart): array
-    {
-        // For published months, return the immutable snapshot stored at publish time.
-        $report = FinancialPeriodReport::whereDate('month', $monthStart)
-            ->whereNotNull('published_at')
-            ->first();
-
-        if ($report && $report->summary_snapshot !== null) {
-            $snap = $report->summary_snapshot;
-            // Ensure accountBalances is a Collection for template compatibility.
-            $snap['accountBalances'] = collect($snap['accountBalances']);
-
-            return $snap;
-        }
-
-        $monthEnd = Carbon::parse($monthStart)->endOfMonth()->toDateString();
-
-        $income = (int) FinancialTransaction::where('type', 'income')
-            ->whereBetween('transacted_at', [$monthStart, $monthEnd])
-            ->sum('amount');
-
-        $expense = (int) FinancialTransaction::where('type', 'expense')
-            ->whereBetween('transacted_at', [$monthStart, $monthEnd])
-            ->sum('amount');
-
-        // Account balances as of end of month — include all accounts regardless of archived
-        // status so that archiving an account later doesn't silently drop it from historical reports
-        $accounts = FinancialAccount::orderBy('name')->get();
-
-        $accountBalances = $accounts->map(function ($account) use ($monthEnd) {
-            $credits = (int) $account->transactions()->where('type', 'income')
-                ->where('transacted_at', '<=', $monthEnd)->sum('amount');
-            $debits = (int) $account->transactions()->where('type', 'expense')
-                ->where('transacted_at', '<=', $monthEnd)->sum('amount');
-            $transfersOut = (int) $account->transactions()->where('type', 'transfer')
-                ->where('transacted_at', '<=', $monthEnd)->sum('amount');
-            $transfersIn = (int) $account->incomingTransfers()->where('type', 'transfer')
-                ->where('transacted_at', '<=', $monthEnd)->sum('amount');
-            $balance = $account->opening_balance + $credits - $debits - $transfersOut + $transfersIn;
-
-            return ['name' => $account->name, 'balance' => $balance];
-        });
-
-        // Budget variance per top-level category — include all categories regardless of archived
-        // status so that archiving a category later doesn't silently drop it from historical reports
-        $categories = FinancialCategory::whereNull('parent_id')
-            ->orderBy('type')
-            ->orderBy('sort_order')
-            ->get();
-
-        $budgetVariances = [];
-        foreach ($categories as $cat) {
-            $planned = (int) optional(MonthlyBudget::whereDate('month', $monthStart)
-                ->where('financial_category_id', $cat->id)
-                ->first())->planned_amount;
-
-            $subIds = FinancialCategory::where('parent_id', $cat->id)->pluck('id');
-            $ids = $subIds->prepend($cat->id);
-            $actual = (int) FinancialTransaction::whereIn('financial_category_id', $ids)
-                ->whereBetween('transacted_at', [$monthStart, $monthEnd])
-                ->whereIn('type', ['income', 'expense'])
-                ->sum('amount');
-
-            if ($planned > 0 || $actual > 0) {
-                $budgetVariances[] = [
-                    'name' => $cat->name,
-                    'type' => $cat->type,
-                    'planned' => $planned,
-                    'actual' => $actual,
-                    // For expenses: positive variance = under budget (good). For income: positive = beat target (good).
-                    'variance' => $cat->type === 'income'
-                        ? $actual - $planned
-                        : $planned - $actual,
-                ];
-            }
-        }
-
-        return [
-            'income' => $income,
-            'expense' => $expense,
-            'net' => $income - $expense,
-            'accountBalances' => $accountBalances,
-            'budgetVariances' => $budgetVariances,
-        ];
-    }
-
-    public function openViewModal(string $monthStart): void
-    {
-        $this->authorize('financials-view');
-
-        $isPublished = FinancialPeriodReport::whereDate('month', $monthStart)
-            ->whereNotNull('published_at')
-            ->exists();
-
-        if (! $isPublished) {
-            abort(404);
-        }
-
-        $this->viewMonth = $monthStart;
-        Flux::modal('view-report-modal')->show();
-    }
-
-    public function closeViewModal(): void
-    {
-        $this->viewMonth = null;
-        Flux::modal('view-report-modal')->close();
-    }
-
-    public function openPublishModal(string $monthStart): void
-    {
-        $this->authorize('financials-treasurer');
-        $this->publishMonth = $monthStart;
-        Flux::modal('publish-report-modal')->show();
-    }
-
-    public function closePublishModal(): void
-    {
-        $this->publishMonth = null;
-        Flux::modal('publish-report-modal')->close();
-    }
-
-    public function confirmPublish(): void
-    {
-        $this->authorize('financials-treasurer');
-
-        if ($this->publishMonth === null) {
-            return;
-        }
-
-        try {
-            PublishPeriodReport::run($this->publishMonth, auth()->user());
-        } catch (\RuntimeException $e) {
-            Flux::toast($e->getMessage(), 'Error', variant: 'danger');
-
-            return;
-        }
-
-        Flux::modal('publish-report-modal')->close();
-        Flux::toast('Period report published.', 'Success', variant: 'success');
-        $this->publishMonth = null;
-    }
 }; ?>
 
 <div class="space-y-6">
@@ -282,7 +124,13 @@ new class extends Component
         <flux:table.rows>
             @forelse ($this->months() as $row)
                 <flux:table.row wire:key="report-{{ $row['ym'] }}">
-                    <flux:table.cell>{{ $row['label'] }}</flux:table.cell>
+                    <flux:table.cell>
+                        <a href="{{ route('finances.reports.show', ['month' => $row['ym']]) }}"
+                            wire:navigate
+                            class="text-blue-600 hover:underline dark:text-blue-400">
+                            {{ $row['label'] }}
+                        </a>
+                    </flux:table.cell>
                     <flux:table.cell class="text-green-500">${{ number_format($row['income'] / 100, 2) }}</flux:table.cell>
                     <flux:table.cell class="text-red-500">${{ number_format($row['expense'] / 100, 2) }}</flux:table.cell>
                     <flux:table.cell>
@@ -300,12 +148,7 @@ new class extends Component
                     <flux:table.cell>
                         <div class="flex gap-2">
                             @if ($row['published'])
-                                <flux:button size="sm" icon="eye" wire:click="openViewModal('{{ $row['monthStart'] }}')">View</flux:button>
                                 <flux:button size="sm" icon="arrow-down-tray" href="{{ route('finances.reports.pdf', ['month' => $row['ym']]) }}" target="_blank">PDF</flux:button>
-                            @else
-                                @can('financials-treasurer')
-                                    <flux:button size="sm" wire:click="openPublishModal('{{ $row['monthStart'] }}')">Publish</flux:button>
-                                @endcan
                             @endif
                         </div>
                     </flux:table.cell>
@@ -319,159 +162,5 @@ new class extends Component
             @endforelse
         </flux:table.rows>
     </flux:table>
-
-    {{-- View Report Modal --}}
-    <flux:modal name="view-report-modal" class="w-full max-w-2xl space-y-5">
-        @if ($viewMonth !== null)
-            @php $viewSummary = $this->summaryForMonth($viewMonth); @endphp
-
-            <flux:heading size="lg">
-                Period Report — {{ \Illuminate\Support\Carbon::parse($viewMonth)->format('F Y') }}
-            </flux:heading>
-
-            <div class="grid grid-cols-3 gap-4">
-                <flux:card class="text-center">
-                    <flux:text variant="subtle" class="text-sm">Total Income</flux:text>
-                    <flux:heading size="lg" class="text-green-500">${{ number_format($viewSummary['income'] / 100, 2) }}</flux:heading>
-                </flux:card>
-                <flux:card class="text-center">
-                    <flux:text variant="subtle" class="text-sm">Total Expenses</flux:text>
-                    <flux:heading size="lg" class="text-red-500">${{ number_format($viewSummary['expense'] / 100, 2) }}</flux:heading>
-                </flux:card>
-                <flux:card class="text-center">
-                    <flux:text variant="subtle" class="text-sm">Net Change</flux:text>
-                    <flux:heading size="lg" class="{{ $viewSummary['net'] >= 0 ? 'text-green-500' : 'text-red-500' }}">
-                        {{ $viewSummary['net'] >= 0 ? '+' : '' }}${{ number_format(abs($viewSummary['net']) / 100, 2) }}
-                    </flux:heading>
-                </flux:card>
-            </div>
-
-            @if ($viewSummary['accountBalances']->isNotEmpty())
-                <div>
-                    <flux:heading size="sm" class="mb-2">Account Balances</flux:heading>
-                    <div class="grid grid-cols-2 gap-2">
-                        @foreach ($viewSummary['accountBalances'] as $ab)
-                            <div class="flex justify-between text-sm">
-                                <span>{{ $ab['name'] }}</span>
-                                <span>${{ number_format($ab['balance'] / 100, 2) }}</span>
-                            </div>
-                        @endforeach
-                    </div>
-                </div>
-            @endif
-
-            @if (!empty($viewSummary['budgetVariances']))
-                <div>
-                    <flux:heading size="sm" class="mb-2">Budget Variance</flux:heading>
-                    <flux:table>
-                        <flux:table.columns>
-                            <flux:table.column>Category</flux:table.column>
-                            <flux:table.column>Planned</flux:table.column>
-                            <flux:table.column>Actual</flux:table.column>
-                            <flux:table.column>Variance</flux:table.column>
-                        </flux:table.columns>
-                        <flux:table.rows>
-                            @foreach ($viewSummary['budgetVariances'] as $bv)
-                                <flux:table.row>
-                                    <flux:table.cell>{{ $bv['name'] }}</flux:table.cell>
-                                    <flux:table.cell>{{ $bv['planned'] > 0 ? '$' . number_format($bv['planned'] / 100, 2) : '—' }}</flux:table.cell>
-                                    <flux:table.cell>{{ $bv['actual'] > 0 ? '$' . number_format($bv['actual'] / 100, 2) : '—' }}</flux:table.cell>
-                                    <flux:table.cell>
-                                        @php $v = $bv['variance']; @endphp
-                                        <span class="{{ $v >= 0 ? 'text-green-500' : 'text-red-500' }}">
-                                            {{ $v >= 0 ? '+' : '' }}${{ number_format(abs($v) / 100, 2) }}
-                                        </span>
-                                    </flux:table.cell>
-                                </flux:table.row>
-                            @endforeach
-                        </flux:table.rows>
-                    </flux:table>
-                </div>
-            @endif
-
-            <div class="flex gap-3 pt-2">
-                <flux:button href="{{ route('finances.reports.pdf', ['month' => \Illuminate\Support\Carbon::parse($viewMonth)->format('Y-m')]) }}" target="_blank" icon="arrow-down-tray">Download PDF</flux:button>
-                <flux:button wire:click="closeViewModal" variant="ghost">Close</flux:button>
-            </div>
-        @endif
-    </flux:modal>
-
-    {{-- Publish Modal --}}
-    @can('financials-treasurer')
-        <flux:modal name="publish-report-modal" class="w-full max-w-2xl space-y-5">
-            @if ($publishMonth !== null)
-                @php $summary = $this->summaryForMonth($publishMonth); @endphp
-
-                <flux:heading size="lg">Publish Report — {{ \Illuminate\Support\Carbon::parse($publishMonth)->format('F Y') }}</flux:heading>
-
-                <flux:text variant="subtle">Review this summary before publishing. Once published, all transactions in this month become read-only.</flux:text>
-
-                <div class="grid grid-cols-3 gap-4">
-                    <flux:card class="text-center">
-                        <flux:text variant="subtle" class="text-sm">Total Income</flux:text>
-                        <flux:heading size="lg" class="text-green-500">${{ number_format($summary['income'] / 100, 2) }}</flux:heading>
-                    </flux:card>
-                    <flux:card class="text-center">
-                        <flux:text variant="subtle" class="text-sm">Total Expenses</flux:text>
-                        <flux:heading size="lg" class="text-red-500">${{ number_format($summary['expense'] / 100, 2) }}</flux:heading>
-                    </flux:card>
-                    <flux:card class="text-center">
-                        <flux:text variant="subtle" class="text-sm">Net Change</flux:text>
-                        <flux:heading size="lg" class="{{ $summary['net'] >= 0 ? 'text-green-500' : 'text-red-500' }}">
-                            {{ $summary['net'] >= 0 ? '+' : '' }}${{ number_format(abs($summary['net']) / 100, 2) }}
-                        </flux:heading>
-                    </flux:card>
-                </div>
-
-                @if ($summary['accountBalances']->isNotEmpty())
-                    <div>
-                        <flux:heading size="sm" class="mb-2">Account Balances (as of end of month)</flux:heading>
-                        <div class="grid grid-cols-2 gap-2">
-                            @foreach ($summary['accountBalances'] as $ab)
-                                <div class="flex justify-between text-sm">
-                                    <span>{{ $ab['name'] }}</span>
-                                    <span>${{ number_format($ab['balance'] / 100, 2) }}</span>
-                                </div>
-                            @endforeach
-                        </div>
-                    </div>
-                @endif
-
-                @if (!empty($summary['budgetVariances']))
-                    <div>
-                        <flux:heading size="sm" class="mb-2">Budget Variance</flux:heading>
-                        <flux:table>
-                            <flux:table.columns>
-                                <flux:table.column>Category</flux:table.column>
-                                <flux:table.column>Planned</flux:table.column>
-                                <flux:table.column>Actual</flux:table.column>
-                                <flux:table.column>Variance</flux:table.column>
-                            </flux:table.columns>
-                            <flux:table.rows>
-                                @foreach ($summary['budgetVariances'] as $bv)
-                                    <flux:table.row>
-                                        <flux:table.cell>{{ $bv['name'] }}</flux:table.cell>
-                                        <flux:table.cell>{{ $bv['planned'] > 0 ? '$' . number_format($bv['planned'] / 100, 2) : '—' }}</flux:table.cell>
-                                        <flux:table.cell>{{ $bv['actual'] > 0 ? '$' . number_format($bv['actual'] / 100, 2) : '—' }}</flux:table.cell>
-                                        <flux:table.cell>
-                                            @php $v = $bv['variance']; @endphp
-                                            <span class="{{ $v >= 0 ? 'text-green-500' : 'text-red-500' }}">
-                                                {{ $v >= 0 ? '+' : '' }}${{ number_format(abs($v) / 100, 2) }}
-                                            </span>
-                                        </flux:table.cell>
-                                    </flux:table.row>
-                                @endforeach
-                            </flux:table.rows>
-                        </flux:table>
-                    </div>
-                @endif
-
-                <div class="flex gap-3 pt-2">
-                    <flux:button wire:click="confirmPublish" variant="primary" icon="lock-closed">Confirm & Publish</flux:button>
-                    <flux:button wire:click="closePublishModal" variant="ghost">Cancel</flux:button>
-                </div>
-            @endif
-        </flux:modal>
-    @endcan
 
 </div>

--- a/resources/views/livewire/finances/reports/show.blade.php
+++ b/resources/views/livewire/finances/reports/show.blade.php
@@ -1,0 +1,709 @@
+<?php
+
+use App\Actions\DeleteFinancialTransaction;
+use App\Actions\PublishPeriodReport;
+use App\Actions\UpdateFinancialTransaction;
+use App\Models\FinancialAccount;
+use App\Models\FinancialCategory;
+use App\Models\FinancialOrganization;
+use App\Models\FinancialPeriodReport;
+use App\Models\FinancialTag;
+use App\Models\FinancialTransaction;
+use App\Models\MonthlyBudget;
+use Flux\Flux;
+use Illuminate\Support\Carbon;
+use Livewire\Attributes\Computed;
+use Livewire\Volt\Component;
+
+new class extends Component
+{
+    public string $month = '';      // Y-m
+    public string $monthStart = ''; // Y-m-d
+    public string $monthEnd = '';   // Y-m-d
+    public bool $isPublished = false;
+
+    // ── Edit transaction ──────────────────────────────────────────────────────
+    public ?int $editTxId = null;
+
+    public string $editType = 'expense';
+
+    public string $editAccountId = '';
+
+    public string $editAmount = '';
+
+    public string $editDate = '';
+
+    public string $editCategoryId = '';
+
+    public string $editNotes = '';
+
+    public array $editTagIds = [];
+
+    public ?int $editOrganizationId = null;
+
+    public string $editOrganizationName = '';
+
+    public string $editOrganizationSearch = '';
+
+    public function mount(string $month): void
+    {
+        try {
+            $date = Carbon::createFromFormat('Y-m', $month)->startOfMonth();
+        } catch (\Exception $e) {
+            abort(404);
+        }
+
+        $this->month = $month;
+        $this->monthStart = $date->toDateString();
+        $this->monthEnd = Carbon::parse($this->monthStart)->endOfMonth()->toDateString();
+
+        $this->isPublished = FinancialPeriodReport::whereDate('month', $this->monthStart)
+            ->whereNotNull('published_at')
+            ->exists();
+
+        if ($this->isPublished) {
+            $this->authorize('financials-view');
+        } else {
+            $this->authorize('financials-treasurer');
+        }
+    }
+
+    // ── Summary ───────────────────────────────────────────────────────────────
+
+    public function summary(): array
+    {
+        // For published months, return the immutable snapshot.
+        $report = FinancialPeriodReport::whereDate('month', $this->monthStart)
+            ->whereNotNull('published_at')
+            ->first();
+
+        if ($report && $report->summary_snapshot !== null) {
+            $snap = $report->summary_snapshot;
+            $snap['accountBalances'] = collect($snap['accountBalances']);
+
+            return $snap;
+        }
+
+        $income = (int) FinancialTransaction::where('type', 'income')
+            ->whereBetween('transacted_at', [$this->monthStart, $this->monthEnd])
+            ->sum('amount');
+
+        $expense = (int) FinancialTransaction::where('type', 'expense')
+            ->whereBetween('transacted_at', [$this->monthStart, $this->monthEnd])
+            ->sum('amount');
+
+        $accounts = FinancialAccount::orderBy('name')->get();
+
+        $accountBalances = $accounts->map(function ($account) {
+            $credits = (int) $account->transactions()->where('type', 'income')
+                ->where('transacted_at', '<=', $this->monthEnd)->sum('amount');
+            $debits = (int) $account->transactions()->where('type', 'expense')
+                ->where('transacted_at', '<=', $this->monthEnd)->sum('amount');
+            $transfersOut = (int) $account->transactions()->where('type', 'transfer')
+                ->where('transacted_at', '<=', $this->monthEnd)->sum('amount');
+            $transfersIn = (int) $account->incomingTransfers()->where('type', 'transfer')
+                ->where('transacted_at', '<=', $this->monthEnd)->sum('amount');
+            $balance = $account->opening_balance + $credits - $debits - $transfersOut + $transfersIn;
+
+            return ['name' => $account->name, 'balance' => $balance];
+        });
+
+        $categories = FinancialCategory::whereNull('parent_id')
+            ->orderBy('type')
+            ->orderBy('sort_order')
+            ->get();
+
+        $budgetVariances = [];
+        foreach ($categories as $cat) {
+            $planned = (int) optional(MonthlyBudget::whereDate('month', $this->monthStart)
+                ->where('financial_category_id', $cat->id)
+                ->first())->planned_amount;
+
+            $subIds = FinancialCategory::where('parent_id', $cat->id)->pluck('id');
+            $ids = $subIds->prepend($cat->id);
+            $actual = (int) FinancialTransaction::whereIn('financial_category_id', $ids)
+                ->whereBetween('transacted_at', [$this->monthStart, $this->monthEnd])
+                ->whereIn('type', ['income', 'expense'])
+                ->sum('amount');
+
+            if ($planned > 0 || $actual > 0) {
+                $budgetVariances[] = [
+                    'name' => $cat->name,
+                    'type' => $cat->type,
+                    'planned' => $planned,
+                    'actual' => $actual,
+                    'variance' => $cat->type === 'income'
+                        ? $actual - $planned
+                        : $planned - $actual,
+                ];
+            }
+        }
+
+        return [
+            'income' => $income,
+            'expense' => $expense,
+            'net' => $income - $expense,
+            'accountBalances' => $accountBalances,
+            'budgetVariances' => $budgetVariances,
+        ];
+    }
+
+    // ── Transactions ──────────────────────────────────────────────────────────
+
+    #[Computed]
+    public function transactions(): \Illuminate\Database\Eloquent\Collection
+    {
+        return FinancialTransaction::with([
+            'account',
+            'targetAccount',
+            'category.parent',
+            'tags',
+            'enteredBy',
+            'organization',
+        ])
+            ->whereBetween('transacted_at', [$this->monthStart, $this->monthEnd])
+            ->orderBy('transacted_at', 'desc')
+            ->orderBy('id', 'desc')
+            ->get();
+    }
+
+    // ── Reference data for edit modal ─────────────────────────────────────────
+
+    public function accounts(): \Illuminate\Database\Eloquent\Collection
+    {
+        return FinancialAccount::where('is_archived', false)->orderBy('name')->get();
+    }
+
+    #[Computed]
+    public function tags(): \Illuminate\Database\Eloquent\Collection
+    {
+        return FinancialTag::where('is_archived', false)->orderBy('name')->get();
+    }
+
+    public function groupedCategoriesForType(string $type): array
+    {
+        $all = FinancialCategory::where('is_archived', false)
+            ->where('type', $type)
+            ->orderBy('sort_order')
+            ->get();
+
+        $topLevel = $all->whereNull('parent_id');
+        $byParent = $all->whereNotNull('parent_id')->groupBy('parent_id');
+
+        $groups = [];
+        foreach ($topLevel as $parent) {
+            $children = $byParent->get($parent->id, collect());
+            if ($children->isEmpty()) {
+                $groups[] = ['type' => 'option', 'id' => $parent->id, 'name' => $parent->name];
+            } else {
+                $groups[] = [
+                    'type' => 'group',
+                    'label' => $parent->name,
+                    'options' => $children->map(fn ($c) => ['id' => $c->id, 'name' => $c->name])->values()->all(),
+                ];
+            }
+        }
+
+        return $groups;
+    }
+
+    public function filteredOrganizations(string $search): \Illuminate\Database\Eloquent\Collection
+    {
+        return FinancialOrganization::where('is_archived', false)
+            ->when($search !== '', fn ($q) => $q->where('name', 'like', '%'.$search.'%'))
+            ->orderBy('name')
+            ->get();
+    }
+
+    // ── Publish ───────────────────────────────────────────────────────────────
+
+    public function publish(): void
+    {
+        $this->authorize('financials-treasurer');
+
+        try {
+            PublishPeriodReport::run($this->monthStart, auth()->user());
+        } catch (\RuntimeException $e) {
+            Flux::toast($e->getMessage(), 'Error', variant: 'danger');
+
+            return;
+        }
+
+        Flux::toast('Period report published.', 'Success', variant: 'success');
+        $this->redirect(route('finances.reports'), navigate: true);
+    }
+
+    // ── Edit transaction ──────────────────────────────────────────────────────
+
+    public function openEditModal(int $id): void
+    {
+        $this->authorize('financials-treasurer');
+
+        $tx = FinancialTransaction::with('tags')->findOrFail($id);
+
+        if ($tx->isInPublishedMonth()) {
+            Flux::toast('Cannot edit a transaction in a published month.', 'Error', variant: 'danger');
+
+            return;
+        }
+
+        if ($tx->type === 'transfer') {
+            Flux::toast('Transfer transactions cannot be edited. Delete and re-enter if needed.', 'Error', variant: 'danger');
+
+            return;
+        }
+
+        $this->editTxId = $id;
+        $this->editType = $tx->type;
+        $this->editAccountId = (string) $tx->account_id;
+        $this->editAmount = number_format($tx->amount / 100, 2, '.', '');
+        $this->editDate = $tx->transacted_at->format('Y-m-d');
+        $this->editNotes = $tx->notes ?? '';
+        $this->editTagIds = $tx->tags->pluck('id')->toArray();
+        $this->editOrganizationId = null;
+        $this->editOrganizationName = '';
+        $this->editOrganizationSearch = '';
+
+        if ($tx->financial_category_id !== null) {
+            $this->editCategoryId = (string) $tx->financial_category_id;
+        }
+
+        if ($tx->organization_id !== null) {
+            $this->editOrganizationId = $tx->organization_id;
+            $this->editOrganizationName = $tx->organization?->name ?? '';
+        }
+
+        Flux::modal('detail-edit-tx-modal')->show();
+    }
+
+    public function updateTransaction(): void
+    {
+        $this->authorize('financials-treasurer');
+
+        $this->validate([
+            'editType' => 'required|in:income,expense',
+            'editAccountId' => 'required|integer|exists:financial_accounts,id',
+            'editAmount' => 'required|numeric|min:0.01',
+            'editDate' => 'required|date',
+            'editCategoryId' => 'required|integer|exists:financial_categories,id',
+            'editNotes' => 'nullable|string|max:1000',
+            'editTagIds' => 'array',
+            'editTagIds.*' => 'integer|exists:financial_tags,id',
+        ]);
+
+        $tx = FinancialTransaction::findOrFail($this->editTxId);
+        $editAmountCents = (int) round((float) $this->editAmount * 100);
+
+        try {
+            UpdateFinancialTransaction::run(
+                $tx,
+                (int) $this->editAccountId,
+                $this->editType,
+                $editAmountCents,
+                $this->editDate,
+                (int) $this->editCategoryId,
+                null,
+                $this->editNotes ?: null,
+                $this->editTagIds,
+                $this->editOrganizationId,
+            );
+        } catch (\RuntimeException $e) {
+            Flux::toast($e->getMessage(), 'Error', variant: 'danger');
+
+            return;
+        }
+
+        Flux::modal('detail-edit-tx-modal')->close();
+        Flux::toast('Transaction updated.', 'Success', variant: 'success');
+        $this->reset(['editTxId', 'editType', 'editAccountId', 'editAmount', 'editDate', 'editCategoryId', 'editNotes', 'editTagIds', 'editOrganizationId', 'editOrganizationName', 'editOrganizationSearch']);
+        $this->editType = 'expense';
+        unset($this->transactions);
+    }
+
+    public function deleteTransaction(int $id): void
+    {
+        $this->authorize('financials-treasurer');
+
+        $tx = FinancialTransaction::findOrFail($id);
+
+        try {
+            DeleteFinancialTransaction::run($tx);
+        } catch (\RuntimeException $e) {
+            Flux::toast($e->getMessage(), 'Error', variant: 'danger');
+
+            return;
+        }
+
+        Flux::toast('Transaction deleted.', 'Success', variant: 'success');
+        unset($this->transactions);
+    }
+
+    public function openEditOrgPickerModal(): void
+    {
+        $this->authorize('financials-treasurer');
+        Flux::modal('detail-edit-org-picker')->show();
+    }
+
+    public function selectEditOrganization(int $id): void
+    {
+        $org = FinancialOrganization::findOrFail($id);
+        $this->editOrganizationId = $org->id;
+        $this->editOrganizationName = $org->name;
+        $this->editOrganizationSearch = '';
+        Flux::modal('detail-edit-org-picker')->close();
+    }
+
+    public function clearEditOrganization(): void
+    {
+        $this->editOrganizationId = null;
+        $this->editOrganizationName = '';
+    }
+
+    public function updatedEditType(): void
+    {
+        $this->editCategoryId = '';
+    }
+}; ?>
+
+<div class="space-y-8">
+
+    {{-- Finance Navigation --}}
+    <div class="flex flex-wrap gap-2">
+        <flux:button href="{{ route('finances.dashboard') }}" wire:navigate size="sm" icon="banknotes">Dashboard</flux:button>
+        <flux:button href="{{ route('finances.budget') }}" wire:navigate size="sm" icon="calculator">Budget</flux:button>
+        <flux:button href="{{ route('finances.reports') }}" wire:navigate size="sm" icon="document-text">Period Reports</flux:button>
+        @can('financials-manage')
+            <flux:button href="{{ route('finances.board-reports') }}" wire:navigate size="sm" icon="chart-bar">Board Reports</flux:button>
+            <flux:button href="{{ route('finances.accounts') }}" wire:navigate size="sm" icon="building-library">Accounts</flux:button>
+            <flux:button href="{{ route('finances.categories') }}" wire:navigate size="sm" icon="tag">Categories &amp; Tags</flux:button>
+        @endcan
+    </div>
+
+    {{-- Page heading --}}
+    <div class="flex items-center justify-between">
+        <div class="flex items-center gap-3">
+            <flux:heading size="xl">
+                Period Report — {{ \Illuminate\Support\Carbon::createFromFormat('Y-m', $month)->format('F Y') }}
+            </flux:heading>
+            @if ($isPublished)
+                <flux:badge variant="success">Published</flux:badge>
+            @else
+                <flux:badge variant="zinc">Unpublished</flux:badge>
+            @endif
+        </div>
+        <flux:button href="{{ route('finances.reports') }}" wire:navigate size="sm" icon="arrow-left" variant="ghost">
+            Back to Reports
+        </flux:button>
+    </div>
+
+    @php $summary = $this->summary(); @endphp
+
+    {{-- Summary cards --}}
+    <div class="grid grid-cols-3 gap-4">
+        <flux:card class="text-center">
+            <flux:text variant="subtle" class="text-sm">Total Income</flux:text>
+            <flux:heading size="lg" class="text-green-500">${{ number_format($summary['income'] / 100, 2) }}</flux:heading>
+        </flux:card>
+        <flux:card class="text-center">
+            <flux:text variant="subtle" class="text-sm">Total Expenses</flux:text>
+            <flux:heading size="lg" class="text-red-500">${{ number_format($summary['expense'] / 100, 2) }}</flux:heading>
+        </flux:card>
+        <flux:card class="text-center">
+            <flux:text variant="subtle" class="text-sm">Net Change</flux:text>
+            <flux:heading size="lg" class="{{ $summary['net'] >= 0 ? 'text-green-500' : 'text-red-500' }}">
+                {{ $summary['net'] >= 0 ? '+' : '' }}${{ number_format(abs($summary['net']) / 100, 2) }}
+            </flux:heading>
+        </flux:card>
+    </div>
+
+    {{-- Account Balances --}}
+    @if ($summary['accountBalances']->isNotEmpty())
+        <div>
+            <flux:heading size="sm" class="mb-2">Account Balances (as of end of month)</flux:heading>
+            <div class="grid grid-cols-2 gap-2">
+                @foreach ($summary['accountBalances'] as $ab)
+                    <div class="flex justify-between text-sm">
+                        <span>{{ $ab['name'] }}</span>
+                        <span>${{ number_format($ab['balance'] / 100, 2) }}</span>
+                    </div>
+                @endforeach
+            </div>
+        </div>
+    @endif
+
+    {{-- Budget Variance --}}
+    @if (!empty($summary['budgetVariances']))
+        <div>
+            <flux:heading size="sm" class="mb-2">Budget Variance</flux:heading>
+            <flux:table>
+                <flux:table.columns>
+                    <flux:table.column>Category</flux:table.column>
+                    <flux:table.column>Planned</flux:table.column>
+                    <flux:table.column>Actual</flux:table.column>
+                    <flux:table.column>Variance</flux:table.column>
+                </flux:table.columns>
+                <flux:table.rows>
+                    @foreach ($summary['budgetVariances'] as $bv)
+                        <flux:table.row>
+                            <flux:table.cell>{{ $bv['name'] }}</flux:table.cell>
+                            <flux:table.cell>{{ $bv['planned'] > 0 ? '$' . number_format($bv['planned'] / 100, 2) : '—' }}</flux:table.cell>
+                            <flux:table.cell>{{ $bv['actual'] > 0 ? '$' . number_format($bv['actual'] / 100, 2) : '—' }}</flux:table.cell>
+                            <flux:table.cell>
+                                @php $v = $bv['variance']; @endphp
+                                <span class="{{ $v >= 0 ? 'text-green-500' : 'text-red-500' }}">
+                                    {{ $v >= 0 ? '+' : '' }}${{ number_format(abs($v) / 100, 2) }}
+                                </span>
+                            </flux:table.cell>
+                        </flux:table.row>
+                    @endforeach
+                </flux:table.rows>
+            </flux:table>
+        </div>
+    @endif
+
+    {{-- Transaction List --}}
+    <div>
+        <flux:heading size="sm" class="mb-2">Transactions</flux:heading>
+        <flux:table>
+            <flux:table.columns>
+                <flux:table.column>Date</flux:table.column>
+                <flux:table.column>Account</flux:table.column>
+                <flux:table.column>Type</flux:table.column>
+                <flux:table.column>Category</flux:table.column>
+                <flux:table.column>Amount</flux:table.column>
+                <flux:table.column>Organization</flux:table.column>
+                <flux:table.column>Tags</flux:table.column>
+                <flux:table.column>Notes</flux:table.column>
+                @if (!$isPublished)
+                    @can('financials-treasurer')
+                        <flux:table.column>Actions</flux:table.column>
+                    @endcan
+                @endif
+            </flux:table.columns>
+            <flux:table.rows>
+                @forelse ($this->transactions as $tx)
+                    <flux:table.row wire:key="detail-tx-{{ $tx->id }}">
+                        <flux:table.cell>{{ $tx->transacted_at->format('Y-m-d') }}</flux:table.cell>
+                        <flux:table.cell>
+                            @if ($tx->type === 'transfer')
+                                {{ $tx->account?->name }} → {{ $tx->targetAccount?->name }}
+                            @else
+                                {{ $tx->account?->name }}
+                            @endif
+                        </flux:table.cell>
+                        <flux:table.cell>
+                            @if ($tx->type === 'income')
+                                <flux:badge variant="success">Income</flux:badge>
+                            @elseif ($tx->type === 'expense')
+                                <flux:badge variant="danger">Expense</flux:badge>
+                            @else
+                                <flux:badge variant="zinc">Transfer</flux:badge>
+                            @endif
+                        </flux:table.cell>
+                        <flux:table.cell>
+                            @if ($tx->category)
+                                @if ($tx->category->parent)
+                                    {{ $tx->category->parent->name }} / {{ $tx->category->name }}
+                                @else
+                                    {{ $tx->category->name }}
+                                @endif
+                            @endif
+                        </flux:table.cell>
+                        <flux:table.cell>${{ number_format($tx->amount / 100, 2) }}</flux:table.cell>
+                        <flux:table.cell>
+                            @if ($tx->organization)
+                                <flux:badge size="sm" variant="zinc">{{ $tx->organization->name }}</flux:badge>
+                            @endif
+                        </flux:table.cell>
+                        <flux:table.cell>
+                            <div class="flex flex-wrap gap-1">
+                                @foreach ($tx->tags as $tag)
+                                    <flux:badge size="sm">{{ $tag->name }}</flux:badge>
+                                @endforeach
+                            </div>
+                        </flux:table.cell>
+                        <flux:table.cell>{{ $tx->notes }}</flux:table.cell>
+                        @if (!$isPublished)
+                            @can('financials-treasurer')
+                                <flux:table.cell>
+                                    <div class="flex gap-2">
+                                        @if ($tx->type === 'transfer')
+                                            <flux:tooltip content="Transfers cannot be edited — delete and re-enter if needed.">
+                                                <flux:button size="sm" icon="pencil-square" disabled>Edit</flux:button>
+                                            </flux:tooltip>
+                                        @else
+                                            <flux:button size="sm" icon="pencil-square" wire:click="openEditModal({{ $tx->id }})">Edit</flux:button>
+                                        @endif
+                                        <flux:button size="sm" variant="danger" icon="trash"
+                                            wire:click="deleteTransaction({{ $tx->id }})"
+                                            wire:confirm="Delete this transaction? This cannot be undone.">
+                                            Delete
+                                        </flux:button>
+                                    </div>
+                                </flux:table.cell>
+                            @endcan
+                        @endif
+                    </flux:table.row>
+                @empty
+                    <flux:table.row>
+                        <flux:table.cell colspan="9">
+                            <flux:text variant="subtle">No transactions found for this month.</flux:text>
+                        </flux:table.cell>
+                    </flux:table.row>
+                @endforelse
+            </flux:table.rows>
+        </flux:table>
+    </div>
+
+    {{-- Action buttons --}}
+    <div class="flex gap-3">
+        @if ($isPublished)
+            <flux:button href="{{ route('finances.reports.pdf', ['month' => $month]) }}" target="_blank" icon="arrow-down-tray">
+                Download PDF
+            </flux:button>
+        @else
+            @can('financials-treasurer')
+                <flux:button wire:click="publish" variant="primary" icon="lock-closed"
+                    wire:confirm="Publish this report? All transactions in this month will become read-only.">
+                    Confirm &amp; Publish
+                </flux:button>
+            @endcan
+        @endif
+        <flux:button href="{{ route('finances.reports') }}" wire:navigate variant="ghost" icon="arrow-left">
+            Back to Reports
+        </flux:button>
+    </div>
+
+    {{-- Edit Transaction Modal (unpublished months, treasurer only) --}}
+    @if (!$isPublished)
+        @can('financials-treasurer')
+            <flux:modal name="detail-edit-tx-modal" class="w-full max-w-2xl space-y-5">
+                <flux:heading size="lg">Edit Transaction</flux:heading>
+
+                <form wire:submit.prevent="updateTransaction" class="space-y-4">
+                    <div class="grid grid-cols-2 gap-4">
+                        <flux:field>
+                            <flux:label>Type <span class="text-red-500">*</span></flux:label>
+                            <flux:select wire:model.live="editType">
+                                <flux:select.option value="expense">Expense</flux:select.option>
+                                <flux:select.option value="income">Income</flux:select.option>
+                            </flux:select>
+                            <flux:error name="editType" />
+                        </flux:field>
+
+                        <flux:field>
+                            <flux:label>Account <span class="text-red-500">*</span></flux:label>
+                            <flux:select wire:model="editAccountId">
+                                <flux:select.option value="">— Select Account —</flux:select.option>
+                                @foreach ($this->accounts() as $account)
+                                    <flux:select.option value="{{ $account->id }}">{{ $account->name }}</flux:select.option>
+                                @endforeach
+                            </flux:select>
+                            <flux:error name="editAccountId" />
+                        </flux:field>
+                    </div>
+
+                    <div class="grid grid-cols-2 gap-4">
+                        <flux:field>
+                            <flux:label>Amount ($) <span class="text-red-500">*</span></flux:label>
+                            <flux:input wire:model="editAmount" type="number" step="0.01" min="0.01" />
+                            <flux:error name="editAmount" />
+                        </flux:field>
+
+                        <flux:field>
+                            <flux:label>Date <span class="text-red-500">*</span></flux:label>
+                            <flux:input wire:model="editDate" type="date" />
+                            <flux:error name="editDate" />
+                        </flux:field>
+                    </div>
+
+                    <flux:field>
+                        <flux:label>Category <span class="text-red-500">*</span></flux:label>
+                        <select wire:model="editCategoryId"
+                            class="w-full rounded-lg border border-zinc-300 bg-white px-3 py-2 text-sm dark:border-zinc-700 dark:bg-zinc-800">
+                            <option value="">— Select Category —</option>
+                            @foreach ($this->groupedCategoriesForType($editType) as $item)
+                                @if ($item['type'] === 'group')
+                                    <optgroup label="{{ $item['label'] }}">
+                                        @foreach ($item['options'] as $opt)
+                                            <option value="{{ $opt['id'] }}">{{ $opt['name'] }}</option>
+                                        @endforeach
+                                    </optgroup>
+                                @else
+                                    <option value="{{ $item['id'] }}">{{ $item['name'] }}</option>
+                                @endif
+                            @endforeach
+                        </select>
+                        <flux:error name="editCategoryId" />
+                    </flux:field>
+
+                    <flux:field>
+                        <flux:label>Tags</flux:label>
+                        <div class="flex flex-wrap gap-2 mt-1">
+                            @foreach ($this->tags as $tag)
+                                <label class="flex items-center gap-1 text-sm cursor-pointer">
+                                    <input type="checkbox" wire:model="editTagIds" value="{{ $tag->id }}"
+                                        class="rounded border-zinc-600" />
+                                    {{ $tag->name }}
+                                </label>
+                            @endforeach
+                        </div>
+                        <flux:error name="editTagIds" />
+                    </flux:field>
+
+                    <flux:field>
+                        <flux:label>Organization</flux:label>
+                        <div class="flex gap-2 items-center">
+                            @if ($editOrganizationId)
+                                <flux:badge>{{ $editOrganizationName }}</flux:badge>
+                                <flux:button size="sm" variant="ghost" wire:click="clearEditOrganization" icon="x-mark">Clear</flux:button>
+                            @else
+                                <flux:button size="sm" wire:click="openEditOrgPickerModal" icon="building-office">Add Organization</flux:button>
+                            @endif
+                        </div>
+                    </flux:field>
+
+                    <flux:field>
+                        <flux:label>Notes</flux:label>
+                        <flux:textarea wire:model="editNotes" rows="2" />
+                        <flux:error name="editNotes" />
+                    </flux:field>
+
+                    <div class="flex gap-3 pt-2">
+                        <flux:button type="submit" variant="primary">Save Changes</flux:button>
+                        <flux:button x-on:click="$flux.modal('detail-edit-tx-modal').close()" variant="ghost">Cancel</flux:button>
+                    </div>
+                </form>
+            </flux:modal>
+
+            {{-- Organization Picker Modal --}}
+            <flux:modal name="detail-edit-org-picker" class="w-full max-w-lg space-y-4">
+                <flux:heading size="lg">Select Organization</flux:heading>
+
+                <flux:field>
+                    <flux:label>Search</flux:label>
+                    <flux:input wire:model.live="editOrganizationSearch" placeholder="Type to search…" />
+                </flux:field>
+
+                @php $editFiltered = $this->filteredOrganizations($editOrganizationSearch); @endphp
+
+                @if ($editFiltered->isNotEmpty())
+                    <div class="space-y-1 max-h-64 overflow-y-auto">
+                        @foreach ($editFiltered as $org)
+                            <button type="button"
+                                wire:click="selectEditOrganization({{ $org->id }})"
+                                class="w-full text-left px-3 py-2 rounded hover:bg-zinc-100 dark:hover:bg-zinc-700 text-sm">
+                                {{ $org->name }}
+                            </button>
+                        @endforeach
+                    </div>
+                @elseif ($editOrganizationSearch !== '')
+                    <flux:text variant="subtle">No match found.</flux:text>
+                @else
+                    <flux:text variant="subtle">No organizations yet.</flux:text>
+                @endif
+            </flux:modal>
+        @endcan
+    @endif
+
+</div>

--- a/resources/views/livewire/finances/reports/show.blade.php
+++ b/resources/views/livewire/finances/reports/show.blade.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Actions\CreateFinancialTag;
 use App\Actions\DeleteFinancialTransaction;
 use App\Actions\PublishPeriodReport;
 use App\Actions\UpdateFinancialTransaction;
@@ -44,6 +45,8 @@ new class extends Component
     public string $editOrganizationName = '';
 
     public string $editOrganizationSearch = '';
+
+    public string $editTagSearch = '';
 
     public function mount(string $month): void
     {
@@ -263,6 +266,7 @@ new class extends Component
         $this->editOrganizationId = null;
         $this->editOrganizationName = '';
         $this->editOrganizationSearch = '';
+        $this->editTagSearch = '';
 
         if ($tx->financial_category_id !== null) {
             $this->editCategoryId = (string) $tx->financial_category_id;
@@ -315,7 +319,7 @@ new class extends Component
 
         Flux::modal('detail-edit-tx-modal')->close();
         Flux::toast('Transaction updated.', 'Success', variant: 'success');
-        $this->reset(['editTxId', 'editType', 'editAccountId', 'editAmount', 'editDate', 'editCategoryId', 'editNotes', 'editTagIds', 'editOrganizationId', 'editOrganizationName', 'editOrganizationSearch']);
+        $this->reset(['editTxId', 'editType', 'editAccountId', 'editAmount', 'editDate', 'editCategoryId', 'editNotes', 'editTagIds', 'editOrganizationId', 'editOrganizationName', 'editOrganizationSearch', 'editTagSearch']);
         $this->editType = 'expense';
         unset($this->transactions);
     }
@@ -357,6 +361,48 @@ new class extends Component
     {
         $this->editOrganizationId = null;
         $this->editOrganizationName = '';
+    }
+
+    public function openEditTagPickerModal(): void
+    {
+        $this->authorize('financials-treasurer');
+        Flux::modal('detail-edit-tag-picker')->show();
+    }
+
+    public function selectEditTag(int $id): void
+    {
+        $this->authorize('financials-treasurer');
+        if (! in_array($id, $this->editTagIds)) {
+            $this->editTagIds[] = $id;
+        }
+        $this->editTagSearch = '';
+        Flux::modal('detail-edit-tag-picker')->close();
+    }
+
+    public function removeEditTag(int $id): void
+    {
+        $this->authorize('financials-treasurer');
+        $this->editTagIds = array_values(array_filter($this->editTagIds, fn ($t) => $t !== $id));
+    }
+
+    public function createEditTagInline(): void
+    {
+        $this->authorize('financials-treasurer');
+
+        $this->validate([
+            'editTagSearch' => 'required|string|max:100|unique:financial_tags,name',
+        ]);
+
+        $tag = CreateFinancialTag::run($this->editTagSearch, auth()->user());
+        $this->selectEditTag($tag->id);
+    }
+
+    public function filteredEditTags(): \Illuminate\Database\Eloquent\Collection
+    {
+        return FinancialTag::where('is_archived', false)
+            ->when($this->editTagSearch !== '', fn ($q) => $q->where('name', 'like', '%'.$this->editTagSearch.'%'))
+            ->orderBy('name')
+            ->get();
     }
 
     public function updatedEditType(): void
@@ -529,7 +575,9 @@ new class extends Component
                                     <div class="flex gap-2">
                                         @if ($tx->type === 'transfer')
                                             <flux:tooltip content="Transfers cannot be edited — delete and re-enter if needed.">
-                                                <flux:button size="sm" icon="pencil-square" disabled>Edit</flux:button>
+                                                <span class="inline-flex">
+                                                    <flux:button size="sm" icon="pencil-square" disabled class="pointer-events-none">Edit</flux:button>
+                                                </span>
                                             </flux:tooltip>
                                         @else
                                             <flux:button size="sm" icon="pencil-square" wire:click="openEditModal({{ $tx->id }})">Edit</flux:button>
@@ -639,15 +687,18 @@ new class extends Component
 
                     <flux:field>
                         <flux:label>Tags</flux:label>
-                        <div class="flex flex-wrap gap-2 mt-1">
-                            @foreach ($this->tags as $tag)
-                                <label class="flex items-center gap-1 text-sm cursor-pointer">
-                                    <input type="checkbox" wire:model="editTagIds" value="{{ $tag->id }}"
-                                        class="rounded border-zinc-600" />
-                                    {{ $tag->name }}
-                                </label>
+                        <div class="flex flex-wrap gap-1 mb-1">
+                            @foreach ($this->editTagIds as $tagId)
+                                @php $tag = $this->filteredEditTags()->firstWhere('id', $tagId) ?? \App\Models\FinancialTag::find($tagId); @endphp
+                                @if ($tag)
+                                    <flux:badge>
+                                        {{ $tag->name }}
+                                        <button type="button" wire:click="removeEditTag({{ $tag->id }})" class="ml-1 opacity-70 hover:opacity-100">&times;</button>
+                                    </flux:badge>
+                                @endif
                             @endforeach
                         </div>
+                        <flux:button size="sm" wire:click="openEditTagPickerModal" icon="tag">Add Tag</flux:button>
                         <flux:error name="editTagIds" />
                     </flux:field>
 
@@ -701,6 +752,37 @@ new class extends Component
                     <flux:text variant="subtle">No match found.</flux:text>
                 @else
                     <flux:text variant="subtle">No organizations yet.</flux:text>
+                @endif
+            </flux:modal>
+            {{-- Tag Picker Modal --}}
+            <flux:modal name="detail-edit-tag-picker" class="w-full max-w-lg space-y-4">
+                <flux:heading size="lg">Select Tag</flux:heading>
+
+                <flux:field>
+                    <flux:label>Search</flux:label>
+                    <flux:input wire:model.live="editTagSearch" placeholder="Type to search…" />
+                </flux:field>
+
+                @php $editTagsFiltered = $this->filteredEditTags(); @endphp
+
+                @if ($editTagsFiltered->isNotEmpty())
+                    <div class="space-y-1 max-h-64 overflow-y-auto">
+                        @foreach ($editTagsFiltered as $tag)
+                            <button type="button"
+                                wire:click="selectEditTag({{ $tag->id }})"
+                                class="w-full text-left px-3 py-2 rounded hover:bg-zinc-100 dark:hover:bg-zinc-700 text-sm">
+                                {{ $tag->name }}
+                            </button>
+                        @endforeach
+                    </div>
+                @elseif ($editTagSearch !== '')
+                    <flux:text variant="subtle">No match found.</flux:text>
+                    <flux:button wire:click="createEditTagInline" variant="primary" size="sm" icon="plus">
+                        Create "{{ $editTagSearch }}"
+                    </flux:button>
+                    <flux:error name="editTagSearch" />
+                @else
+                    <flux:text variant="subtle">Start typing to search or create a tag.</flux:text>
                 @endif
             </flux:modal>
         @endcan

--- a/resources/views/livewire/users/display-basic-details.blade.php
+++ b/resources/views/livewire/users/display-basic-details.blade.php
@@ -538,6 +538,14 @@ new class extends Component {
                                     </flux:menu.item>
                                 @endif
                             @endcan
+
+                            @can('createAsStaff', \App\Models\Thread::class)
+                                @if($user->id !== Auth::id())
+                                    <flux:menu.item icon="ticket" href="{{ route('tickets.create-admin', ['user_id' => $user->id]) }}">
+                                        Open Admin Ticket
+                                    </flux:menu.item>
+                                @endif
+                            @endcan
                         </flux:menu>
                     </flux:dropdown>
                 </div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -195,6 +195,7 @@ Route::prefix('finances')
         Volt::route('/categories', 'finances.categories')->name('categories');
         Volt::route('/budget/{month?}', 'finances.budget')->name('budget');
         Volt::route('/reports', 'finances.reports')->name('reports');
+        Volt::route('/reports/{month}', 'finances.reports.show')->name('reports.show');
         Route::get('/reports/{month}/pdf', \App\Http\Controllers\Finances\PeriodReportPdfController::class)->name('reports.pdf');
         Volt::route('/board-reports', 'finances.board-reports')->name('board-reports');
         Route::get('/board-reports/income-statement/pdf', \App\Http\Controllers\Finances\IncomeStatementPdfController::class)->name('board-reports.income-statement.pdf');

--- a/tests/Feature/Finances/PeriodReportPublishingTest.php
+++ b/tests/Feature/Finances/PeriodReportPublishingTest.php
@@ -72,7 +72,7 @@ it('publish action stores a summary snapshot', function () {
         ->and($report->summary_snapshot['net'])->toBe(5000);
 });
 
-it('summaryForMonth returns snapshot for published month instead of live queries', function () {
+it('detail page summary returns snapshot for published month instead of live queries', function () {
     $user = User::factory()->withRole('Financials - Treasurer')->create();
     $account = FinancialAccount::factory()->create(['opening_balance' => 0, 'name' => 'Original Name']);
     $category = FinancialCategory::factory()->income()->create();
@@ -92,8 +92,8 @@ it('summaryForMonth returns snapshot for published month instead of live queries
     // Rename the account after publication
     $account->update(['name' => 'Renamed After Publish']);
 
-    $component = livewire('finances.reports');
-    $summary = $component->instance()->summaryForMonth('2026-03-01');
+    $component = livewire('finances.reports.show', ['month' => '2026-03']);
+    $summary = $component->instance()->summary();
 
     // Snapshot should preserve the name at publish time, not the renamed value
     $names = collect($summary['accountBalances'])->pluck('name')->all();
@@ -145,7 +145,7 @@ it('treasurer sees publish button for unpublished month with transactions', func
         ->and($march['published'])->toBeFalse();
 });
 
-it('treasurer can publish a month via confirmPublish', function () {
+it('treasurer can publish a month via the detail page', function () {
     $user = User::factory()->withRole('Financials - Treasurer')->create();
     $account = FinancialAccount::factory()->create();
     $this->actingAs($user);
@@ -156,9 +156,8 @@ it('treasurer can publish a month via confirmPublish', function () {
         'entered_by' => $user->id,
     ]);
 
-    livewire('finances.reports')
-        ->call('openPublishModal', '2026-03-01')
-        ->call('confirmPublish');
+    livewire('finances.reports.show', ['month' => '2026-03'])
+        ->call('publish');
 
     expect(FinancialPeriodReport::whereDate('month', '2026-03-01')->first()?->isPublished())->toBeTrue();
 });
@@ -183,7 +182,7 @@ it('published month shows as published in report list', function () {
     expect($march['published'])->toBeTrue();
 });
 
-it('view-only user cannot publish a month', function () {
+it('view-only user cannot access the detail page for an unpublished month', function () {
     $user = User::factory()->withRole('Financials - View')->create();
     $account = FinancialAccount::factory()->create();
     $this->actingAs($user);
@@ -194,8 +193,7 @@ it('view-only user cannot publish a month', function () {
         'entered_by' => $user->id,
     ]);
 
-    livewire('finances.reports')
-        ->call('openPublishModal', '2026-03-01')
+    livewire('finances.reports.show', ['month' => '2026-03'])
         ->assertForbidden();
 
     expect(FinancialPeriodReport::count())->toBe(0);

--- a/tests/Feature/Finances/PeriodReportViewTest.php
+++ b/tests/Feature/Finances/PeriodReportViewTest.php
@@ -71,7 +71,7 @@ it('treasurer sees both published and unpublished months', function () {
 
 // == View modal == //
 
-it('view-only user can open view modal for a published month', function () {
+it('view-only user can access the detail page for a published month', function () {
     $user = User::factory()->withRole('Financials - View')->create();
     $account = FinancialAccount::factory()->create();
     $this->actingAs($user);
@@ -83,12 +83,12 @@ it('view-only user can open view modal for a published month', function () {
     ]);
     FinancialPeriodReport::factory()->published()->forMonth('2026-03-01')->create();
 
-    livewire('finances.reports')
-        ->call('openViewModal', '2026-03-01')
-        ->assertSet('viewMonth', '2026-03-01');
+    livewire('finances.reports.show', ['month' => '2026-03'])
+        ->assertOk()
+        ->assertSet('isPublished', true);
 });
 
-it('view-only user cannot open view modal for an unpublished month', function () {
+it('view-only user cannot access the detail page for an unpublished month', function () {
     $user = User::factory()->withRole('Financials - View')->create();
     $account = FinancialAccount::factory()->create();
     $this->actingAs($user);
@@ -100,10 +100,8 @@ it('view-only user cannot open view modal for an unpublished month', function ()
     ]);
 
     // No published report for March
-
-    livewire('finances.reports')
-        ->call('openViewModal', '2026-03-01')
-        ->assertNotFound();
+    livewire('finances.reports.show', ['month' => '2026-03'])
+        ->assertForbidden();
 });
 
 // == PDF download route == //

--- a/tests/Feature/Finances/ReportDetailPageTest.php
+++ b/tests/Feature/Finances/ReportDetailPageTest.php
@@ -1,0 +1,356 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Actions\PublishPeriodReport;
+use App\Models\FinancialAccount;
+use App\Models\FinancialCategory;
+use App\Models\FinancialPeriodReport;
+use App\Models\FinancialTransaction;
+use App\Models\User;
+
+use function Pest\Livewire\livewire;
+
+uses()->group('finances', 'report-detail');
+
+// == Route access == //
+
+it('treasurer can access the detail page for an unpublished month', function () {
+    $user = User::factory()->withRole('Financials - Treasurer')->create();
+    $account = FinancialAccount::factory()->create();
+    $this->actingAs($user);
+
+    FinancialTransaction::factory()->create([
+        'account_id' => $account->id,
+        'transacted_at' => '2026-03-15',
+        'entered_by' => $user->id,
+    ]);
+
+    $this->get(route('finances.reports.show', ['month' => '2026-03']))->assertOk();
+});
+
+it('treasurer can access the detail page for a published month', function () {
+    $user = User::factory()->withRole('Financials - Treasurer')->create();
+    $account = FinancialAccount::factory()->create();
+    $this->actingAs($user);
+
+    FinancialTransaction::factory()->create([
+        'account_id' => $account->id,
+        'transacted_at' => '2026-03-15',
+        'entered_by' => $user->id,
+    ]);
+    FinancialPeriodReport::factory()->published()->forMonth('2026-03-01')->create();
+
+    $this->get(route('finances.reports.show', ['month' => '2026-03']))->assertOk();
+});
+
+it('financials-view user can access the detail page for a published month', function () {
+    $user = User::factory()->withRole('Financials - View')->create();
+    $account = FinancialAccount::factory()->create();
+    $this->actingAs($user);
+
+    FinancialTransaction::factory()->create([
+        'account_id' => $account->id,
+        'transacted_at' => '2026-03-15',
+        'entered_by' => $user->id,
+    ]);
+    FinancialPeriodReport::factory()->published()->forMonth('2026-03-01')->create();
+
+    $this->get(route('finances.reports.show', ['month' => '2026-03']))->assertOk();
+});
+
+it('financials-view user is forbidden from the detail page of an unpublished month', function () {
+    $user = User::factory()->withRole('Financials - View')->create();
+    $account = FinancialAccount::factory()->create();
+    $this->actingAs($user);
+
+    FinancialTransaction::factory()->create([
+        'account_id' => $account->id,
+        'transacted_at' => '2026-03-15',
+        'entered_by' => $user->id,
+    ]);
+
+    livewire('finances.reports.show', ['month' => '2026-03'])
+        ->assertForbidden();
+});
+
+// == Detail page content == //
+
+it('detail page shows the month heading', function () {
+    $user = User::factory()->withRole('Financials - Treasurer')->create();
+    $account = FinancialAccount::factory()->create();
+    $this->actingAs($user);
+
+    FinancialTransaction::factory()->create([
+        'account_id' => $account->id,
+        'transacted_at' => '2026-03-15',
+        'entered_by' => $user->id,
+    ]);
+
+    livewire('finances.reports.show', ['month' => '2026-03'])
+        ->assertSee('March 2026');
+});
+
+it('detail page shows transactions for the month', function () {
+    $user = User::factory()->withRole('Financials - Treasurer')->create();
+    $account = FinancialAccount::factory()->create();
+    $category = FinancialCategory::factory()->expense()->create(['name' => 'Infrastructure']);
+    $this->actingAs($user);
+
+    FinancialTransaction::factory()->create([
+        'account_id' => $account->id,
+        'financial_category_id' => $category->id,
+        'type' => 'expense',
+        'amount' => 5000,
+        'transacted_at' => '2026-03-15',
+        'entered_by' => $user->id,
+        'notes' => 'Hosting bill',
+    ]);
+
+    livewire('finances.reports.show', ['month' => '2026-03'])
+        ->assertSee('Hosting bill');
+});
+
+it('detail page does not show transactions from other months', function () {
+    $user = User::factory()->withRole('Financials - Treasurer')->create();
+    $account = FinancialAccount::factory()->create();
+    $this->actingAs($user);
+
+    FinancialTransaction::factory()->create([
+        'account_id' => $account->id,
+        'transacted_at' => '2026-03-15',
+        'notes' => 'March transaction',
+        'entered_by' => $user->id,
+    ]);
+
+    FinancialTransaction::factory()->create([
+        'account_id' => $account->id,
+        'transacted_at' => '2026-04-10',
+        'notes' => 'April transaction',
+        'entered_by' => $user->id,
+    ]);
+
+    livewire('finances.reports.show', ['month' => '2026-03'])
+        ->assertSee('March transaction')
+        ->assertDontSee('April transaction');
+});
+
+it('detail page shows Publish button for treasurer on unpublished month', function () {
+    $user = User::factory()->withRole('Financials - Treasurer')->create();
+    $account = FinancialAccount::factory()->create();
+    $this->actingAs($user);
+
+    FinancialTransaction::factory()->create([
+        'account_id' => $account->id,
+        'transacted_at' => '2026-03-15',
+        'entered_by' => $user->id,
+    ]);
+
+    livewire('finances.reports.show', ['month' => '2026-03'])
+        ->assertSee('Confirm')
+        ->assertSee('Publish');
+});
+
+it('detail page shows Download PDF button for published month', function () {
+    $user = User::factory()->withRole('Financials - View')->create();
+    $account = FinancialAccount::factory()->create();
+    $this->actingAs($user);
+
+    FinancialTransaction::factory()->create([
+        'account_id' => $account->id,
+        'transacted_at' => '2026-03-15',
+        'entered_by' => $user->id,
+    ]);
+    FinancialPeriodReport::factory()->published()->forMonth('2026-03-01')->create();
+
+    livewire('finances.reports.show', ['month' => '2026-03'])
+        ->assertSee('Download PDF');
+});
+
+it('detail page shows edit and delete buttons for unpublished month for treasurer', function () {
+    $user = User::factory()->withRole('Financials - Treasurer')->create();
+    $account = FinancialAccount::factory()->create();
+    $category = FinancialCategory::factory()->expense()->create();
+    $this->actingAs($user);
+
+    FinancialTransaction::factory()->create([
+        'account_id' => $account->id,
+        'financial_category_id' => $category->id,
+        'type' => 'expense',
+        'amount' => 1000,
+        'transacted_at' => '2026-03-15',
+        'entered_by' => $user->id,
+    ]);
+
+    livewire('finances.reports.show', ['month' => '2026-03'])
+        ->assertSee('Edit')
+        ->assertSee('Delete');
+});
+
+it('detail page does not show edit or delete buttons for published month', function () {
+    $user = User::factory()->withRole('Financials - Treasurer')->create();
+    $account = FinancialAccount::factory()->create();
+    $category = FinancialCategory::factory()->expense()->create();
+    $this->actingAs($user);
+
+    FinancialTransaction::factory()->create([
+        'account_id' => $account->id,
+        'financial_category_id' => $category->id,
+        'type' => 'expense',
+        'amount' => 1000,
+        'transacted_at' => '2026-03-15',
+        'entered_by' => $user->id,
+    ]);
+    FinancialPeriodReport::factory()->published()->forMonth('2026-03-01')->create();
+
+    $html = livewire('finances.reports.show', ['month' => '2026-03'])
+        ->html();
+
+    // Actions column header and Edit/Delete buttons should not appear
+    expect($html)->not->toContain('wire:click="openEditModal(')
+        ->not->toContain('wire:click="deleteTransaction(');
+});
+
+// == Publish via detail page == //
+
+it('treasurer can publish a month via the detail page', function () {
+    $user = User::factory()->withRole('Financials - Treasurer')->create();
+    $account = FinancialAccount::factory()->create();
+    $this->actingAs($user);
+
+    FinancialTransaction::factory()->create([
+        'account_id' => $account->id,
+        'transacted_at' => '2026-03-15',
+        'entered_by' => $user->id,
+    ]);
+
+    livewire('finances.reports.show', ['month' => '2026-03'])
+        ->call('publish');
+
+    expect(FinancialPeriodReport::whereDate('month', '2026-03-01')->first()?->isPublished())->toBeTrue();
+});
+
+it('detail page publish shows error toast when month already published', function () {
+    $user = User::factory()->withRole('Financials - Treasurer')->create();
+    $account = FinancialAccount::factory()->create();
+    $this->actingAs($user);
+
+    FinancialTransaction::factory()->create([
+        'account_id' => $account->id,
+        'transacted_at' => '2026-03-15',
+        'entered_by' => $user->id,
+    ]);
+    FinancialPeriodReport::factory()->published()->forMonth('2026-03-01')->create();
+
+    // Action throws RuntimeException which is caught and toasted — no exception bubbles up
+    livewire('finances.reports.show', ['month' => '2026-03'])
+        ->call('publish')
+        ->assertHasNoErrors();
+    expect(FinancialPeriodReport::whereDate('month', '2026-03-01')->count())->toBe(1);
+});
+
+// == Sequential publish guard (PublishPeriodReport action) == //
+
+it('publish action blocks publishing when an earlier month has unpublished transactions', function () {
+    $user = User::factory()->withRole('Financials - Treasurer')->create();
+    $account = FinancialAccount::factory()->create();
+
+    // February has transactions but no published report
+    FinancialTransaction::factory()->create([
+        'account_id' => $account->id,
+        'transacted_at' => '2026-02-15',
+        'entered_by' => $user->id,
+    ]);
+
+    // March also has transactions
+    FinancialTransaction::factory()->create([
+        'account_id' => $account->id,
+        'transacted_at' => '2026-03-15',
+        'entered_by' => $user->id,
+    ]);
+
+    // Trying to publish March while February is unpublished should fail
+    expect(fn () => PublishPeriodReport::run('2026-03-01', $user))
+        ->toThrow(\RuntimeException::class, 'earlier months');
+});
+
+it('publish action allows publishing when all earlier months are published', function () {
+    $user = User::factory()->withRole('Financials - Treasurer')->create();
+    $account = FinancialAccount::factory()->create();
+
+    // February has transactions AND a published report
+    FinancialTransaction::factory()->create([
+        'account_id' => $account->id,
+        'transacted_at' => '2026-02-15',
+        'entered_by' => $user->id,
+    ]);
+    FinancialPeriodReport::factory()->published()->forMonth('2026-02-01')->create();
+
+    // March has transactions
+    FinancialTransaction::factory()->create([
+        'account_id' => $account->id,
+        'transacted_at' => '2026-03-15',
+        'entered_by' => $user->id,
+    ]);
+
+    // Publishing March should succeed
+    $report = PublishPeriodReport::run('2026-03-01', $user);
+    expect($report->isPublished())->toBeTrue();
+});
+
+it('publish action allows publishing the earliest month with no prior months', function () {
+    $user = User::factory()->withRole('Financials - Treasurer')->create();
+    $account = FinancialAccount::factory()->create();
+
+    FinancialTransaction::factory()->create([
+        'account_id' => $account->id,
+        'transacted_at' => '2026-03-15',
+        'entered_by' => $user->id,
+    ]);
+
+    // No prior months with transactions — should succeed
+    $report = PublishPeriodReport::run('2026-03-01', $user);
+    expect($report->isPublished())->toBeTrue();
+});
+
+// == Edit/delete on detail page == //
+
+it('treasurer can delete a transaction from the detail page', function () {
+    $user = User::factory()->withRole('Financials - Treasurer')->create();
+    $account = FinancialAccount::factory()->create();
+    $this->actingAs($user);
+
+    $tx = FinancialTransaction::factory()->create([
+        'account_id' => $account->id,
+        'transacted_at' => '2026-03-15',
+        'entered_by' => $user->id,
+    ]);
+
+    livewire('finances.reports.show', ['month' => '2026-03'])
+        ->call('deleteTransaction', $tx->id);
+
+    expect(FinancialTransaction::find($tx->id))->toBeNull();
+});
+
+it('treasurer can edit a transaction from the detail page', function () {
+    $user = User::factory()->withRole('Financials - Treasurer')->create();
+    $account = FinancialAccount::factory()->create();
+    $category = FinancialCategory::factory()->expense()->create();
+    $this->actingAs($user);
+
+    $tx = FinancialTransaction::factory()->create([
+        'account_id' => $account->id,
+        'financial_category_id' => $category->id,
+        'type' => 'expense',
+        'amount' => 1000,
+        'transacted_at' => '2026-03-15',
+        'entered_by' => $user->id,
+    ]);
+
+    livewire('finances.reports.show', ['month' => '2026-03'])
+        ->call('openEditModal', $tx->id)
+        ->set('editAmount', '25.00')
+        ->call('updateTransaction');
+
+    expect($tx->fresh()->amount)->toBe(2500);
+});

--- a/tests/Feature/Finances/TransactionLedgerTest.php
+++ b/tests/Feature/Finances/TransactionLedgerTest.php
@@ -340,6 +340,64 @@ it('financials-view user cannot open edit modal', function () {
         ->assertForbidden();
 });
 
+// == Edit Tag Picker == //
+
+it('opening the edit-tag-picker modal calls openEditTagPickerModal', function () {
+    $user = User::factory()->withRole('Financials - Treasurer')->create();
+    $this->actingAs($user);
+
+    livewire('finances.dashboard')
+        ->call('openEditTagPickerModal')
+        ->assertDispatched('modal-show', name: 'edit-tag-picker');
+});
+
+it('selectEditTag adds tag id to editTagIds and closes modal', function () {
+    $user = User::factory()->withRole('Financials - Treasurer')->create();
+    $tag = FinancialTag::factory()->create();
+    $this->actingAs($user);
+
+    livewire('finances.dashboard')
+        ->call('selectEditTag', $tag->id)
+        ->assertSet('editTagIds', [$tag->id])
+        ->assertSet('editTagSearch', '');
+});
+
+it('selectEditTag does not add duplicate tag ids', function () {
+    $user = User::factory()->withRole('Financials - Treasurer')->create();
+    $tag = FinancialTag::factory()->create();
+    $this->actingAs($user);
+
+    livewire('finances.dashboard')
+        ->set('editTagIds', [$tag->id])
+        ->call('selectEditTag', $tag->id)
+        ->assertSet('editTagIds', [$tag->id]);
+});
+
+it('removeEditTag removes the tag id from editTagIds', function () {
+    $user = User::factory()->withRole('Financials - Treasurer')->create();
+    $tag1 = FinancialTag::factory()->create();
+    $tag2 = FinancialTag::factory()->create();
+    $this->actingAs($user);
+
+    livewire('finances.dashboard')
+        ->set('editTagIds', [$tag1->id, $tag2->id])
+        ->call('removeEditTag', $tag1->id)
+        ->assertSet('editTagIds', [$tag2->id]);
+});
+
+it('createEditTagInline creates a new tag and adds it to editTagIds', function () {
+    $user = User::factory()->withRole('Financials - Treasurer')->create();
+    $this->actingAs($user);
+
+    $component = livewire('finances.dashboard')
+        ->set('editTagSearch', 'Brand New Tag')
+        ->call('createEditTagInline');
+
+    $tag = \App\Models\FinancialTag::where('name', 'Brand New Tag')->first();
+    expect($tag)->not->toBeNull();
+    $component->assertSet('editTagIds', [$tag->id]);
+});
+
 it('treasurer cannot move a transaction date into a published month', function () {
     $user = User::factory()->withRole('Financials - Treasurer')->create();
     $account = FinancialAccount::factory()->create();


### PR DESCRIPTION
## What Changed

Fixes based on tester feedback for PRD #466 (Ministry Finance Tracking System). This round addresses 3 bug reports: a transfer edit tooltip not rendering, adding an "Open Admin Ticket" action to user profiles, and converting the Edit Transaction tags field into a modal-based picker matching the Organization picker pattern. Also includes the dedicated Period Report detail page (#491) implemented earlier this cycle.

## Issues Addressed

- #517: Transfer Edit button tooltip was not rendering because Flux tooltips don't fire on disabled elements directly — wrapped the disabled button in a `<span>` so the tooltip can attach to the parent
- #516: Added "Open Admin Ticket" action to the user profile Actions dropdown, visible to staff with the `createAsStaff` ability, pre-filling the target user via query param
- #513: Replaced the flat checkbox list in Edit Transaction's Tags field with a button → modal → search/create flow matching the Organization picker pattern; tags appear as badge pills with inline × removal
- #491: Period Reports list now links to a dedicated detail page at `/finances/reports/{month}` with full transaction list, publish flow, and sequential publish guard

## How to Re-Test

### #517 — Transfer tooltip
1. Go to Finance Dashboard and find a transfer transaction in the ledger
2. Hover over the disabled Edit button
3. **Expected:** Tooltip appears explaining transfers cannot be edited

### #516 — Open Admin Ticket on profile
1. As a staff member, visit another user's profile
2. Click the Actions dropdown
3. **Expected:** "Open Admin Ticket" option appears, links to the admin ticket creation page with `?user_id=<id>` pre-filled
4. **Verify:** Option is hidden when viewing your own profile

### #513 — Tag picker in Edit Transaction
1. Go to Finance Dashboard and click Edit on any transaction
2. Find the Tags field
3. **Expected:** A "Select Tags" button opens a modal with live search, existing tag selection, and inline tag creation
4. Selected tags appear as badge pills with × to remove
5. Verify tags save correctly on Update

### #491 — Report detail page
1. Go to Finance → Period Reports
2. Click on any month name
3. **Expected:** Navigates to a dedicated detail page showing the transaction list for that month
4. For unpublished months (treasurer only): Edit, Delete, and Publish buttons are available
5. For published months: Download PDF button is shown; Edit/Delete are not

## Things to Watch For

- Tag picker in Edit Transaction should not allow duplicate tags
- Sequential publish guard: attempting to publish a month when an earlier month has unpublished transactions should show a danger toast
- Admin Ticket option should not appear on your own profile

## Parent PRD

#466

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Monthly financial report detail page with full transaction management (edit, delete, publish) and PDF download
  * Enhanced tag selection via searchable modal picker with inline tag creation
  * "Open Admin Ticket" quick action in user management

* **Bug Fixes**
  * Prevents publishing a month when earlier months with transactions remain unpublished (sequential publish enforcement)

* **Refactor**
  * Report viewing/publishing moved from dashboard modals to dedicated detail page
<!-- end of auto-generated comment: release notes by coderabbit.ai -->