### PR TITLE
Staging (#566)

### DIFF
--- a/app/Actions/CompleteReconciliation.php
+++ b/app/Actions/CompleteReconciliation.php
@@ -32,7 +32,14 @@ class CompleteReconciliation
             ->selectRaw('COALESCE(SUM(jel.debit) - SUM(jel.credit), 0) as net')
             ->value('net');
 
-        $difference = $reconciliation->statement_ending_balance - $clearedBalance;
+        $prior = FinancialReconciliation::findPriorCompleted(
+            $reconciliation->account_id,
+            $reconciliation->period->start_date->toDateString()
+        );
+
+        $openingBalance = $prior?->statement_ending_balance ?? 0;
+
+        $difference = $reconciliation->statement_ending_balance - ($openingBalance + $clearedBalance);
 
         if ($difference !== 0) {
             throw new \RuntimeException(

--- a/app/Models/FinancialReconciliation.php
+++ b/app/Models/FinancialReconciliation.php
@@ -46,4 +46,18 @@ class FinancialReconciliation extends Model
     {
         return $this->hasMany(FinancialReconciliationLine::class, 'reconciliation_id');
     }
+
+    /**
+     * Find the most recently completed reconciliation for an account that precedes the given period start date.
+     */
+    public static function findPriorCompleted(int $accountId, string $periodStartDate): ?self
+    {
+        return self::where('financial_reconciliations.account_id', $accountId)
+            ->where('financial_reconciliations.status', 'completed')
+            ->whereHas('period', fn ($q) => $q->where('end_date', '<', $periodStartDate))
+            ->join('financial_periods', 'financial_periods.id', '=', 'financial_reconciliations.period_id')
+            ->orderByDesc('financial_periods.end_date')
+            ->select('financial_reconciliations.*')
+            ->first();
+    }
 }

--- a/resources/views/livewire/finance/bank-reconciliation.blade.php
+++ b/resources/views/livewire/finance/bank-reconciliation.blade.php
@@ -75,6 +75,16 @@ new class extends Component {
         );
     }
 
+    public function getOpeningBalanceProperty(): int
+    {
+        $prior = FinancialReconciliation::findPriorCompleted(
+            $this->account->id,
+            $this->period->start_date->toDateString()
+        );
+
+        return $prior?->statement_ending_balance ?? 0;
+    }
+
     public function getStatementBalanceCentsProperty(): int
     {
         try {
@@ -86,7 +96,7 @@ new class extends Component {
 
     public function getDifferenceProperty(): int
     {
-        return $this->statementBalanceCents - $this->clearedBalance;
+        return $this->statementBalanceCents - ($this->openingBalance + $this->clearedBalance);
     }
 
     public function getIsBalancedProperty(): bool
@@ -175,19 +185,10 @@ new class extends Component {
     {{-- Statement balance + summary --}}
     <flux:card>
         <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
-            <flux:field>
-                <flux:label>Statement Ending Balance ($)</flux:label>
-                @if ($reconciliation->status === 'completed')
-                    <p class="text-sm font-mono font-medium">${{ number_format($reconciliation->statement_ending_balance / 100, 2) }}</p>
-                @else
-                    <flux:input
-                        wire:model.live="statementBalance"
-                        wire:change="updateStatementBalance"
-                        placeholder="0.00"
-                    />
-                    <flux:error name="statementBalance" />
-                @endif
-            </flux:field>
+            <div class="text-center">
+                <p class="text-xs text-zinc-500 mb-1">Opening Balance</p>
+                <p class="text-lg font-mono font-semibold dark:text-zinc-100">${{ number_format($this->openingBalance / 100, 2) }}</p>
+            </div>
 
             <div class="text-center">
                 <p class="text-xs text-zinc-500 mb-1">Cleared Balance</p>
@@ -212,8 +213,23 @@ new class extends Component {
             </div>
         </div>
 
-        @if ($reconciliation->status !== 'completed')
-            <div class="flex justify-end mt-4 pt-4 border-t border-zinc-200 dark:border-zinc-700">
+        <div class="flex items-end justify-between mt-4 pt-4 border-t border-zinc-200 dark:border-zinc-700">
+            <flux:field>
+                <flux:label>Statement Ending Balance ($)</flux:label>
+                @if ($reconciliation->status === 'completed')
+                    <p class="text-sm font-mono font-medium">${{ number_format($reconciliation->statement_ending_balance / 100, 2) }}</p>
+                @else
+                    <flux:input
+                        wire:model.live="statementBalance"
+                        wire:change="updateStatementBalance"
+                        placeholder="0.00"
+                        class="w-40"
+                    />
+                    <flux:error name="statementBalance" />
+                @endif
+            </flux:field>
+
+            @if ($reconciliation->status !== 'completed')
                 <flux:button
                     variant="primary"
                     wire:click="complete"
@@ -221,13 +237,13 @@ new class extends Component {
                 >
                     Complete Reconciliation
                 </flux:button>
-            </div>
-        @else
-            <div class="mt-4 pt-4 border-t border-zinc-200 dark:border-zinc-700 text-sm text-zinc-500">
-                Completed {{ $reconciliation->completed_at->format('M j, Y \a\t g:i A') }}
-                by {{ $reconciliation->completedBy?->name ?? 'Unknown' }}
-            </div>
-        @endif
+            @else
+                <p class="text-sm text-zinc-500">
+                    Completed {{ $reconciliation->completed_at->format('M j, Y \a\t g:i A') }}
+                    by {{ $reconciliation->completedBy?->name ?? 'Unknown' }}
+                </p>
+            @endif
+        </div>
     </flux:card>
 
     <div class="grid grid-cols-1 lg:grid-cols-2 gap-6">

--- a/resources/views/livewire/finance/create-journal-entry.blade.php
+++ b/resources/views/livewire/finance/create-journal-entry.blade.php
@@ -233,8 +233,8 @@ new class extends Component
         $formatted = '$'.number_format($amountCents / 100, 2);
 
         return [
-            ['side' => 'Debit',  'account' => $debitAccount?->name,  'amount' => $formatted],
-            ['side' => 'Credit', 'account' => $creditAccount?->name, 'amount' => $formatted],
+            ['side' => 'Debit',  'account' => $debitAccount?->name,  'amount' => $formatted, 'date' => $this->date],
+            ['side' => 'Credit', 'account' => $creditAccount?->name, 'amount' => $formatted, 'date' => $this->date],
         ];
     }
 
@@ -498,17 +498,19 @@ new class extends Component
                 <flux:table.columns>
                     <flux:table.column>Side</flux:table.column>
                     <flux:table.column>Account</flux:table.column>
+                    <flux:table.column>Date</flux:table.column>
                     <flux:table.column>Amount</flux:table.column>
                 </flux:table.columns>
                 <flux:table.rows>
                     @foreach ($previewLines as $line)
-                        <flux:table.row>
+                        <flux:table.row wire:key="preview-line-{{ $loop->index }}">
                             <flux:table.cell>
                                 <flux:badge color="{{ $line['side'] === 'Debit' ? 'blue' : 'green' }}" size="sm">
                                     {{ $line['side'] }}
                                 </flux:badge>
                             </flux:table.cell>
                             <flux:table.cell>{{ $line['account'] }}</flux:table.cell>
+                            <flux:table.cell>{{ \Carbon\Carbon::parse($line['date'])->format('M j, Y') }}</flux:table.cell>
                             <flux:table.cell class="font-mono">{{ $line['amount'] }}</flux:table.cell>
                         </flux:table.row>
                     @endforeach


### PR DESCRIPTION
## What Changed

This PR adds a complete versioned Community Rules system to the site. The old static rules page is replaced with a database-backed system where rules are organized into categories, bundled into published versions, and tracked per-user.

Key features:
- Staff with "Rules - Manage" can create draft rule versions, add/edit/deactivate rules, manage categories, and edit header/footer content
- A two-person approval workflow ensures rule changes are reviewed before going live
- Members must agree to each new version individually, with NEW/UPDATED badges highlighting what changed
- A daily job sends reminder emails at 14 days and places non-compliant members in a temporary Rules Non-Compliance restriction at 28 days (auto-lifted on agreement)
- Parents can agree on behalf of linked child accounts via a proxy agreement flow
- Discipline reports can now optionally link to specific rules that were violated
- Staff admin page includes compliance monitoring (who hasn't agreed) and a full agreement audit history

## How to Test

### Agreeing to the Rules (as a member)
1. Log in as a Stowaway+ user who has not agreed to the current version
2. Try to visit `/dashboard` -- you should be redirected to `/rules`
3. On the rules page, check each rule checkbox one by one
4. The "I Have Read and Agree to All Rules" button should only become active once all boxes are checked
5. Click it and confirm you're redirected to the dashboard

### NEW / UPDATED badges
1. Publish a new rule version with at least one new rule and one edited rule
2. Log in as a user who agreed to the previous version
3. Visit `/rules` -- new rules should show a **NEW** badge; edited rules should show **UPDATED** with a collapsible previous version

### Parent Proxy Agreement
1. Log in as a parent user with a child account that has not agreed
2. Visit `/dashboard` -- you should be redirected to `/rules`
3. After the main rules list (assuming you've already agreed), you should see a "Proxy Agreement Required" section listing your unagreed children
4. Select one or more children and click "Submit Proxy Agreement"
5. Verify that the child's agreement is recorded and the dashboard becomes accessible

### Rules Admin (requires "Rules - Manage" role)
1. Go to the Admin Control Panel → Rules tab
2. Create a new draft version
3. Add a new rule, edit an existing one, and deactivate another
4. Submit for approval
5. As a different user with "Rules - Approve" role, approve the version
6. Verify all Stowaway+ users receive an email notification

### Compliance Monitoring
1. After publishing a version, go to the Rules Admin page
2. Scroll to the Compliance section -- it should list members who haven't agreed
3. Days overdue should show amber at 14+ days and red at 28+

### Discipline Report Rules Violated
1. Open a user's profile and create a new discipline report
2. In the form, expand the "Rules Violated" section and select one or more rules
3. Save and view the report -- the selected rules should appear as red badges
4. Edit the report and change the selected rules -- verify the list updates

## Things to Watch For

- The middleware gate (`ensure-rules-agreed`) is now on the dashboard route -- if something is broken in the rules agreement logic, all members could get stuck in a redirect loop
- The parent proxy section only appears after the parent has agreed themselves -- confirm a parent who hasn't agreed yet sees only the main rules form, not the proxy section
- The compliance list should exclude Drifter-level users (they're not yet required to agree)
- Agreeing auto-lifts a Rules Non-Compliance brig -- test this end-to-end if you have a test user in that state

## Parent PRD

#571

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Bank reconciliation interface now displays opening balance sourced from the prior period
  * Journal entry previews now include transaction dates in the preview table

* **Bug Fixes**
  * Improved reconciliation balance validation to properly account for prior period ending balances in calculations
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
Edited to trigger automation for Cloud