### PR TITLE
Versioned Rules System with Agreement Tracking and Report Linking

### DIFF
--- a/app/Actions/AddRuleToDraft.php
+++ b/app/Actions/AddRuleToDraft.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Actions;
+
+use App\Models\Rule;
+use App\Models\RuleCategory;
+use App\Models\RuleVersion;
+use App\Models\User;
+use Lorisleiva\Actions\Concerns\AsAction;
+
+class AddRuleToDraft
+{
+    use AsAction;
+
+    /**
+     * Create a new rule in draft status and link it to the given draft version.
+     */
+    public function handle(
+        RuleVersion $draft,
+        RuleCategory $category,
+        string $title,
+        string $description,
+        User $createdBy
+    ): Rule {
+        $rule = Rule::create([
+            'rule_category_id' => $category->id,
+            'title' => $title,
+            'description' => $description,
+            'status' => 'draft',
+            'created_by_user_id' => $createdBy->id,
+        ]);
+
+        $draft->rules()->attach($rule->id, ['deactivate_on_publish' => false]);
+
+        return $rule;
+    }
+}

--- a/app/Actions/AddRuleToDraft.php
+++ b/app/Actions/AddRuleToDraft.php
@@ -6,6 +6,7 @@ use App\Models\Rule;
 use App\Models\RuleCategory;
 use App\Models\RuleVersion;
 use App\Models\User;
+use Illuminate\Auth\Access\AuthorizationException;
 use Lorisleiva\Actions\Concerns\AsAction;
 
 class AddRuleToDraft
@@ -22,6 +23,10 @@ class AddRuleToDraft
         string $description,
         User $createdBy
     ): Rule {
+        if ($draft->status !== 'draft') {
+            throw new AuthorizationException('Rules can only be added to draft versions.');
+        }
+
         $rule = Rule::create([
             'rule_category_id' => $category->id,
             'title' => $title,

--- a/app/Actions/AddRuleToDraft.php
+++ b/app/Actions/AddRuleToDraft.php
@@ -37,6 +37,8 @@ class AddRuleToDraft
 
         $draft->rules()->attach($rule->id, ['deactivate_on_publish' => false]);
 
+        RecordActivity::run($rule, 'rule_added_to_draft', "Rule \"{$rule->title}\" added to draft version.");
+
         return $rule;
     }
 }

--- a/app/Actions/AgreeToRulesVersion.php
+++ b/app/Actions/AgreeToRulesVersion.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace App\Actions;
+
+use App\Enums\BrigType;
+use App\Enums\MembershipLevel;
+use App\Models\RuleVersion;
+use App\Models\User;
+use App\Models\UserRuleAgreement;
+use Lorisleiva\Actions\Concerns\AsAction;
+
+class AgreeToRulesVersion
+{
+    use AsAction;
+
+    /**
+     * Record agreement to the current published rules version.
+     *
+     * Promotes Drifter-level users to Stowaway and auto-lifts any
+     * rules_non_compliance brig. Idempotent — safe to call multiple times.
+     */
+    public function handle(User $user, User $actingUser): void
+    {
+        $version = RuleVersion::currentPublished();
+
+        if (! $version) {
+            return;
+        }
+
+        UserRuleAgreement::updateOrCreate(
+            ['user_id' => $user->id, 'rule_version_id' => $version->id],
+            ['agreed_at' => now()],
+        );
+
+        $user->rules_accepted_at = now();
+        $user->rules_accepted_by_user_id = $actingUser->id;
+        $user->save();
+
+        $isSelf = $user->id === $actingUser->id;
+
+        if ($user->isLevel(MembershipLevel::Drifter)) {
+            $description = $isSelf
+                ? 'User accepted community rules and was promoted to Stowaway.'
+                : "Community rules agreed on behalf of user by {$actingUser->name} (parent). User promoted to Stowaway.";
+
+            RecordActivity::run($user, 'rules_accepted', $description, $actingUser);
+            PromoteUser::run($user, MembershipLevel::Stowaway);
+        } else {
+            RecordActivity::run($user, 'rules_accepted', "User agreed to rules version {$version->version_number}.", $actingUser);
+        }
+
+        if ($user->isInBrig() && $user->brig_type === BrigType::RulesNonCompliance) {
+            ReleaseUserFromBrig::run($user, $user, 'Rules non-compliance brig lifted after agreeing to rules.', notify: false);
+        }
+    }
+}

--- a/app/Actions/AgreeToRulesVersion.php
+++ b/app/Actions/AgreeToRulesVersion.php
@@ -27,16 +27,16 @@ class AgreeToRulesVersion
             return;
         }
 
+        $isSelf = $user->id === $actingUser->id;
+
         UserRuleAgreement::updateOrCreate(
             ['user_id' => $user->id, 'rule_version_id' => $version->id],
-            ['agreed_at' => now()],
+            ['agreed_at' => now(), 'proxy_user_id' => $isSelf ? null : $actingUser->id],
         );
 
         $user->rules_accepted_at = now();
         $user->rules_accepted_by_user_id = $actingUser->id;
         $user->save();
-
-        $isSelf = $user->id === $actingUser->id;
 
         if ($user->isLevel(MembershipLevel::Drifter)) {
             $description = $isSelf

--- a/app/Actions/ApproveAndPublishVersion.php
+++ b/app/Actions/ApproveAndPublishVersion.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace App\Actions;
+
+use App\Enums\MembershipLevel;
+use App\Models\Rule;
+use App\Models\RuleVersion;
+use App\Models\User;
+use App\Notifications\RulesVersionPublishedNotification;
+use App\Services\TicketNotificationService;
+use Illuminate\Auth\Access\AuthorizationException;
+use Lorisleiva\Actions\Concerns\AsAction;
+
+class ApproveAndPublishVersion
+{
+    use AsAction;
+
+    /**
+     * Approve and publish a submitted rule version.
+     *
+     * Validates that the approver is not the same as the creator, transitions the version
+     * to published, activates draft rules, deactivates rules marked for removal, and
+     * notifies all active users that the rules have been updated.
+     */
+    public function handle(RuleVersion $version, User $approvedBy): void
+    {
+        if ($version->status !== 'submitted') {
+            throw new AuthorizationException('Only submitted versions can be approved.');
+        }
+
+        if ($version->created_by_user_id === $approvedBy->id) {
+            throw new AuthorizationException('The creator of a draft cannot approve their own version.');
+        }
+
+        $version->status = 'published';
+        $version->approved_by_user_id = $approvedBy->id;
+        $version->published_at = now();
+        $version->save();
+
+        // Activate draft rules in the version (deactivate_on_publish = false)
+        $version->rules()
+            ->wherePivot('deactivate_on_publish', false)
+            ->where('rules.status', 'draft')
+            ->each(fn (Rule $rule) => $rule->update(['status' => 'active']));
+
+        // Deactivate rules marked for deactivation
+        $version->rules()
+            ->wherePivot('deactivate_on_publish', true)
+            ->where('rules.status', 'active')
+            ->each(fn (Rule $rule) => $rule->update(['status' => 'inactive']));
+
+        // Notify all active users that new rules require agreement
+        $notificationService = app(TicketNotificationService::class);
+        User::where('membership_level', '>=', MembershipLevel::Stowaway->value)
+            ->each(function (User $user) use ($version, $notificationService) {
+                $notificationService->send($user, new RulesVersionPublishedNotification($user, $version));
+            });
+    }
+}

--- a/app/Actions/ApproveAndPublishVersion.php
+++ b/app/Actions/ApproveAndPublishVersion.php
@@ -52,6 +52,8 @@ class ApproveAndPublishVersion
                 ->each(fn (Rule $rule) => $rule->update(['status' => 'inactive']));
         });
 
+        RecordActivity::run($version, 'rules_version_published', "Rules version v{$version->version_number} published by {$approvedBy->name}.");
+
         // Notify all active users that new rules require agreement (after transaction commits)
         $notificationService = app(TicketNotificationService::class);
         User::where('membership_level', '>=', MembershipLevel::Stowaway->value)

--- a/app/Actions/ApproveAndPublishVersion.php
+++ b/app/Actions/ApproveAndPublishVersion.php
@@ -9,6 +9,7 @@ use App\Models\User;
 use App\Notifications\RulesVersionPublishedNotification;
 use App\Services\TicketNotificationService;
 use Illuminate\Auth\Access\AuthorizationException;
+use Illuminate\Support\Facades\DB;
 use Lorisleiva\Actions\Concerns\AsAction;
 
 class ApproveAndPublishVersion
@@ -32,24 +33,26 @@ class ApproveAndPublishVersion
             throw new AuthorizationException('The creator of a draft cannot approve their own version.');
         }
 
-        $version->status = 'published';
-        $version->approved_by_user_id = $approvedBy->id;
-        $version->published_at = now();
-        $version->save();
+        DB::transaction(function () use ($version, $approvedBy): void {
+            $version->status = 'published';
+            $version->approved_by_user_id = $approvedBy->id;
+            $version->published_at = now();
+            $version->save();
 
-        // Activate draft rules in the version (deactivate_on_publish = false)
-        $version->rules()
-            ->wherePivot('deactivate_on_publish', false)
-            ->where('rules.status', 'draft')
-            ->each(fn (Rule $rule) => $rule->update(['status' => 'active']));
+            // Activate draft rules in the version (deactivate_on_publish = false)
+            $version->rules()
+                ->wherePivot('deactivate_on_publish', false)
+                ->where('rules.status', 'draft')
+                ->each(fn (Rule $rule) => $rule->update(['status' => 'active']));
 
-        // Deactivate rules marked for deactivation
-        $version->rules()
-            ->wherePivot('deactivate_on_publish', true)
-            ->where('rules.status', 'active')
-            ->each(fn (Rule $rule) => $rule->update(['status' => 'inactive']));
+            // Deactivate rules marked for deactivation
+            $version->rules()
+                ->wherePivot('deactivate_on_publish', true)
+                ->where('rules.status', 'active')
+                ->each(fn (Rule $rule) => $rule->update(['status' => 'inactive']));
+        });
 
-        // Notify all active users that new rules require agreement
+        // Notify all active users that new rules require agreement (after transaction commits)
         $notificationService = app(TicketNotificationService::class);
         User::where('membership_level', '>=', MembershipLevel::Stowaway->value)
             ->each(function (User $user) use ($version, $notificationService) {

--- a/app/Actions/CreateDisciplineReport.php
+++ b/app/Actions/CreateDisciplineReport.php
@@ -27,6 +27,7 @@ class CreateDisciplineReport
         ReportSeverity $severity,
         ?string $witnesses = null,
         ?ReportCategory $category = null,
+        array $ruleIds = [],
     ): DisciplineReport {
         $report = DisciplineReport::create([
             'subject_user_id' => $subject->id,
@@ -39,6 +40,10 @@ class CreateDisciplineReport
             'severity' => $severity,
             'status' => ReportStatus::Draft,
         ]);
+
+        if (! empty($ruleIds)) {
+            $report->violatedRules()->sync($ruleIds);
+        }
 
         RecordActivity::run($subject, 'discipline_report_created',
             "Discipline report #{$report->id} created by {$reporter->name}. Severity: {$severity->label()}.", $reporter);

--- a/app/Actions/CreateRuleVersion.php
+++ b/app/Actions/CreateRuleVersion.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Actions;
+
+use App\Models\RuleVersion;
+use App\Models\User;
+use Lorisleiva\Actions\Concerns\AsAction;
+
+class CreateRuleVersion
+{
+    use AsAction;
+
+    /**
+     * Create a new draft version, seeded with all currently active rules from the latest published version.
+     */
+    public function handle(User $createdBy): RuleVersion
+    {
+        $published = RuleVersion::currentPublished();
+        $nextNumber = $published ? $published->version_number + 1 : 1;
+
+        $draft = RuleVersion::create([
+            'version_number' => $nextNumber,
+            'status' => 'draft',
+            'created_by_user_id' => $createdBy->id,
+        ]);
+
+        // Seed draft with all currently active rules from the published version
+        if ($published) {
+            $activeRuleIds = $published->activeRules()->pluck('rules.id');
+            $attach = $activeRuleIds->mapWithKeys(fn ($id) => [$id => ['deactivate_on_publish' => false]]);
+            $draft->rules()->attach($attach->all());
+        }
+
+        return $draft;
+    }
+}

--- a/app/Actions/CreateRuleVersion.php
+++ b/app/Actions/CreateRuleVersion.php
@@ -4,6 +4,7 @@ namespace App\Actions;
 
 use App\Models\RuleVersion;
 use App\Models\User;
+use Illuminate\Support\Facades\DB;
 use Lorisleiva\Actions\Concerns\AsAction;
 
 class CreateRuleVersion
@@ -15,27 +16,38 @@ class CreateRuleVersion
      */
     public function handle(User $createdBy): RuleVersion
     {
-        $existing = RuleVersion::currentDraft();
-        if ($existing) {
-            return $existing;
-        }
+        return DB::transaction(function () use ($createdBy): RuleVersion {
+            $existing = RuleVersion::query()
+                ->whereIn('status', ['draft', 'submitted'])
+                ->lockForUpdate()
+                ->orderByDesc('version_number')
+                ->first();
 
-        $published = RuleVersion::currentPublished();
-        $nextNumber = $published ? $published->version_number + 1 : 1;
+            if ($existing) {
+                return $existing;
+            }
 
-        $draft = RuleVersion::create([
-            'version_number' => $nextNumber,
-            'status' => 'draft',
-            'created_by_user_id' => $createdBy->id,
-        ]);
+            $published = RuleVersion::query()
+                ->where('status', 'published')
+                ->orderByDesc('version_number')
+                ->first();
 
-        // Seed draft with all currently active rules from the published version
-        if ($published) {
-            $activeRuleIds = $published->activeRules()->pluck('rules.id');
-            $attach = $activeRuleIds->mapWithKeys(fn ($id) => [$id => ['deactivate_on_publish' => false]]);
-            $draft->rules()->attach($attach->all());
-        }
+            $nextNumber = $published ? $published->version_number + 1 : 1;
 
-        return $draft;
+            $draft = RuleVersion::create([
+                'version_number' => $nextNumber,
+                'status' => 'draft',
+                'created_by_user_id' => $createdBy->id,
+            ]);
+
+            // Seed draft with all currently active rules from the published version
+            if ($published) {
+                $activeRuleIds = $published->activeRules()->pluck('rules.id');
+                $attach = $activeRuleIds->mapWithKeys(fn ($id) => [$id => ['deactivate_on_publish' => false]]);
+                $draft->rules()->attach($attach->all());
+            }
+
+            return $draft;
+        });
     }
 }

--- a/app/Actions/CreateRuleVersion.php
+++ b/app/Actions/CreateRuleVersion.php
@@ -15,6 +15,11 @@ class CreateRuleVersion
      */
     public function handle(User $createdBy): RuleVersion
     {
+        $existing = RuleVersion::currentDraft();
+        if ($existing) {
+            return $existing;
+        }
+
         $published = RuleVersion::currentPublished();
         $nextNumber = $published ? $published->version_number + 1 : 1;
 

--- a/app/Actions/DeactivateRuleInDraft.php
+++ b/app/Actions/DeactivateRuleInDraft.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Actions;
+
+use App\Models\Rule;
+use App\Models\RuleVersion;
+use Lorisleiva\Actions\Concerns\AsAction;
+
+class DeactivateRuleInDraft
+{
+    use AsAction;
+
+    /**
+     * Mark a rule for deactivation when this draft version is published.
+     *
+     * Does not immediately deactivate the rule — deactivation happens when the version publishes.
+     */
+    public function handle(RuleVersion $draft, Rule $rule): void
+    {
+        if ($draft->rules()->where('rules.id', $rule->id)->exists()) {
+            $draft->rules()->updateExistingPivot($rule->id, ['deactivate_on_publish' => true]);
+        } else {
+            $draft->rules()->attach($rule->id, ['deactivate_on_publish' => true]);
+        }
+    }
+}

--- a/app/Actions/DeactivateRuleInDraft.php
+++ b/app/Actions/DeactivateRuleInDraft.php
@@ -4,6 +4,7 @@ namespace App\Actions;
 
 use App\Models\Rule;
 use App\Models\RuleVersion;
+use Illuminate\Auth\Access\AuthorizationException;
 use Lorisleiva\Actions\Concerns\AsAction;
 
 class DeactivateRuleInDraft
@@ -17,6 +18,10 @@ class DeactivateRuleInDraft
      */
     public function handle(RuleVersion $draft, Rule $rule): void
     {
+        if ($draft->status !== 'draft') {
+            throw new AuthorizationException('Rules can only be deactivated in draft versions.');
+        }
+
         if ($draft->rules()->where('rules.id', $rule->id)->exists()) {
             $draft->rules()->updateExistingPivot($rule->id, ['deactivate_on_publish' => true]);
         } else {

--- a/app/Actions/DeactivateRuleInDraft.php
+++ b/app/Actions/DeactivateRuleInDraft.php
@@ -27,5 +27,7 @@ class DeactivateRuleInDraft
         } else {
             $draft->rules()->attach($rule->id, ['deactivate_on_publish' => true]);
         }
+
+        RecordActivity::run($rule, 'rule_marked_for_deactivation', "Rule \"{$rule->title}\" marked for deactivation on publish.");
     }
 }

--- a/app/Actions/GetRulesAgreementStatus.php
+++ b/app/Actions/GetRulesAgreementStatus.php
@@ -68,11 +68,15 @@ class GetRulesAgreementStatus
         $categories = RuleCategory::with(['rules.supersedes'])
             ->orderBy('sort_order')
             ->get()
-            ->map(function (RuleCategory $category) use ($currentRuleIds, $agreedRuleIds, $lastVersionRuleIds) {
+            ->map(function (RuleCategory $category) use ($currentRuleIds, $agreedRuleIds, $lastVersionRuleIds, $lastAgreement) {
                 $category->setRelation('rules', $category->rules->filter(function ($rule) use ($currentRuleIds) {
                     return isset($currentRuleIds[$rule->id]);
-                })->values()->map(function ($rule) use ($agreedRuleIds, $lastVersionRuleIds) {
-                    if (isset($agreedRuleIds[$rule->id])) {
+                })->values()->map(function ($rule) use ($agreedRuleIds, $lastVersionRuleIds, $lastAgreement) {
+                    if (! $lastAgreement) {
+                        // First-time user: nothing is "new" or "updated" — all rules are simply the rules
+                        $rule->agreement_status = 'unchanged';
+                        $rule->previous_rule = null;
+                    } elseif (isset($agreedRuleIds[$rule->id])) {
                         $rule->agreement_status = 'unchanged';
                         $rule->previous_rule = null;
                     } elseif ($rule->supersedes_rule_id && isset($lastVersionRuleIds[$rule->supersedes_rule_id])) {

--- a/app/Actions/GetRulesAgreementStatus.php
+++ b/app/Actions/GetRulesAgreementStatus.php
@@ -40,6 +40,7 @@ class GetRulesAgreementStatus
         $agreedVersionIds = $user->ruleAgreements()->pluck('rule_version_id');
         $agreedRuleIds = DB::table('rule_version_rules')
             ->whereIn('rule_version_id', $agreedVersionIds)
+            ->where('deactivate_on_publish', false)
             ->pluck('rule_id')
             ->flip()
             ->all(); // keyed lookup
@@ -50,6 +51,7 @@ class GetRulesAgreementStatus
         if ($lastAgreement) {
             $lastVersionRuleIds = DB::table('rule_version_rules')
                 ->where('rule_version_id', $lastAgreement->rule_version_id)
+                ->where('deactivate_on_publish', false)
                 ->pluck('rule_id')
                 ->flip()
                 ->all();

--- a/app/Actions/GetRulesAgreementStatus.php
+++ b/app/Actions/GetRulesAgreementStatus.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace App\Actions;
+
+use App\Models\RuleCategory;
+use App\Models\RuleVersion;
+use App\Models\User;
+use Illuminate\Support\Facades\DB;
+use Lorisleiva\Actions\Concerns\AsAction;
+
+class GetRulesAgreementStatus
+{
+    use AsAction;
+
+    /**
+     * Return whether the user has agreed to the current published version, and
+     * classify each rule in that version as 'new', 'updated', or 'unchanged'
+     * relative to the versions the user has previously agreed to.
+     *
+     * Returns an array with keys:
+     *   - has_agreed (bool)
+     *   - current_version (RuleVersion|null)
+     *   - categories (Collection of RuleCategory, each with ->rules bearing ->agreement_status and ->previous_rule)
+     */
+    public function handle(User $user): array
+    {
+        $currentVersion = RuleVersion::currentPublished();
+
+        if (! $currentVersion) {
+            return [
+                'has_agreed' => true,
+                'current_version' => null,
+                'categories' => collect(),
+            ];
+        }
+
+        $hasAgreed = $user->ruleAgreements()->where('rule_version_id', $currentVersion->id)->exists();
+
+        // Rule IDs across ALL versions the user has agreed to
+        $agreedVersionIds = $user->ruleAgreements()->pluck('rule_version_id');
+        $agreedRuleIds = DB::table('rule_version_rules')
+            ->whereIn('rule_version_id', $agreedVersionIds)
+            ->pluck('rule_id')
+            ->flip()
+            ->all(); // keyed lookup
+
+        // Rule IDs in the user's most-recently agreed version
+        $lastAgreement = $user->ruleAgreements()->orderByDesc('agreed_at')->first();
+        $lastVersionRuleIds = [];
+        if ($lastAgreement) {
+            $lastVersionRuleIds = DB::table('rule_version_rules')
+                ->where('rule_version_id', $lastAgreement->rule_version_id)
+                ->pluck('rule_id')
+                ->flip()
+                ->all();
+        }
+
+        // Active rule IDs in the current version (deactivate_on_publish = false)
+        $currentRuleIds = DB::table('rule_version_rules')
+            ->where('rule_version_id', $currentVersion->id)
+            ->where('deactivate_on_publish', false)
+            ->pluck('rule_id')
+            ->flip()
+            ->all();
+
+        $categories = RuleCategory::with(['rules.supersedes'])
+            ->orderBy('sort_order')
+            ->get()
+            ->map(function (RuleCategory $category) use ($currentRuleIds, $agreedRuleIds, $lastVersionRuleIds) {
+                $category->setRelation('rules', $category->rules->filter(function ($rule) use ($currentRuleIds) {
+                    return isset($currentRuleIds[$rule->id]);
+                })->values()->map(function ($rule) use ($agreedRuleIds, $lastVersionRuleIds) {
+                    if (isset($agreedRuleIds[$rule->id])) {
+                        $rule->agreement_status = 'unchanged';
+                        $rule->previous_rule = null;
+                    } elseif ($rule->supersedes_rule_id && isset($lastVersionRuleIds[$rule->supersedes_rule_id])) {
+                        $rule->agreement_status = 'updated';
+                        $rule->previous_rule = $rule->supersedes;
+                    } else {
+                        $rule->agreement_status = 'new';
+                        $rule->previous_rule = null;
+                    }
+
+                    return $rule;
+                }));
+
+                return $category;
+            })
+            ->filter(fn (RuleCategory $cat) => $cat->rules->isNotEmpty())
+            ->values();
+
+        return [
+            'has_agreed' => $hasAgreed,
+            'current_version' => $currentVersion,
+            'categories' => $categories,
+        ];
+    }
+}

--- a/app/Actions/ProcessMeetingPayouts.php
+++ b/app/Actions/ProcessMeetingPayouts.php
@@ -6,6 +6,7 @@ use App\Enums\StaffRank;
 use App\Models\Meeting;
 use App\Models\MeetingPayout;
 use App\Models\SiteConfig;
+use App\Models\User;
 use App\Services\MinecraftRconService;
 use Lorisleiva\Actions\Concerns\AsAction;
 
@@ -28,12 +29,22 @@ class ProcessMeetingPayouts
 
         $attendees = $meeting->attendees()->get();
 
+        // Jr Crew don't attend meetings but are still eligible for payouts if
+        // they submitted their Staff Update Report. Include them alongside attendees.
+        $attendeeIds = $attendees->pluck('id');
+        $jrCrewSubmitters = User::where('staff_rank', StaffRank::JrCrew->value)
+            ->whereNotIn('id', $attendeeIds)
+            ->whereIn('id', $submittedUserIds)
+            ->get();
+
+        $allParticipants = $attendees->concat($jrCrewSubmitters);
+
         $paidCount = 0;
         $skippedCount = 0;
         $failedCount = 0;
         $pendingCount = 0;
 
-        foreach ($attendees as $attendee) {
+        foreach ($allParticipants as $attendee) {
             // Skip if payout record already exists (duplicate prevention).
             // Count pending records so the activity log surfaces interrupted payouts.
             $existingPayout = MeetingPayout::where('meeting_id', $meeting->id)->where('user_id', $attendee->id)->first();

--- a/app/Actions/PutUserInRulesBrig.php
+++ b/app/Actions/PutUserInRulesBrig.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Actions;
+
+use App\Enums\BrigType;
+use App\Models\User;
+use Lorisleiva\Actions\Concerns\AsAction;
+
+class PutUserInRulesBrig
+{
+    use AsAction;
+
+    /**
+     * Place a user in a rules_non_compliance brig with no expiry.
+     *
+     * Skips silently if the user is already in a rules_non_compliance brig.
+     * The brig is auto-lifted when the user agrees to the current rules via AgreeToRulesVersion.
+     */
+    public function handle(User $user): void
+    {
+        if ($user->isInBrig() && $user->brig_type === BrigType::RulesNonCompliance) {
+            return;
+        }
+
+        if ($user->isInBrig()) {
+            return;
+        }
+
+        $admin = User::where('email', 'system@lighthouse.local')->first() ?? $user;
+
+        PutUserInBrig::run(
+            target: $user,
+            admin: $admin,
+            reason: 'Failed to agree to the updated community rules within the required timeframe.',
+            expiresAt: null,
+            appealAvailableAt: null,
+            brigType: BrigType::RulesNonCompliance,
+            notify: true,
+        );
+    }
+}

--- a/app/Actions/RejectDraftVersion.php
+++ b/app/Actions/RejectDraftVersion.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Actions;
+
+use App\Models\RuleVersion;
+use App\Models\User;
+use Illuminate\Auth\Access\AuthorizationException;
+use Lorisleiva\Actions\Concerns\AsAction;
+
+class RejectDraftVersion
+{
+    use AsAction;
+
+    /**
+     * Reject a submitted version and move it back to draft with a rejection note.
+     */
+    public function handle(RuleVersion $version, User $rejectedBy, string $rejectionNote): void
+    {
+        if ($version->status !== 'submitted') {
+            throw new AuthorizationException('Only submitted versions can be rejected.');
+        }
+
+        $version->status = 'draft';
+        $version->rejection_note = $rejectionNote;
+        $version->save();
+    }
+}

--- a/app/Actions/RemoveRuleFromDraft.php
+++ b/app/Actions/RemoveRuleFromDraft.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace App\Actions;
+
+use App\Models\Rule;
+use App\Models\RuleVersion;
+use Illuminate\Auth\Access\AuthorizationException;
+use Illuminate\Support\Facades\DB;
+use Lorisleiva\Actions\Concerns\AsAction;
+
+class RemoveRuleFromDraft
+{
+    use AsAction;
+
+    /**
+     * Remove a draft-status rule from the draft version, deleting the rule entirely.
+     *
+     * If the rule is a replacement (supersedes_rule_id is set), also removes the
+     * deactivation mark on the superseded rule so it remains active on publish.
+     */
+    public function handle(RuleVersion $draft, Rule $rule): void
+    {
+        if ($draft->status !== 'draft') {
+            throw new AuthorizationException('Rules can only be removed from draft versions.');
+        }
+
+        if ($rule->status !== 'draft') {
+            throw new AuthorizationException('Only draft rules can be removed. Use DeactivateRuleInDraft for active rules.');
+        }
+
+        DB::transaction(function () use ($draft, $rule): void {
+            $title = $rule->title;
+
+            // If this rule supersedes another (it's a replacement), remove the
+            // deactivation mark on the original rule so it stays active.
+            if ($rule->supersedes_rule_id) {
+                $draft->rules()->detach($rule->supersedes_rule_id);
+            }
+
+            // Detach this draft rule from the version pivot and delete it.
+            $draft->rules()->detach($rule->id);
+            $rule->delete();
+
+            RecordActivity::run($draft, 'rule_removed_from_draft', "Draft rule \"{$title}\" removed from draft version.");
+        });
+    }
+}

--- a/app/Actions/RemoveRuleFromDraft.php
+++ b/app/Actions/RemoveRuleFromDraft.php
@@ -28,6 +28,10 @@ class RemoveRuleFromDraft
             throw new AuthorizationException('Only draft rules can be removed. Use DeactivateRuleInDraft for active rules.');
         }
 
+        if (! $draft->rules()->whereKey($rule->id)->exists()) {
+            throw new AuthorizationException('This rule is not attached to the selected draft version.');
+        }
+
         DB::transaction(function () use ($draft, $rule): void {
             $title = $rule->title;
 

--- a/app/Actions/SendRulesAgreementReminder.php
+++ b/app/Actions/SendRulesAgreementReminder.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Actions;
+
+use App\Models\RuleVersion;
+use App\Models\User;
+use App\Notifications\RulesAgreementReminderNotification;
+use App\Services\TicketNotificationService;
+use Lorisleiva\Actions\Concerns\AsAction;
+
+class SendRulesAgreementReminder
+{
+    use AsAction;
+
+    /**
+     * Send a rules agreement reminder email to $user and record the timestamp.
+     */
+    public function handle(User $user, RuleVersion $version): void
+    {
+        $notificationService = app(TicketNotificationService::class);
+        $notificationService->send($user, new RulesAgreementReminderNotification($user, $version));
+
+        $user->rules_reminder_sent_at = now();
+        $user->save();
+    }
+}

--- a/app/Actions/SubmitVersionForApproval.php
+++ b/app/Actions/SubmitVersionForApproval.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Actions;
+
+use App\Models\RuleVersion;
+use App\Models\User;
+use Illuminate\Auth\Access\AuthorizationException;
+use Lorisleiva\Actions\Concerns\AsAction;
+
+class SubmitVersionForApproval
+{
+    use AsAction;
+
+    /**
+     * Move a draft version to submitted status for approval.
+     */
+    public function handle(RuleVersion $version, User $submittedBy): void
+    {
+        if ($version->status !== 'draft') {
+            throw new AuthorizationException('Only draft versions can be submitted for approval.');
+        }
+
+        $version->status = 'submitted';
+        $version->save();
+    }
+}

--- a/app/Actions/UpdateDisciplineReport.php
+++ b/app/Actions/UpdateDisciplineReport.php
@@ -22,6 +22,7 @@ class UpdateDisciplineReport
         ReportSeverity $severity,
         ?string $witnesses = null,
         ?ReportCategory $category = null,
+        array $ruleIds = [],
     ): DisciplineReport {
         $report->update([
             'description' => $description,
@@ -31,6 +32,8 @@ class UpdateDisciplineReport
             'severity' => $severity,
             'report_category_id' => $category?->id,
         ]);
+
+        $report->violatedRules()->sync($ruleIds);
 
         RecordActivity::run($report->subject, 'discipline_report_updated',
             "Discipline report #{$report->id} updated by {$editor->name}.", $editor);

--- a/app/Actions/UpdateRuleInDraft.php
+++ b/app/Actions/UpdateRuleInDraft.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace App\Actions;
+
+use App\Models\Rule;
+use App\Models\RuleCategory;
+use App\Models\RuleVersion;
+use App\Models\User;
+use Lorisleiva\Actions\Concerns\AsAction;
+
+class UpdateRuleInDraft
+{
+    use AsAction;
+
+    /**
+     * Replace an existing rule in a draft version.
+     *
+     * Creates a replacement rule (with supersedes_rule_id pointing to the old rule),
+     * adds it to the draft, and marks the old rule for deactivation on publish.
+     */
+    public function handle(
+        RuleVersion $draft,
+        Rule $oldRule,
+        string $newTitle,
+        string $newDescription,
+        User $createdBy,
+        ?RuleCategory $newCategory = null
+    ): Rule {
+        $replacement = Rule::create([
+            'rule_category_id' => $newCategory?->id ?? $oldRule->rule_category_id,
+            'title' => $newTitle,
+            'description' => $newDescription,
+            'status' => 'draft',
+            'supersedes_rule_id' => $oldRule->id,
+            'created_by_user_id' => $createdBy->id,
+        ]);
+
+        // Add the replacement rule to the draft as "activate on publish"
+        $draft->rules()->attach($replacement->id, ['deactivate_on_publish' => false]);
+
+        // Mark the old rule for deactivation on publish (it may or may not be in the version already)
+        if ($draft->rules()->where('rules.id', $oldRule->id)->exists()) {
+            $draft->rules()->updateExistingPivot($oldRule->id, ['deactivate_on_publish' => true]);
+        } else {
+            $draft->rules()->attach($oldRule->id, ['deactivate_on_publish' => true]);
+        }
+
+        return $replacement;
+    }
+}

--- a/app/Actions/UpdateRuleInDraft.php
+++ b/app/Actions/UpdateRuleInDraft.php
@@ -6,6 +6,8 @@ use App\Models\Rule;
 use App\Models\RuleCategory;
 use App\Models\RuleVersion;
 use App\Models\User;
+use Illuminate\Support\Facades\DB;
+use InvalidArgumentException;
 use Lorisleiva\Actions\Concerns\AsAction;
 
 class UpdateRuleInDraft
@@ -26,25 +28,31 @@ class UpdateRuleInDraft
         User $createdBy,
         ?RuleCategory $newCategory = null
     ): Rule {
-        $replacement = Rule::create([
-            'rule_category_id' => $newCategory?->id ?? $oldRule->rule_category_id,
-            'title' => $newTitle,
-            'description' => $newDescription,
-            'status' => 'draft',
-            'supersedes_rule_id' => $oldRule->id,
-            'created_by_user_id' => $createdBy->id,
-        ]);
-
-        // Add the replacement rule to the draft as "activate on publish"
-        $draft->rules()->attach($replacement->id, ['deactivate_on_publish' => false]);
-
-        // Mark the old rule for deactivation on publish (it may or may not be in the version already)
-        if ($draft->rules()->where('rules.id', $oldRule->id)->exists()) {
-            $draft->rules()->updateExistingPivot($oldRule->id, ['deactivate_on_publish' => true]);
-        } else {
-            $draft->rules()->attach($oldRule->id, ['deactivate_on_publish' => true]);
+        if ($draft->status !== 'draft') {
+            throw new InvalidArgumentException('Only draft versions can be updated.');
         }
 
-        return $replacement;
+        return DB::transaction(function () use ($draft, $oldRule, $newTitle, $newDescription, $createdBy, $newCategory): Rule {
+            $replacement = Rule::create([
+                'rule_category_id' => $newCategory?->id ?? $oldRule->rule_category_id,
+                'title' => $newTitle,
+                'description' => $newDescription,
+                'status' => 'draft',
+                'supersedes_rule_id' => $oldRule->id,
+                'created_by_user_id' => $createdBy->id,
+            ]);
+
+            // Add the replacement rule to the draft as "activate on publish"
+            $draft->rules()->attach($replacement->id, ['deactivate_on_publish' => false]);
+
+            // Mark the old rule for deactivation on publish (it may or may not be in the version already)
+            if ($draft->rules()->where('rules.id', $oldRule->id)->exists()) {
+                $draft->rules()->updateExistingPivot($oldRule->id, ['deactivate_on_publish' => true]);
+            } else {
+                $draft->rules()->attach($oldRule->id, ['deactivate_on_publish' => true]);
+            }
+
+            return $replacement;
+        });
     }
 }

--- a/app/Actions/UpdateRuleInDraft.php
+++ b/app/Actions/UpdateRuleInDraft.php
@@ -33,6 +33,23 @@ class UpdateRuleInDraft
         }
 
         return DB::transaction(function () use ($draft, $oldRule, $newTitle, $newDescription, $createdBy, $newCategory): Rule {
+            // If a draft replacement for this rule already exists in the draft, update it
+            // rather than creating a second one (which would cause both to be activated on publish).
+            $existingReplacement = $draft->rules()
+                ->where('rules.supersedes_rule_id', $oldRule->id)
+                ->where('rules.status', 'draft')
+                ->first();
+
+            if ($existingReplacement) {
+                $existingReplacement->update([
+                    'rule_category_id' => $newCategory?->id ?? $oldRule->rule_category_id,
+                    'title' => $newTitle,
+                    'description' => $newDescription,
+                ]);
+
+                return $existingReplacement->fresh();
+            }
+
             $replacement = Rule::create([
                 'rule_category_id' => $newCategory?->id ?? $oldRule->rule_category_id,
                 'title' => $newTitle,

--- a/app/Actions/UpdateRulesHeaderFooter.php
+++ b/app/Actions/UpdateRulesHeaderFooter.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Actions;
+
+use App\Models\SiteConfig;
+use Lorisleiva\Actions\Concerns\AsAction;
+
+class UpdateRulesHeaderFooter
+{
+    use AsAction;
+
+    public function handle(string $header, string $footer): void
+    {
+        SiteConfig::setValue('rules_header', $header);
+        SiteConfig::setValue('rules_footer', $footer);
+    }
+}

--- a/app/Console/Commands/DemoteAdminUser.php
+++ b/app/Console/Commands/DemoteAdminUser.php
@@ -25,7 +25,7 @@ class DemoteAdminUser extends Command
      */
     public function handle()
     {
-        $email = $this->argument('email');
+        $email = strtolower(trim($this->argument('email')));
 
         $user = \App\Models\User::where('email', $email)->first();
 

--- a/app/Console/Commands/DemoteAdminUser.php
+++ b/app/Console/Commands/DemoteAdminUser.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+
+class DemoteAdminUser extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'app:demote-admin-user {email}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Remove the Admin role from a user by email address';
+
+    /**
+     * Execute the console command.
+     */
+    public function handle()
+    {
+        $email = $this->argument('email');
+
+        $user = \App\Models\User::where('email', $email)->first();
+
+        if (! $user) {
+            $this->error("User with email {$email} not found.");
+
+            return 1;
+        }
+
+        if (! $user->isAdmin()) {
+            $this->info("User {$user->email} is not an Admin.");
+
+            return 0;
+        }
+
+        \App\Actions\RevokeUserAdmin::run($user);
+
+        $this->info("Admin role removed from {$user->email}.");
+
+        return 0;
+    }
+}

--- a/app/Enums/BrigType.php
+++ b/app/Enums/BrigType.php
@@ -8,6 +8,7 @@ enum BrigType: string
     case ParentalPending = 'parental_pending';
     case ParentalDisabled = 'parental_disabled';
     case AgeLock = 'age_lock';
+    case RulesNonCompliance = 'rules_non_compliance';
 
     public function label(): string
     {
@@ -16,6 +17,7 @@ enum BrigType: string
             self::ParentalPending => 'Pending Parental Approval',
             self::ParentalDisabled => 'Restricted by Parent',
             self::AgeLock => 'Age Verification Required',
+            self::RulesNonCompliance => 'Rules Non-Compliance',
         };
     }
 

--- a/app/Http/Controllers/DonationController.php
+++ b/app/Http/Controllers/DonationController.php
@@ -2,10 +2,47 @@
 
 namespace App\Http\Controllers;
 
+use App\Models\FinancialPeriod;
+use Illuminate\Support\Facades\DB;
+
 class DonationController extends Controller
 {
     public function index()
     {
-        return view('donation.index');
+        $closedPeriods = FinancialPeriod::where('status', 'closed')
+            ->orderByDesc('fiscal_year')
+            ->orderByDesc('start_date')
+            ->limit(2)
+            ->get()
+            ->map(function (FinancialPeriod $period) {
+                $income = (int) DB::table('financial_journal_entry_lines as jel')
+                    ->join('financial_journal_entries as je', 'je.id', '=', 'jel.journal_entry_id')
+                    ->join('financial_accounts as fa', 'fa.id', '=', 'jel.account_id')
+                    ->where('je.period_id', $period->id)
+                    ->where('je.status', 'posted')
+                    ->whereNot('je.entry_type', 'closing')
+                    ->where('fa.type', 'revenue')
+                    ->selectRaw('COALESCE(SUM(jel.credit) - SUM(jel.debit), 0) as total')
+                    ->value('total');
+
+                $expenses = (int) DB::table('financial_journal_entry_lines as jel')
+                    ->join('financial_journal_entries as je', 'je.id', '=', 'jel.journal_entry_id')
+                    ->join('financial_accounts as fa', 'fa.id', '=', 'jel.account_id')
+                    ->where('je.period_id', $period->id)
+                    ->where('je.status', 'posted')
+                    ->whereNot('je.entry_type', 'closing')
+                    ->where('fa.type', 'expense')
+                    ->selectRaw('COALESCE(SUM(jel.debit) - SUM(jel.credit), 0) as total')
+                    ->value('total');
+
+                return [
+                    'name' => $period->name,
+                    'income' => $income,
+                    'expenses' => $expenses,
+                    'net' => $income - $expenses,
+                ];
+            });
+
+        return view('donation.index', compact('closedPeriods'));
     }
 }

--- a/app/Http/Middleware/EnsureRulesAgreed.php
+++ b/app/Http/Middleware/EnsureRulesAgreed.php
@@ -9,7 +9,17 @@ class EnsureRulesAgreed
 {
     public function handle(Request $request, Closure $next)
     {
-        if ($request->user() && ! $request->user()->hasAgreedToCurrentRules()) {
+        $user = $request->user();
+
+        if (! $user) {
+            return $next($request);
+        }
+
+        if (! $user->hasAgreedToCurrentRules()) {
+            return redirect()->route('rules.show');
+        }
+
+        if ($user->unagreedChildren()->isNotEmpty()) {
             return redirect()->route('rules.show');
         }
 

--- a/app/Http/Middleware/EnsureRulesAgreed.php
+++ b/app/Http/Middleware/EnsureRulesAgreed.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+
+class EnsureRulesAgreed
+{
+    public function handle(Request $request, Closure $next)
+    {
+        if ($request->user() && ! $request->user()->hasAgreedToCurrentRules()) {
+            return redirect()->route('rules.show');
+        }
+
+        return $next($request);
+    }
+}

--- a/app/Jobs/CheckRulesAgreementJob.php
+++ b/app/Jobs/CheckRulesAgreementJob.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace App\Jobs;
+
+use App\Actions\PutUserInRulesBrig;
+use App\Actions\SendRulesAgreementReminder;
+use App\Enums\BrigType;
+use App\Enums\MembershipLevel;
+use App\Models\RuleVersion;
+use App\Models\User;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Queue\Queueable;
+
+class CheckRulesAgreementJob implements ShouldQueue
+{
+    use Queueable;
+
+    public function handle(): void
+    {
+        $version = RuleVersion::currentPublished();
+
+        if (! $version || ! $version->published_at) {
+            return;
+        }
+
+        $agreedUserIds = $version->agreements()->pluck('user_id');
+
+        $unagreedUsers = User::whereNotIn('id', $agreedUserIds)
+            ->where('membership_level', '>=', MembershipLevel::Stowaway->value)
+            ->get();
+
+        $daysSincePublish = (int) $version->published_at->diffInDays(now());
+
+        foreach ($unagreedUsers as $user) {
+            if ($daysSincePublish >= 28) {
+                if (! $user->isInBrig() || $user->brig_type !== BrigType::RulesNonCompliance) {
+                    PutUserInRulesBrig::run($user);
+                }
+            } elseif ($daysSincePublish >= 14 && $user->rules_reminder_sent_at === null) {
+                SendRulesAgreementReminder::run($user, $version);
+            }
+        }
+    }
+}

--- a/app/Models/DisciplineReport.php
+++ b/app/Models/DisciplineReport.php
@@ -9,6 +9,7 @@ use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\MorphMany;
 
 class DisciplineReport extends Model
@@ -82,6 +83,11 @@ class DisciplineReport extends Model
     public function isPublished(): bool
     {
         return $this->status === ReportStatus::Published;
+    }
+
+    public function violatedRules(): BelongsToMany
+    {
+        return $this->belongsToMany(Rule::class, 'discipline_report_rules');
     }
 
     public function topics(): MorphMany

--- a/app/Models/Rule.php
+++ b/app/Models/Rule.php
@@ -15,6 +15,7 @@ class Rule extends Model
         'status',
         'supersedes_rule_id',
         'created_by_user_id',
+        'sort_order',
     ];
 
     public function ruleCategory(): BelongsTo

--- a/app/Models/Rule.php
+++ b/app/Models/Rule.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+
+class Rule extends Model
+{
+    protected $fillable = [
+        'rule_category_id',
+        'title',
+        'description',
+        'status',
+        'supersedes_rule_id',
+        'created_by_user_id',
+    ];
+
+    public function ruleCategory(): BelongsTo
+    {
+        return $this->belongsTo(RuleCategory::class);
+    }
+
+    public function supersedes(): BelongsTo
+    {
+        return $this->belongsTo(Rule::class, 'supersedes_rule_id');
+    }
+
+    public function ruleVersions(): BelongsToMany
+    {
+        return $this->belongsToMany(RuleVersion::class, 'rule_version_rules')
+            ->withPivot('deactivate_on_publish');
+    }
+
+    public function isDraft(): bool
+    {
+        return $this->status === 'draft';
+    }
+
+    public function isActive(): bool
+    {
+        return $this->status === 'active';
+    }
+}

--- a/app/Models/Rule.php
+++ b/app/Models/Rule.php
@@ -2,12 +2,15 @@
 
 namespace App\Models;
 
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 
 class Rule extends Model
 {
+    use HasFactory;
+
     protected $fillable = [
         'rule_category_id',
         'title',

--- a/app/Models/RuleCategory.php
+++ b/app/Models/RuleCategory.php
@@ -2,11 +2,14 @@
 
 namespace App\Models;
 
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 
 class RuleCategory extends Model
 {
+    use HasFactory;
+
     protected $fillable = ['name', 'sort_order'];
 
     public function rules(): HasMany

--- a/app/Models/RuleCategory.php
+++ b/app/Models/RuleCategory.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+class RuleCategory extends Model
+{
+    protected $fillable = ['name', 'sort_order'];
+
+    public function rules(): HasMany
+    {
+        return $this->hasMany(Rule::class)->orderBy('sort_order');
+    }
+}

--- a/app/Models/RuleVersion.php
+++ b/app/Models/RuleVersion.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
@@ -9,6 +10,8 @@ use Illuminate\Database\Eloquent\Relations\HasMany;
 
 class RuleVersion extends Model
 {
+    use HasFactory;
+
     protected $fillable = [
         'version_number',
         'status',

--- a/app/Models/RuleVersion.php
+++ b/app/Models/RuleVersion.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+
+class RuleVersion extends Model
+{
+    protected $fillable = [
+        'version_number',
+        'status',
+        'created_by_user_id',
+        'approved_by_user_id',
+        'rejection_note',
+        'published_at',
+    ];
+
+    protected $casts = [
+        'published_at' => 'datetime',
+    ];
+
+    public function createdBy(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'created_by_user_id');
+    }
+
+    public function approvedBy(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'approved_by_user_id');
+    }
+
+    public function rules(): BelongsToMany
+    {
+        return $this->belongsToMany(Rule::class, 'rule_version_rules')
+            ->withPivot('deactivate_on_publish');
+    }
+
+    public function activeRules(): BelongsToMany
+    {
+        return $this->belongsToMany(Rule::class, 'rule_version_rules')
+            ->withPivot('deactivate_on_publish')
+            ->wherePivot('deactivate_on_publish', false);
+    }
+
+    public function isDraft(): bool
+    {
+        return $this->status === 'draft';
+    }
+
+    public function isPublished(): bool
+    {
+        return $this->status === 'published';
+    }
+
+    public static function currentPublished(): ?static
+    {
+        return static::where('status', 'published')->orderByDesc('version_number')->first();
+    }
+
+    public static function currentDraft(): ?static
+    {
+        return static::whereIn('status', ['draft', 'submitted'])->orderByDesc('version_number')->first();
+    }
+}

--- a/app/Models/RuleVersion.php
+++ b/app/Models/RuleVersion.php
@@ -5,6 +5,7 @@ namespace App\Models;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 
 class RuleVersion extends Model
 {
@@ -42,6 +43,11 @@ class RuleVersion extends Model
         return $this->belongsToMany(Rule::class, 'rule_version_rules')
             ->withPivot('deactivate_on_publish')
             ->wherePivot('deactivate_on_publish', false);
+    }
+
+    public function agreements(): HasMany
+    {
+        return $this->hasMany(UserRuleAgreement::class);
     }
 
     public function isDraft(): bool

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -287,6 +287,21 @@ class User extends Authenticatable // implements MustVerifyEmail
         return $this->belongsTo(User::class, 'rules_accepted_by_user_id');
     }
 
+    public function ruleAgreements(): HasMany
+    {
+        return $this->hasMany(UserRuleAgreement::class);
+    }
+
+    public function hasAgreedToCurrentRules(): bool
+    {
+        $current = RuleVersion::currentPublished();
+        if (! $current) {
+            return true;
+        }
+
+        return $this->ruleAgreements()->where('rule_version_id', $current->id)->exists();
+    }
+
     public function children(): BelongsToMany
     {
         return $this->belongsToMany(User::class, 'parent_child_links', 'parent_user_id', 'child_user_id')

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -302,6 +302,18 @@ class User extends Authenticatable // implements MustVerifyEmail
         return $this->ruleAgreements()->where('rule_version_id', $current->id)->exists();
     }
 
+    public function unagreedChildren(): \Illuminate\Support\Collection
+    {
+        $current = RuleVersion::currentPublished();
+        if (! $current) {
+            return collect();
+        }
+
+        $agreedUserIds = $current->agreements()->pluck('user_id');
+
+        return $this->children()->whereNotIn('users.id', $agreedUserIds)->get();
+    }
+
     public function children(): BelongsToMany
     {
         return $this->belongsToMany(User::class, 'parent_child_links', 'parent_user_id', 'child_user_id')

--- a/app/Models/UserRuleAgreement.php
+++ b/app/Models/UserRuleAgreement.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class UserRuleAgreement extends Model
+{
+    protected $fillable = ['user_id', 'rule_version_id', 'agreed_at'];
+
+    protected $casts = [
+        'agreed_at' => 'datetime',
+    ];
+
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    public function ruleVersion(): BelongsTo
+    {
+        return $this->belongsTo(RuleVersion::class);
+    }
+}

--- a/app/Models/UserRuleAgreement.php
+++ b/app/Models/UserRuleAgreement.php
@@ -7,7 +7,7 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
 class UserRuleAgreement extends Model
 {
-    protected $fillable = ['user_id', 'rule_version_id', 'agreed_at'];
+    protected $fillable = ['user_id', 'rule_version_id', 'agreed_at', 'proxy_user_id'];
 
     protected $casts = [
         'agreed_at' => 'datetime',
@@ -21,5 +21,15 @@ class UserRuleAgreement extends Model
     public function ruleVersion(): BelongsTo
     {
         return $this->belongsTo(RuleVersion::class);
+    }
+
+    public function proxyUser(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'proxy_user_id');
+    }
+
+    public function isProxy(): bool
+    {
+        return $this->proxy_user_id !== null;
     }
 }

--- a/app/Notifications/RulesAgreementReminderNotification.php
+++ b/app/Notifications/RulesAgreementReminderNotification.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace App\Notifications;
+
+use App\Models\RuleVersion;
+use App\Models\User;
+use App\Notifications\Channels\PushoverChannel;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Notifications\Messages\MailMessage;
+use Illuminate\Notifications\Notification;
+use Illuminate\Queue\SerializesModels;
+
+class RulesAgreementReminderNotification extends Notification implements ShouldQueue
+{
+    use Queueable, SerializesModels;
+
+    protected array $allowedChannels = ['mail'];
+
+    protected ?string $pushoverKey = null;
+
+    public function __construct(
+        public User $user,
+        public RuleVersion $version
+    ) {}
+
+    public function setChannels(array $channels, ?string $pushoverKey = null): self
+    {
+        $this->allowedChannels = $channels;
+        $this->pushoverKey = $pushoverKey;
+
+        return $this;
+    }
+
+    public function via(object $notifiable): array
+    {
+        $channels = [];
+
+        if (in_array('mail', $this->allowedChannels)) {
+            $channels[] = 'mail';
+        }
+
+        if (in_array('pushover', $this->allowedChannels) && $this->pushoverKey) {
+            $channels[] = PushoverChannel::class;
+        }
+
+        return $channels;
+    }
+
+    public function toMail(object $notifiable): MailMessage
+    {
+        return (new MailMessage)
+            ->subject('Reminder: Please Agree to the Updated Community Rules')
+            ->greeting("Hello {$this->user->name},")
+            ->line('You have not yet agreed to the latest version of the Lighthouse community rules.')
+            ->line('Agreement is required to maintain your access to the community. Please log in and review the updated rules as soon as possible.')
+            ->line('If you do not agree within the next two weeks, your account may be placed in a restricted status.')
+            ->action('Review and Agree to Rules', route('rules.show'));
+    }
+
+    public function toPushover(object $notifiable): array
+    {
+        return [
+            'title' => 'Rules Agreement Required',
+            'message' => 'You have not yet agreed to the updated community rules. Please log in to review them.',
+            'url' => route('rules.show'),
+        ];
+    }
+}

--- a/app/Notifications/RulesVersionPublishedNotification.php
+++ b/app/Notifications/RulesVersionPublishedNotification.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace App\Notifications;
+
+use App\Models\RuleVersion;
+use App\Models\User;
+use App\Notifications\Channels\PushoverChannel;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Notifications\Messages\MailMessage;
+use Illuminate\Notifications\Notification;
+use Illuminate\Queue\SerializesModels;
+
+class RulesVersionPublishedNotification extends Notification implements ShouldQueue
+{
+    use Queueable, SerializesModels;
+
+    protected array $allowedChannels = ['mail'];
+
+    protected ?string $pushoverKey = null;
+
+    public function __construct(
+        public User $user,
+        public RuleVersion $version
+    ) {}
+
+    public function setChannels(array $channels, ?string $pushoverKey = null): self
+    {
+        $this->allowedChannels = $channels;
+        $this->pushoverKey = $pushoverKey;
+
+        return $this;
+    }
+
+    public function via(object $notifiable): array
+    {
+        $channels = [];
+
+        if (in_array('mail', $this->allowedChannels)) {
+            $channels[] = 'mail';
+        }
+
+        if (in_array('pushover', $this->allowedChannels) && $this->pushoverKey) {
+            $channels[] = PushoverChannel::class;
+        }
+
+        return $channels;
+    }
+
+    public function toMail(object $notifiable): MailMessage
+    {
+        return (new MailMessage)
+            ->subject('Community Rules Updated — Please Review and Agree')
+            ->greeting("Hello {$this->user->name},")
+            ->line('The Lighthouse community rules have been updated and require your agreement.')
+            ->line('Please log in and review the updated rules. Your continued access to the community depends on your agreement.')
+            ->action('Review and Agree to Rules', route('dashboard'));
+    }
+
+    public function toPushover(object $notifiable): array
+    {
+        return [
+            'title' => 'Community Rules Updated',
+            'message' => 'The community rules have been updated and require your agreement. Please log in to review them.',
+            'url' => route('dashboard'),
+        ];
+    }
+}

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -258,5 +258,14 @@ class AuthServiceProvider extends ServiceProvider
         Gate::define('finance-community-view', function ($user) {
             return $user->isAdmin() || (! $user->in_brig && $user->isAtLeastLevel(MembershipLevel::Resident));
         });
+
+        // Rules gates
+        Gate::define('rules.manage', function ($user) {
+            return $user->hasRole('Rules - Manage');
+        });
+
+        Gate::define('rules.approve', function ($user) {
+            return $user->hasRole('Rules - Approve');
+        });
     }
 }

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -20,6 +20,7 @@ return Application::configure(basePath: dirname(__DIR__))
             'track-notification-read' => \App\Http\Middleware\UpdateLastNotificationRead::class,
             'ensure-dob' => \App\Http\Middleware\EnsureDateOfBirthIsSet::class,
             'ensure-local' => \App\Http\Middleware\EnsureLocalEnvironment::class,
+            'ensure-rules-agreed' => \App\Http\Middleware\EnsureRulesAgreed::class,
         ]);
 
         $middleware->validateCsrfTokens(except: [

--- a/database/factories/RuleCategoryFactory.php
+++ b/database/factories/RuleCategoryFactory.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\RuleCategory;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class RuleCategoryFactory extends Factory
+{
+    protected $model = RuleCategory::class;
+
+    public function definition(): array
+    {
+        return [
+            'name' => $this->faker->unique()->words(3, true),
+            'sort_order' => $this->faker->numberBetween(1, 100),
+        ];
+    }
+}

--- a/database/factories/RuleFactory.php
+++ b/database/factories/RuleFactory.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Rule;
+use App\Models\RuleCategory;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class RuleFactory extends Factory
+{
+    protected $model = Rule::class;
+
+    public function definition(): array
+    {
+        return [
+            'rule_category_id' => RuleCategory::factory(),
+            'title' => $this->faker->sentence(6),
+            'description' => $this->faker->paragraph(),
+            'status' => 'active',
+            'supersedes_rule_id' => null,
+            'created_by_user_id' => User::factory(),
+            'sort_order' => $this->faker->numberBetween(1, 100),
+        ];
+    }
+
+    public function draft(): static
+    {
+        return $this->state(['status' => 'draft']);
+    }
+
+    public function inactive(): static
+    {
+        return $this->state(['status' => 'inactive']);
+    }
+}

--- a/database/factories/RuleVersionFactory.php
+++ b/database/factories/RuleVersionFactory.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\RuleVersion;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class RuleVersionFactory extends Factory
+{
+    protected $model = RuleVersion::class;
+
+    public function definition(): array
+    {
+        return [
+            'version_number' => $this->faker->unique()->numberBetween(1, 9999),
+            'status' => 'draft',
+            'created_by_user_id' => User::factory(),
+            'approved_by_user_id' => null,
+            'rejection_note' => null,
+            'published_at' => null,
+        ];
+    }
+
+    public function submitted(): static
+    {
+        return $this->state(['status' => 'submitted']);
+    }
+
+    public function published(): static
+    {
+        return $this->state([
+            'status' => 'published',
+            'approved_by_user_id' => User::factory(),
+            'published_at' => now(),
+        ]);
+    }
+}

--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -114,4 +114,32 @@ class UserFactory extends Factory
             'date_of_birth' => now()->subYears(25),
         ]);
     }
+
+    /**
+     * Automatically agree to the current published rules version after creating the user.
+     * Applied by default so that factory users can access the dashboard in tests.
+     */
+    public function configure(): static
+    {
+        return $this->afterCreating(function ($user) {
+            $version = \App\Models\RuleVersion::currentPublished();
+            if ($version) {
+                \App\Models\UserRuleAgreement::updateOrCreate(
+                    ['user_id' => $user->id, 'rule_version_id' => $version->id],
+                    ['agreed_at' => now()],
+                );
+            }
+        });
+    }
+
+    /**
+     * Create a user that has NOT agreed to the current rules version.
+     * Use this when specifically testing the rules agreement flow.
+     */
+    public function withoutRulesAgreed(): static
+    {
+        return $this->afterCreating(function ($user) {
+            $user->ruleAgreements()->delete();
+        });
+    }
 }

--- a/database/migrations/2026_04_09_000001_create_rules_tables.php
+++ b/database/migrations/2026_04_09_000001_create_rules_tables.php
@@ -1,0 +1,82 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('rule_categories', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->unsignedInteger('sort_order')->default(0);
+            $table->timestamps();
+        });
+
+        Schema::create('rules', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('rule_category_id')->constrained('rule_categories')->cascadeOnDelete();
+            $table->string('title');
+            $table->text('description');
+            $table->enum('status', ['draft', 'active', 'inactive'])->default('draft');
+            $table->foreignId('supersedes_rule_id')->nullable()->constrained('rules')->nullOnDelete();
+            $table->foreignId('created_by_user_id')->nullable()->constrained('users')->nullOnDelete();
+            $table->timestamps();
+        });
+
+        Schema::create('rule_versions', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedInteger('version_number');
+            $table->enum('status', ['draft', 'submitted', 'published'])->default('draft');
+            $table->foreignId('created_by_user_id')->nullable()->constrained('users')->nullOnDelete();
+            $table->foreignId('approved_by_user_id')->nullable()->constrained('users')->nullOnDelete();
+            $table->text('rejection_note')->nullable();
+            $table->timestamp('published_at')->nullable();
+            $table->timestamps();
+
+            $table->unique('version_number');
+        });
+
+        Schema::create('rule_version_rules', function (Blueprint $table) {
+            $table->foreignId('rule_version_id')->constrained('rule_versions')->cascadeOnDelete();
+            $table->foreignId('rule_id')->constrained('rules')->cascadeOnDelete();
+            $table->primary(['rule_version_id', 'rule_id']);
+        });
+
+        Schema::create('user_rule_agreements', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('user_id')->constrained('users')->cascadeOnDelete();
+            $table->foreignId('rule_version_id')->constrained('rule_versions')->cascadeOnDelete();
+            $table->timestamp('agreed_at');
+            $table->timestamps();
+
+            $table->unique(['user_id', 'rule_version_id']);
+        });
+
+        Schema::create('discipline_report_rules', function (Blueprint $table) {
+            $table->foreignId('discipline_report_id')->constrained('discipline_reports')->cascadeOnDelete();
+            $table->foreignId('rule_id')->constrained('rules')->cascadeOnDelete();
+            $table->primary(['discipline_report_id', 'rule_id']);
+        });
+
+        Schema::table('users', function (Blueprint $table) {
+            $table->timestamp('rules_reminder_sent_at')->nullable()->after('rules_accepted_by_user_id');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropColumn('rules_reminder_sent_at');
+        });
+
+        Schema::dropIfExists('discipline_report_rules');
+        Schema::dropIfExists('user_rule_agreements');
+        Schema::dropIfExists('rule_version_rules');
+        Schema::dropIfExists('rule_versions');
+        Schema::dropIfExists('rules');
+        Schema::dropIfExists('rule_categories');
+    }
+};

--- a/database/migrations/2026_04_09_000002_seed_rules_data.php
+++ b/database/migrations/2026_04_09_000002_seed_rules_data.php
@@ -7,128 +7,129 @@ return new class extends Migration
 {
     public function up(): void
     {
-        $now = now();
+        DB::transaction(function () {
+            $now = now();
 
-        // --- Seed rule categories and rules ---
+            // --- Seed rule categories and rules ---
 
-        $categories = [
-            [
-                'name' => 'Honor God',
-                'sort_order' => 1,
-                'rules' => [
-                    ['title' => 'No Inappropriate Use of God\'s Name', 'description' => 'Do not use God\'s name in an inappropriate manner.'],
-                    ['title' => 'No Disrespectful Depictions of God or Jesus', 'description' => 'Do not share images that depict God or Jesus in a disrespectful way.'],
-                    ['title' => 'No Promotion of Sinful Lifestyles', 'description' => 'Do not promote or encourage any sinful lifestyle (as defined by a traditional view of Scripture).'],
+            $categories = [
+                [
+                    'name' => 'Honor God',
+                    'sort_order' => 1,
+                    'rules' => [
+                        ['title' => 'No Inappropriate Use of God\'s Name', 'description' => 'Do not use God\'s name in an inappropriate manner.'],
+                        ['title' => 'No Disrespectful Depictions of God or Jesus', 'description' => 'Do not share images that depict God or Jesus in a disrespectful way.'],
+                        ['title' => 'No Promotion of Sinful Lifestyles', 'description' => 'Do not promote or encourage any sinful lifestyle (as defined by a traditional view of Scripture).'],
+                    ],
                 ],
-            ],
-            [
-                'name' => 'Be Respectful of Others',
-                'sort_order' => 2,
-                'rules' => [
-                    ['title' => 'No Disrespectful Behavior', 'description' => 'Do not steal, grief, insult, slander, or gossip.'],
+                [
+                    'name' => 'Be Respectful of Others',
+                    'sort_order' => 2,
+                    'rules' => [
+                        ['title' => 'No Disrespectful Behavior', 'description' => 'Do not steal, grief, insult, slander, or gossip.'],
+                    ],
                 ],
-            ],
-            [
-                'name' => 'Keep Language Clean',
-                'sort_order' => 3,
-                'rules' => [
-                    ['title' => 'No Cursing', 'description' => 'Do not curse or use acronyms for cursing.'],
-                    ['title' => 'No Filthy Joking', 'description' => 'Do not make filthy jokes or promote sinful behavior.'],
+                [
+                    'name' => 'Keep Language Clean',
+                    'sort_order' => 3,
+                    'rules' => [
+                        ['title' => 'No Cursing', 'description' => 'Do not curse or use acronyms for cursing.'],
+                        ['title' => 'No Filthy Joking', 'description' => 'Do not make filthy jokes or promote sinful behavior.'],
+                    ],
                 ],
-            ],
-            [
-                'name' => 'Keep Sharing Clean',
-                'sort_order' => 4,
-                'rules' => [
-                    ['title' => 'No NSFW Content', 'description' => 'Do not share NSFW (Not Safe For Work) images or content.'],
+                [
+                    'name' => 'Keep Sharing Clean',
+                    'sort_order' => 4,
+                    'rules' => [
+                        ['title' => 'No NSFW Content', 'description' => 'Do not share NSFW (Not Safe For Work) images or content.'],
+                    ],
                 ],
-            ],
-            [
-                'name' => 'No Spamming',
-                'sort_order' => 5,
-                'rules' => [
-                    ['title' => 'No ALL CAPS or Repeating Messages', 'description' => 'Do not send ALL CAPS messages or repeat phrases.'],
-                    ['title' => 'No Begging for Items or Privileges', 'description' => 'Do not beg others for items or privileges.'],
+                [
+                    'name' => 'No Spamming',
+                    'sort_order' => 5,
+                    'rules' => [
+                        ['title' => 'No ALL CAPS or Repeating Messages', 'description' => 'Do not send ALL CAPS messages or repeat phrases.'],
+                        ['title' => 'No Begging for Items or Privileges', 'description' => 'Do not beg others for items or privileges.'],
+                    ],
                 ],
-            ],
-            [
-                'name' => 'No Talk About Self-Harm',
-                'sort_order' => 6,
-                'rules' => [
-                    ['title' => 'No Discussion of Self-Harm', 'description' => 'Do not discuss suicide, cutting, or other harmful behaviors.'],
-                    ['title' => 'No Encouraging Self-Harm', 'description' => 'Do not encourage others to harm themselves.'],
+                [
+                    'name' => 'No Talk About Self-Harm',
+                    'sort_order' => 6,
+                    'rules' => [
+                        ['title' => 'No Discussion of Self-Harm', 'description' => 'Do not discuss suicide, cutting, or other harmful behaviors.'],
+                        ['title' => 'No Encouraging Self-Harm', 'description' => 'Do not encourage others to harm themselves.'],
+                    ],
                 ],
-            ],
-            [
-                'name' => 'When Sharing Links',
-                'sort_order' => 7,
-                'rules' => [
-                    ['title' => 'No Advertising Other Servers', 'description' => 'Do not advertise or promote other Minecraft or Discord servers.'],
-                    ['title' => 'No Inappropriate Media', 'description' => 'Do not share videos or music with inappropriate images or language.'],
-                    ['title' => 'No False Teaching', 'description' => 'Do not share sermons or teachings from false teachers (e.g. Bethel, prosperity gospel, "Name it and claim it").'],
+                [
+                    'name' => 'When Sharing Links',
+                    'sort_order' => 7,
+                    'rules' => [
+                        ['title' => 'No Advertising Other Servers', 'description' => 'Do not advertise or promote other Minecraft or Discord servers.'],
+                        ['title' => 'No Inappropriate Media', 'description' => 'Do not share videos or music with inappropriate images or language.'],
+                        ['title' => 'No False Teaching', 'description' => 'Do not share sermons or teachings from false teachers (e.g. Bethel, prosperity gospel, "Name it and claim it").'],
+                    ],
                 ],
-            ],
-            [
-                'name' => 'Moderation',
-                'sort_order' => 8,
-                'rules' => [
-                    ['title' => 'No Public Disputes with Staff', 'description' => 'Do not argue publicly with moderator decisions.'],
-                    ['title' => 'Disagreements Go Through Officers', 'description' => 'If you disagree with a decision, contact the officers privately.'],
+                [
+                    'name' => 'Moderation',
+                    'sort_order' => 8,
+                    'rules' => [
+                        ['title' => 'No Public Disputes with Staff', 'description' => 'Do not argue publicly with moderator decisions.'],
+                        ['title' => 'Disagreements Go Through Officers', 'description' => 'If you disagree with a decision, contact the officers privately.'],
+                    ],
                 ],
-            ],
-            [
-                'name' => 'In-Game Conduct',
-                'sort_order' => 9,
-                'rules' => [
-                    ['title' => 'No Begging for Handouts', 'description' => 'Do not beg for handouts in-game.'],
-                    ['title' => 'No Stealing', 'description' => 'Do not steal from others\' chests or property.'],
-                    ['title' => 'No Auto Clickers or Auto Aiming', 'description' => 'Do not use auto clickers or auto aiming tools.'],
-                    ['title' => 'No XRay Mods or Exploits', 'description' => 'Do not use XRay mods or exploits.'],
-                    ['title' => 'Keep Farms Server-Friendly', 'description' => 'Keep farms server-friendly: turn them off when not in use, and avoid hopper and entity lag.'],
-                    ['title' => 'No Unsolicited PvP', 'description' => 'Only engage in PvP with willing participants.'],
-                    ['title' => 'No Mass Destruction', 'description' => 'Do not use tunnel bores or cause mass destruction.'],
-                    ['title' => 'No Using Others\' Farms Without Permission', 'description' => 'Do not use other players\' farms without permission.'],
+                [
+                    'name' => 'In-Game Conduct',
+                    'sort_order' => 9,
+                    'rules' => [
+                        ['title' => 'No Begging for Handouts', 'description' => 'Do not beg for handouts in-game.'],
+                        ['title' => 'No Stealing', 'description' => 'Do not steal from others\' chests or property.'],
+                        ['title' => 'No Auto Clickers or Auto Aiming', 'description' => 'Do not use auto clickers or auto aiming tools.'],
+                        ['title' => 'No XRay Mods or Exploits', 'description' => 'Do not use XRay mods or exploits.'],
+                        ['title' => 'Keep Farms Server-Friendly', 'description' => 'Keep farms server-friendly: turn them off when not in use, and avoid hopper and entity lag.'],
+                        ['title' => 'No Unsolicited PvP', 'description' => 'Only engage in PvP with willing participants.'],
+                        ['title' => 'No Mass Destruction', 'description' => 'Do not use tunnel bores or cause mass destruction.'],
+                        ['title' => 'No Using Others\' Farms Without Permission', 'description' => 'Do not use other players\' farms without permission.'],
+                    ],
                 ],
-            ],
-            [
-                'name' => 'Duping Rules',
-                'sort_order' => 10,
-                'rules' => [
-                    ['title' => 'Allowed Duping: Carpet and TNT', 'description' => 'Carpet and TNT duplication is allowed when used in a farm that requires it.'],
-                    ['title' => 'Allowed Duping: Sticks and String', 'description' => 'Sticks and String duplication is allowed.'],
+                [
+                    'name' => 'Duping Rules',
+                    'sort_order' => 10,
+                    'rules' => [
+                        ['title' => 'Allowed Duping: Carpet and TNT', 'description' => 'Carpet and TNT duplication is allowed when used in a farm that requires it.'],
+                        ['title' => 'Allowed Duping: Sticks and String', 'description' => 'Sticks and String duplication is allowed.'],
+                    ],
                 ],
-            ],
-        ];
+            ];
 
-        $allRuleIds = [];
+            $allRuleIds = [];
 
-        foreach ($categories as $categoryData) {
-            $categoryId = DB::table('rule_categories')->insertGetId([
-                'name' => $categoryData['name'],
-                'sort_order' => $categoryData['sort_order'],
-                'created_at' => $now,
-                'updated_at' => $now,
-            ]);
-
-            foreach ($categoryData['rules'] as $ruleData) {
-                $ruleId = DB::table('rules')->insertGetId([
-                    'rule_category_id' => $categoryId,
-                    'title' => $ruleData['title'],
-                    'description' => $ruleData['description'],
-                    'status' => 'active',
-                    'supersedes_rule_id' => null,
-                    'created_by_user_id' => null,
+            foreach ($categories as $categoryData) {
+                $categoryId = DB::table('rule_categories')->insertGetId([
+                    'name' => $categoryData['name'],
+                    'sort_order' => $categoryData['sort_order'],
                     'created_at' => $now,
                     'updated_at' => $now,
                 ]);
 
-                $allRuleIds[] = $ruleId;
+                foreach ($categoryData['rules'] as $ruleData) {
+                    $ruleId = DB::table('rules')->insertGetId([
+                        'rule_category_id' => $categoryId,
+                        'title' => $ruleData['title'],
+                        'description' => $ruleData['description'],
+                        'status' => 'active',
+                        'supersedes_rule_id' => null,
+                        'created_by_user_id' => null,
+                        'created_at' => $now,
+                        'updated_at' => $now,
+                    ]);
+
+                    $allRuleIds[] = $ruleId;
+                }
             }
-        }
 
-        // --- Seed SiteConfig keys for rules header and footer ---
+            // --- Seed SiteConfig keys for rules header and footer ---
 
-        $rulesHeader = <<<'MARKDOWN'
+            $rulesHeader = <<<'MARKDOWN'
 > "Love one another with brotherly affection. Outdo one another in showing honor."
 > — Romans 12:10 (ESV)
 
@@ -136,59 +137,60 @@ return new class extends Migration
 > — Matthew 22:37–39 (ESV)
 MARKDOWN;
 
-        $rulesFooter = 'The Officers reserve the right to remove individuals from the community that we feel are harmful or a bad influence on members of Lighthouse.';
+            $rulesFooter = 'The Officers reserve the right to remove individuals from the community that we feel are harmful or a bad influence on members of Lighthouse.';
 
-        DB::table('site_configs')->insertOrIgnore([
-            'key' => 'rules_header',
-            'value' => $rulesHeader,
-            'description' => 'Markdown content displayed above the community rules (e.g. scripture quotes).',
-            'created_at' => $now,
-            'updated_at' => $now,
-        ]);
-
-        DB::table('site_configs')->insertOrIgnore([
-            'key' => 'rules_footer',
-            'value' => $rulesFooter,
-            'description' => 'Markdown content displayed below the community rules (e.g. officer discretion disclaimer).',
-            'created_at' => $now,
-            'updated_at' => $now,
-        ]);
-
-        // --- Create version 1 as published ---
-
-        $versionId = DB::table('rule_versions')->insertGetId([
-            'version_number' => 1,
-            'status' => 'published',
-            'created_by_user_id' => null,
-            'approved_by_user_id' => null,
-            'published_at' => $now,
-            'created_at' => $now,
-            'updated_at' => $now,
-        ]);
-
-        foreach ($allRuleIds as $ruleId) {
-            DB::table('rule_version_rules')->insert([
-                'rule_version_id' => $versionId,
-                'rule_id' => $ruleId,
-            ]);
-        }
-
-        // --- Migrate existing user agreements to version 1 ---
-
-        $usersWithAgreement = DB::table('users')
-            ->whereNotNull('rules_accepted_at')
-            ->select('id', 'rules_accepted_at')
-            ->get();
-
-        foreach ($usersWithAgreement as $user) {
-            DB::table('user_rule_agreements')->insertOrIgnore([
-                'user_id' => $user->id,
-                'rule_version_id' => $versionId,
-                'agreed_at' => $user->rules_accepted_at,
+            DB::table('site_configs')->insertOrIgnore([
+                'key' => 'rules_header',
+                'value' => $rulesHeader,
+                'description' => 'Markdown content displayed above the community rules (e.g. scripture quotes).',
                 'created_at' => $now,
                 'updated_at' => $now,
             ]);
-        }
+
+            DB::table('site_configs')->insertOrIgnore([
+                'key' => 'rules_footer',
+                'value' => $rulesFooter,
+                'description' => 'Markdown content displayed below the community rules (e.g. officer discretion disclaimer).',
+                'created_at' => $now,
+                'updated_at' => $now,
+            ]);
+
+            // --- Create version 1 as published ---
+
+            $versionId = DB::table('rule_versions')->insertGetId([
+                'version_number' => 1,
+                'status' => 'published',
+                'created_by_user_id' => null,
+                'approved_by_user_id' => null,
+                'published_at' => $now,
+                'created_at' => $now,
+                'updated_at' => $now,
+            ]);
+
+            foreach ($allRuleIds as $ruleId) {
+                DB::table('rule_version_rules')->insert([
+                    'rule_version_id' => $versionId,
+                    'rule_id' => $ruleId,
+                ]);
+            }
+
+            // --- Migrate existing user agreements to version 1 ---
+
+            $usersWithAgreement = DB::table('users')
+                ->whereNotNull('rules_accepted_at')
+                ->select('id', 'rules_accepted_at')
+                ->get();
+
+            foreach ($usersWithAgreement as $user) {
+                DB::table('user_rule_agreements')->insertOrIgnore([
+                    'user_id' => $user->id,
+                    'rule_version_id' => $versionId,
+                    'agreed_at' => $user->rules_accepted_at,
+                    'created_at' => $now,
+                    'updated_at' => $now,
+                ]);
+            }
+        }); // end DB::transaction
     }
 
     public function down(): void

--- a/database/migrations/2026_04_09_000002_seed_rules_data.php
+++ b/database/migrations/2026_04_09_000002_seed_rules_data.php
@@ -199,15 +199,18 @@ MARKDOWN;
             ->where('created_at', '>=', $migrationDate)
             ->delete();
 
-        DB::table('rule_version_rules')->delete();
-        DB::table('rule_versions')->where('version_number', 1)->delete();
+        $versionId = DB::table('rule_versions')->where('version_number', 1)->value('id');
+        if ($versionId) {
+            DB::table('rule_version_rules')->where('rule_version_id', $versionId)->delete();
+            DB::table('rule_versions')->where('id', $versionId)->delete();
+        }
 
         DB::table('site_configs')
             ->whereIn('key', ['rules_header', 'rules_footer'])
             ->where('created_at', '>=', $migrationDate)
             ->delete();
 
-        DB::table('rules')->delete();
-        DB::table('rule_categories')->delete();
+        DB::table('rules')->where('created_at', '>=', $migrationDate)->delete();
+        DB::table('rule_categories')->where('created_at', '>=', $migrationDate)->delete();
     }
 };

--- a/database/migrations/2026_04_09_000002_seed_rules_data.php
+++ b/database/migrations/2026_04_09_000002_seed_rules_data.php
@@ -1,0 +1,213 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        $now = now();
+
+        // --- Seed rule categories and rules ---
+
+        $categories = [
+            [
+                'name' => 'Honor God',
+                'sort_order' => 1,
+                'rules' => [
+                    ['title' => 'No Inappropriate Use of God\'s Name', 'description' => 'Do not use God\'s name in an inappropriate manner.'],
+                    ['title' => 'No Disrespectful Depictions of God or Jesus', 'description' => 'Do not share images that depict God or Jesus in a disrespectful way.'],
+                    ['title' => 'No Promotion of Sinful Lifestyles', 'description' => 'Do not promote or encourage any sinful lifestyle (as defined by a traditional view of Scripture).'],
+                ],
+            ],
+            [
+                'name' => 'Be Respectful of Others',
+                'sort_order' => 2,
+                'rules' => [
+                    ['title' => 'No Disrespectful Behavior', 'description' => 'Do not steal, grief, insult, slander, or gossip.'],
+                ],
+            ],
+            [
+                'name' => 'Keep Language Clean',
+                'sort_order' => 3,
+                'rules' => [
+                    ['title' => 'No Cursing', 'description' => 'Do not curse or use acronyms for cursing.'],
+                    ['title' => 'No Filthy Joking', 'description' => 'Do not make filthy jokes or promote sinful behavior.'],
+                ],
+            ],
+            [
+                'name' => 'Keep Sharing Clean',
+                'sort_order' => 4,
+                'rules' => [
+                    ['title' => 'No NSFW Content', 'description' => 'Do not share NSFW (Not Safe For Work) images or content.'],
+                ],
+            ],
+            [
+                'name' => 'No Spamming',
+                'sort_order' => 5,
+                'rules' => [
+                    ['title' => 'No ALL CAPS or Repeating Messages', 'description' => 'Do not send ALL CAPS messages or repeat phrases.'],
+                    ['title' => 'No Begging for Items or Privileges', 'description' => 'Do not beg others for items or privileges.'],
+                ],
+            ],
+            [
+                'name' => 'No Talk About Self-Harm',
+                'sort_order' => 6,
+                'rules' => [
+                    ['title' => 'No Discussion of Self-Harm', 'description' => 'Do not discuss suicide, cutting, or other harmful behaviors.'],
+                    ['title' => 'No Encouraging Self-Harm', 'description' => 'Do not encourage others to harm themselves.'],
+                ],
+            ],
+            [
+                'name' => 'When Sharing Links',
+                'sort_order' => 7,
+                'rules' => [
+                    ['title' => 'No Advertising Other Servers', 'description' => 'Do not advertise or promote other Minecraft or Discord servers.'],
+                    ['title' => 'No Inappropriate Media', 'description' => 'Do not share videos or music with inappropriate images or language.'],
+                    ['title' => 'No False Teaching', 'description' => 'Do not share sermons or teachings from false teachers (e.g. Bethel, prosperity gospel, "Name it and claim it").'],
+                ],
+            ],
+            [
+                'name' => 'Moderation',
+                'sort_order' => 8,
+                'rules' => [
+                    ['title' => 'No Public Disputes with Staff', 'description' => 'Do not argue publicly with moderator decisions.'],
+                    ['title' => 'Disagreements Go Through Officers', 'description' => 'If you disagree with a decision, contact the officers privately.'],
+                ],
+            ],
+            [
+                'name' => 'In-Game Conduct',
+                'sort_order' => 9,
+                'rules' => [
+                    ['title' => 'No Begging for Handouts', 'description' => 'Do not beg for handouts in-game.'],
+                    ['title' => 'No Stealing', 'description' => 'Do not steal from others\' chests or property.'],
+                    ['title' => 'No Auto Clickers or Auto Aiming', 'description' => 'Do not use auto clickers or auto aiming tools.'],
+                    ['title' => 'No XRay Mods or Exploits', 'description' => 'Do not use XRay mods or exploits.'],
+                    ['title' => 'Keep Farms Server-Friendly', 'description' => 'Keep farms server-friendly: turn them off when not in use, and avoid hopper and entity lag.'],
+                    ['title' => 'No Unsolicited PvP', 'description' => 'Only engage in PvP with willing participants.'],
+                    ['title' => 'No Mass Destruction', 'description' => 'Do not use tunnel bores or cause mass destruction.'],
+                    ['title' => 'No Using Others\' Farms Without Permission', 'description' => 'Do not use other players\' farms without permission.'],
+                ],
+            ],
+            [
+                'name' => 'Duping Rules',
+                'sort_order' => 10,
+                'rules' => [
+                    ['title' => 'Allowed Duping: Carpet and TNT', 'description' => 'Carpet and TNT duplication is allowed when used in a farm that requires it.'],
+                    ['title' => 'Allowed Duping: Sticks and String', 'description' => 'Sticks and String duplication is allowed.'],
+                ],
+            ],
+        ];
+
+        $allRuleIds = [];
+
+        foreach ($categories as $categoryData) {
+            $categoryId = DB::table('rule_categories')->insertGetId([
+                'name' => $categoryData['name'],
+                'sort_order' => $categoryData['sort_order'],
+                'created_at' => $now,
+                'updated_at' => $now,
+            ]);
+
+            foreach ($categoryData['rules'] as $ruleData) {
+                $ruleId = DB::table('rules')->insertGetId([
+                    'rule_category_id' => $categoryId,
+                    'title' => $ruleData['title'],
+                    'description' => $ruleData['description'],
+                    'status' => 'active',
+                    'supersedes_rule_id' => null,
+                    'created_by_user_id' => null,
+                    'created_at' => $now,
+                    'updated_at' => $now,
+                ]);
+
+                $allRuleIds[] = $ruleId;
+            }
+        }
+
+        // --- Seed SiteConfig keys for rules header and footer ---
+
+        $rulesHeader = <<<'MARKDOWN'
+> "Love one another with brotherly affection. Outdo one another in showing honor."
+> — Romans 12:10 (ESV)
+
+> "You shall love the Lord your God with all your heart and with all your soul and with all your mind. This is the great and first commandment. And a second is like it: You shall love your neighbor as yourself."
+> — Matthew 22:37–39 (ESV)
+MARKDOWN;
+
+        $rulesFooter = 'The Officers reserve the right to remove individuals from the community that we feel are harmful or a bad influence on members of Lighthouse.';
+
+        DB::table('site_configs')->insertOrIgnore([
+            'key' => 'rules_header',
+            'value' => $rulesHeader,
+            'description' => 'Markdown content displayed above the community rules (e.g. scripture quotes).',
+            'created_at' => $now,
+            'updated_at' => $now,
+        ]);
+
+        DB::table('site_configs')->insertOrIgnore([
+            'key' => 'rules_footer',
+            'value' => $rulesFooter,
+            'description' => 'Markdown content displayed below the community rules (e.g. officer discretion disclaimer).',
+            'created_at' => $now,
+            'updated_at' => $now,
+        ]);
+
+        // --- Create version 1 as published ---
+
+        $versionId = DB::table('rule_versions')->insertGetId([
+            'version_number' => 1,
+            'status' => 'published',
+            'created_by_user_id' => null,
+            'approved_by_user_id' => null,
+            'published_at' => $now,
+            'created_at' => $now,
+            'updated_at' => $now,
+        ]);
+
+        foreach ($allRuleIds as $ruleId) {
+            DB::table('rule_version_rules')->insert([
+                'rule_version_id' => $versionId,
+                'rule_id' => $ruleId,
+            ]);
+        }
+
+        // --- Migrate existing user agreements to version 1 ---
+
+        $usersWithAgreement = DB::table('users')
+            ->whereNotNull('rules_accepted_at')
+            ->select('id', 'rules_accepted_at')
+            ->get();
+
+        foreach ($usersWithAgreement as $user) {
+            DB::table('user_rule_agreements')->insertOrIgnore([
+                'user_id' => $user->id,
+                'rule_version_id' => $versionId,
+                'agreed_at' => $user->rules_accepted_at,
+                'created_at' => $now,
+                'updated_at' => $now,
+            ]);
+        }
+    }
+
+    public function down(): void
+    {
+        $migrationDate = '2026-04-09 00:00:00';
+
+        DB::table('user_rule_agreements')
+            ->where('created_at', '>=', $migrationDate)
+            ->delete();
+
+        DB::table('rule_version_rules')->delete();
+        DB::table('rule_versions')->where('version_number', 1)->delete();
+
+        DB::table('site_configs')
+            ->whereIn('key', ['rules_header', 'rules_footer'])
+            ->where('created_at', '>=', $migrationDate)
+            ->delete();
+
+        DB::table('rules')->delete();
+        DB::table('rule_categories')->delete();
+    }
+};

--- a/database/migrations/2026_04_09_000003_seed_rules_permission_roles.php
+++ b/database/migrations/2026_04_09_000003_seed_rules_permission_roles.php
@@ -1,0 +1,40 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        $roles = [
+            [
+                'name' => 'Rules - Manage',
+                'description' => 'Create and edit draft rule versions, add/edit/deactivate rules, reorder categories, and edit the rules header and footer.',
+                'color' => 'indigo',
+                'icon' => 'book-open',
+            ],
+            [
+                'name' => 'Rules - Approve',
+                'description' => 'Review submitted rule versions and approve or reject them. Cannot approve a version they created.',
+                'color' => 'violet',
+                'icon' => 'check-badge',
+            ],
+        ];
+
+        foreach ($roles as $role) {
+            $exists = DB::table('roles')->where('name', $role['name'])->exists();
+            if (! $exists) {
+                DB::table('roles')->insert(array_merge($role, [
+                    'created_at' => now(),
+                    'updated_at' => now(),
+                ]));
+            }
+        }
+    }
+
+    public function down(): void
+    {
+        DB::table('roles')->whereIn('name', ['Rules - Manage', 'Rules - Approve'])->delete();
+    }
+};

--- a/database/migrations/2026_04_09_000004_add_deactivate_on_publish_to_rule_version_rules.php
+++ b/database/migrations/2026_04_09_000004_add_deactivate_on_publish_to_rule_version_rules.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('rule_version_rules', function (Blueprint $table) {
+            $table->boolean('deactivate_on_publish')->default(false)->after('rule_id');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('rule_version_rules', function (Blueprint $table) {
+            $table->dropColumn('deactivate_on_publish');
+        });
+    }
+};

--- a/database/migrations/2026_04_09_000005_add_sort_order_to_rules.php
+++ b/database/migrations/2026_04_09_000005_add_sort_order_to_rules.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('rules', function (Blueprint $table) {
+            $table->unsignedInteger('sort_order')->default(0)->after('created_by_user_id');
+        });
+
+        // Seed initial sort_order for existing rules based on their id within each category
+        $categories = DB::table('rule_categories')->orderBy('id')->pluck('id');
+        foreach ($categories as $categoryId) {
+            $rules = DB::table('rules')->where('rule_category_id', $categoryId)->orderBy('id')->get();
+            foreach ($rules as $index => $rule) {
+                DB::table('rules')->where('id', $rule->id)->update(['sort_order' => ($index + 1) * 10]);
+            }
+        }
+    }
+
+    public function down(): void
+    {
+        Schema::table('rules', function (Blueprint $table) {
+            $table->dropColumn('sort_order');
+        });
+    }
+};

--- a/database/migrations/2026_04_09_000006_add_proxy_user_id_to_user_rule_agreements.php
+++ b/database/migrations/2026_04_09_000006_add_proxy_user_id_to_user_rule_agreements.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('user_rule_agreements', function (Blueprint $table) {
+            $table->foreignId('proxy_user_id')
+                ->nullable()
+                ->after('agreed_at')
+                ->constrained('users')
+                ->nullOnDelete();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('user_rule_agreements', function (Blueprint $table) {
+            $table->dropForeignIdFor(\App\Models\User::class, 'proxy_user_id');
+            $table->dropColumn('proxy_user_id');
+        });
+    }
+};

--- a/docs/features/Rules System.md
+++ b/docs/features/Rules System.md
@@ -1,0 +1,1020 @@
+# Rules System — Technical Documentation
+
+> **Audience:** Project owner, developers, AI agents
+> **Generated:** 2026-04-09
+> **Generator:** `/document-feature` skill
+
+---
+
+## Table of Contents
+
+1. [Overview](#1-overview)
+2. [Database Schema](#2-database-schema)
+3. [Models & Relationships](#3-models--relationships)
+4. [Enums Reference](#4-enums-reference)
+5. [Authorization & Permissions](#5-authorization--permissions)
+6. [Routes](#6-routes)
+7. [User Interface Components](#7-user-interface-components)
+8. [Actions (Business Logic)](#8-actions-business-logic)
+9. [Notifications](#9-notifications)
+10. [Background Jobs](#10-background-jobs)
+11. [Console Commands & Scheduled Tasks](#11-console-commands--scheduled-tasks)
+12. [Services](#12-services)
+13. [Activity Log Entries](#13-activity-log-entries)
+14. [Data Flow Diagrams](#14-data-flow-diagrams)
+15. [Configuration](#15-configuration)
+16. [Test Coverage](#16-test-coverage)
+17. [File Map](#17-file-map)
+18. [Known Issues & Improvement Opportunities](#18-known-issues--improvement-opportunities)
+
+---
+
+## 1. Overview
+
+The Rules System replaces the previous static rules page with a fully dynamic, versioned rules management system. Community rules are stored in the database and organized into categories. Each rule has a title, Markdown description, and can be updated by creating a replacement rule entry that tracks what it supersedes. Rules are bundled into published versions; users must explicitly agree to the current version.
+
+**Who uses it:**
+
+- **All Stowaway+ users** must agree to the current published rules version to access the dashboard. Agreement is tracked per-version so users must re-agree whenever a new version is published.
+- **Drifter users** (new/unverified) are presented with rules agreement as part of onboarding; agreeing promotes them to Stowaway.
+- **Parent users** can submit proxy agreements for linked child accounts that have not agreed.
+- **Staff with "Rules - Manage"** can create draft rule versions, add/edit/deactivate rules, manage categories, and edit header/footer content.
+- **Staff with "Rules - Approve"** (different person from the draft creator) can review and publish or reject submitted versions.
+- **Admins** have access to full agreement history and compliance monitoring.
+
+**Key concepts:**
+
+- **Rule Version**: A snapshot of the active ruleset at a point in time. A new draft is created, rules are modified, then submitted for approval by a second reviewer, and finally published.
+- **Agreement**: A `user_rule_agreements` record ties a user to a specific version at a specific timestamp. Agreements can optionally record a `proxy_user_id` (for parent proxy agreements).
+- **Rules Non-Compliance Brig**: Users who do not agree within 28 days of a version being published are automatically placed in a brig of type `RulesNonCompliance`. This brig auto-lifts when they agree.
+- **Rule Classification**: When re-agreeing, each rule in the current version is classified as `new`, `updated`, or `unchanged` relative to the user's last agreement.
+
+---
+
+## 2. Database Schema
+
+### `rule_categories` table
+
+| Column | Type | Nullable | Default | Notes |
+|--------|------|----------|---------|-------|
+| id | bigint unsigned | No | auto | Primary key |
+| name | varchar(255) | No | | Category display name |
+| sort_order | int | No | 0 | Display order (ascending) |
+| created_at | timestamp | Yes | null | |
+| updated_at | timestamp | Yes | null | |
+
+**Migration:** `database/migrations/2026_04_09_000001_create_rules_tables.php`, `2026_04_09_000005_add_sort_order_to_rules.php`
+
+---
+
+### `rules` table
+
+| Column | Type | Nullable | Default | Notes |
+|--------|------|----------|---------|-------|
+| id | bigint unsigned | No | auto | Primary key |
+| rule_category_id | bigint unsigned | No | | FK → rule_categories.id |
+| title | varchar(255) | No | | Short identifier (e.g. "No Griefing") |
+| description | text | No | | Markdown rule text |
+| status | varchar(255) | No | 'draft' | 'draft', 'active', 'inactive' |
+| supersedes_rule_id | bigint unsigned | Yes | null | FK → rules.id; points to replaced rule |
+| created_by_user_id | bigint unsigned | Yes | null | FK → users.id |
+| sort_order | int | No | 0 | Display order within category |
+| created_at | timestamp | Yes | null | |
+| updated_at | timestamp | Yes | null | |
+
+**Indexes:** `rule_category_id`, `supersedes_rule_id`, `created_by_user_id`
+**Migration:** `2026_04_09_000001_create_rules_tables.php`, `2026_04_09_000005_add_sort_order_to_rules.php`
+
+---
+
+### `rule_versions` table
+
+| Column | Type | Nullable | Default | Notes |
+|--------|------|----------|---------|-------|
+| id | bigint unsigned | No | auto | Primary key |
+| version_number | int | No | | Auto-incremented per version |
+| status | varchar(255) | No | 'draft' | 'draft', 'submitted', 'published' |
+| created_by_user_id | bigint unsigned | Yes | null | FK → users.id |
+| approved_by_user_id | bigint unsigned | Yes | null | FK → users.id; must differ from creator |
+| rejection_note | text | Yes | null | Feedback when version rejected |
+| published_at | timestamp | Yes | null | When version was published |
+| created_at | timestamp | Yes | null | |
+| updated_at | timestamp | Yes | null | |
+
+**Migration:** `2026_04_09_000001_create_rules_tables.php`
+
+---
+
+### `rule_version_rules` pivot table
+
+| Column | Type | Nullable | Default | Notes |
+|--------|------|----------|---------|-------|
+| rule_version_id | bigint unsigned | No | | FK → rule_versions.id, cascadeOnDelete |
+| rule_id | bigint unsigned | No | | FK → rules.id, cascadeOnDelete |
+| deactivate_on_publish | tinyint(1) | No | 0 | If 1, rule is deactivated when version is published |
+
+**Primary Key:** `(rule_version_id, rule_id)`
+**Migration:** `2026_04_09_000001_create_rules_tables.php`, `2026_04_09_000004_add_deactivate_on_publish_to_rule_version_rules.php`
+
+---
+
+### `user_rule_agreements` table
+
+| Column | Type | Nullable | Default | Notes |
+|--------|------|----------|---------|-------|
+| id | bigint unsigned | No | auto | Primary key |
+| user_id | bigint unsigned | No | | FK → users.id, cascadeOnDelete |
+| rule_version_id | bigint unsigned | No | | FK → rule_versions.id, cascadeOnDelete |
+| agreed_at | timestamp | No | | When agreement was recorded |
+| proxy_user_id | bigint unsigned | Yes | null | FK → users.id, nullOnDelete; parent user if proxy agreement |
+| created_at | timestamp | Yes | null | |
+| updated_at | timestamp | Yes | null | |
+
+**Unique Index:** `(user_id, rule_version_id)`
+**Migration:** `2026_04_09_000001_create_rules_tables.php`, `2026_04_09_000006_add_proxy_user_id_to_user_rule_agreements.php`
+
+---
+
+### `discipline_report_rules` pivot table
+
+| Column | Type | Nullable | Default | Notes |
+|--------|------|----------|---------|-------|
+| discipline_report_id | bigint unsigned | No | | FK → discipline_reports.id, cascadeOnDelete |
+| rule_id | bigint unsigned | No | | FK → rules.id, cascadeOnDelete |
+
+**Primary Key:** `(discipline_report_id, rule_id)`
+**Migration:** `2026_04_09_000001_create_rules_tables.php`
+
+---
+
+### `users` table additions
+
+| Column | Type | Nullable | Default | Notes |
+|--------|------|----------|---------|-------|
+| rules_accepted_at | timestamp | Yes | null | Legacy; last time user agreed to any rules |
+| rules_accepted_by_user_id | bigint unsigned | Yes | null | FK → users.id; who recorded the agreement |
+| rules_reminder_sent_at | timestamp | Yes | null | When the 2-week reminder email was last sent |
+
+**Migration:** `2025_08_05_040555_update_users_add_rules_acceptance_field.php`, `2026_03_31_000001_add_rules_accepted_by_user_id_to_users.php`, `2026_04_09_000001_create_rules_tables.php`
+
+---
+
+## 3. Models & Relationships
+
+### `Rule` (`app/Models/Rule.php`)
+
+**Relationships:**
+
+| Method | Type | Related Model | Notes |
+|--------|------|---------------|-------|
+| `ruleCategory()` | BelongsTo | RuleCategory | |
+| `supersedes()` | BelongsTo | Rule (self) | Points to the rule this entry replaces |
+| `ruleVersions()` | BelongsToMany | RuleVersion | Via `rule_version_rules`; pivot includes `deactivate_on_publish` |
+
+**Key Methods:**
+- `isDraft(): bool` — returns `status === 'draft'`
+- `isActive(): bool` — returns `status === 'active'`
+
+**Casts:** None
+
+---
+
+### `RuleVersion` (`app/Models/RuleVersion.php`)
+
+**Relationships:**
+
+| Method | Type | Related Model | Notes |
+|--------|------|---------------|-------|
+| `createdBy()` | BelongsTo | User | |
+| `approvedBy()` | BelongsTo | User | |
+| `rules()` | BelongsToMany | Rule | Via `rule_version_rules`; pivot includes `deactivate_on_publish` |
+| `activeRules()` | BelongsToMany | Rule | Same pivot; filtered to `deactivate_on_publish = false` |
+| `agreements()` | HasMany | UserRuleAgreement | |
+
+**Scopes/Static Methods:**
+- `currentPublished(): ?RuleVersion` — static method; returns the latest published version
+- `currentDraft(): ?RuleVersion` — static method; returns the latest draft or submitted version
+
+**Key Methods:**
+- `isDraft(): bool` — returns `status === 'draft'`
+- `isPublished(): bool` — returns `status === 'published'`
+
+**Casts:**
+- `published_at` → `datetime`
+
+---
+
+### `RuleCategory` (`app/Models/RuleCategory.php`)
+
+**Relationships:**
+
+| Method | Type | Related Model | Notes |
+|--------|------|---------------|-------|
+| `rules()` | HasMany | Rule | Ordered by `sort_order` |
+
+---
+
+### `UserRuleAgreement` (`app/Models/UserRuleAgreement.php`)
+
+**Relationships:**
+
+| Method | Type | Related Model | Notes |
+|--------|------|---------------|-------|
+| `user()` | BelongsTo | User | The user who the agreement is for |
+| `ruleVersion()` | BelongsTo | RuleVersion | |
+| `proxyUser()` | BelongsTo | User | The parent who submitted the agreement (if proxy) |
+
+**Key Methods:**
+- `isProxy(): bool` — returns `proxy_user_id !== null`
+
+**Casts:**
+- `agreed_at` → `datetime`
+
+---
+
+### `User` (`app/Models/User.php`) — rules-related additions
+
+**Relationships:**
+
+| Method | Type | Related Model | Notes |
+|--------|------|---------------|-------|
+| `ruleAgreements()` | HasMany | UserRuleAgreement | |
+| `rulesAcceptedBy()` | BelongsTo | User | Via `rules_accepted_by_user_id` |
+| `children()` | BelongsToMany | User | Via `parent_child_links` |
+| `parents()` | BelongsToMany | User | Via `parent_child_links` (reverse) |
+
+**Key Methods:**
+- `hasAgreedToCurrentRules(): bool` — checks for a `user_rule_agreements` record for the current published version; returns `true` if no published version exists
+- `unagreedChildren(): Collection` — returns linked children (via `parent_child_links`) who do not have an agreement for the current published version
+
+---
+
+### `DisciplineReport` (`app/Models/DisciplineReport.php`) — rules-related addition
+
+**Relationship:**
+
+| Method | Type | Related Model | Notes |
+|--------|------|---------------|-------|
+| `violatedRules()` | BelongsToMany | Rule | Via `discipline_report_rules` pivot |
+
+---
+
+## 4. Enums Reference
+
+### `BrigType` (`app/Enums/BrigType.php`) — rules-related case
+
+| Case | Value | Label | Notes |
+|------|-------|-------|-------|
+| `RulesNonCompliance` | `'rules_non_compliance'` | "Rules Non-Compliance" | Auto-placed at 28+ days; auto-lifted on agreement |
+
+Other BrigType cases exist but are unrelated to the rules system. See the Brig System documentation for the full enum.
+
+---
+
+## 5. Authorization & Permissions
+
+### Gates (from `AuthServiceProvider`)
+
+| Gate Name | Who Can Pass | Logic Summary |
+|-----------|-------------|---------------|
+| `rules.manage` | Staff with "Rules - Manage" role | `$user->hasRole('Rules - Manage')` |
+| `rules.approve` | Staff with "Rules - Approve" role | `$user->hasRole('Rules - Approve')` |
+
+**Roles seeded by migration `2026_04_09_000003_seed_rules_permission_roles.php`:**
+- `Rules - Manage` — create/edit rules, manage categories, edit header/footer
+- `Rules - Approve` — submit version for approval, approve/reject submitted versions
+
+### Policies
+
+No dedicated policy class for rules models. Authorization uses gates directly via `$this->authorize('rules.manage')` in components.
+
+The `EnsureRulesAgreed` middleware enforces agreement at the route level (not via policy).
+
+### Permissions Matrix
+
+| User Type | View Rules Page | Agree to Rules | Proxy Agree for Child | View Compliance List | View Agreement History | Manage Draft | Approve Version |
+|-----------|:-:|:-:|:-:|:-:|:-:|:-:|:-:|
+| Drifter | ✓ | ✓ | — | — | — | — | — |
+| Stowaway+ | ✓ | ✓ | ✓ (if parent) | — | — | — | — |
+| Staff (Rules - Manage) | ✓ | ✓ | ✓ | ✓ | — | ✓ | — |
+| Admin | ✓ | ✓ | ✓ | ✓ | ✓ | — | — |
+| Staff (Rules - Approve, different from draft creator) | ✓ | ✓ | ✓ | — | — | — | ✓ |
+
+---
+
+## 6. Routes
+
+| Method | URL | Middleware | Handler | Route Name |
+|--------|-----|-----------|---------|------------|
+| GET | `/rules` | `auth`, `verified`, `ensure-dob` | `rules-page` Volt component | `rules.show` |
+| GET | `/dashboard` | `auth`, `verified`, `ensure-dob`, `ensure-rules-agreed` | `dashboard` Volt component | `dashboard` |
+| GET | `/acp/rules` | `auth`, `verified`, staff-access gate | `admin-manage-rules-page` Volt component | ACP tab |
+
+The `ensure-rules-agreed` middleware is registered in `bootstrap/app.php` as `'ensure-rules-agreed' => \App\Http\Middleware\EnsureRulesAgreed::class`.
+
+---
+
+## 7. User Interface Components
+
+### Rules Agreement Page
+**File:** `resources/views/livewire/rules-page.blade.php`
+**Route:** `/rules` (route name: `rules.show`)
+
+**Purpose:** Allows users to read and agree to the current published rules version. Also handles parent proxy agreement for child accounts.
+
+**Authorization:** No explicit gate; accessible to any authenticated verified user with date-of-birth confirmed.
+
+**User Actions Available:**
+- **Agree to rules** (self): Check all rule checkboxes → click sticky "I Have Read and Agree to All Rules" button → calls `AgreeToRulesVersion::run(auth()->user(), auth()->user())` → redirects to dashboard
+- **Agree on behalf of children** (proxy): Select child accounts via checkboxes → click "Submit Proxy Agreement" → calls `AgreeToRulesVersion::run($child, $parent)` for each selected child → redirects to dashboard when all children are covered
+
+**UI Elements:**
+- Optional top notice banner (amber for self, blue for proxy requirement)
+- Optional header markdown (from `SiteConfig::getValue('rules_header')`)
+- Per-category sections with rule cards
+- Each rule card: title, `NEW`/`UPDATED` badges, Markdown description
+- `UPDATED` rules show a collapsible `<details>` section with the previous rule text
+- Checkboxes per rule (hidden once user has already agreed)
+- Sticky bottom bar: text hint + agree button (disabled until all rules checked)
+- "You have agreed" confirmation when already agreed
+- Proxy agreement section (visible only when user has agreed but has unagreed children): child list with checkboxes, submit button
+
+---
+
+### Admin Manage Rules Page
+**File:** `resources/views/livewire/admin-manage-rules-page.blade.php`
+**Route:** ACP tab (within `/acp`)
+
+**Purpose:** Full rules administration UI for managing categories, rules, draft versions, approval workflow, and header/footer content.
+
+**Authorization:** `$this->authorize('rules.manage')` for management actions; `$this->authorize('rules.approve')` for approve/reject.
+
+**User Actions Available:**
+- Edit header/footer text → calls `UpdateRulesHeaderFooter::run($header, $footer)`
+- Add category → calls `CreateCategory::run(...)` (inline RuleCategory::create)
+- Move category up/down → swaps `sort_order` values
+- Add rule to draft → calls `AddRuleToDraft::run(...)`
+- Edit rule in draft → calls `UpdateRuleInDraft::run(...)`
+- Deactivate rule in draft → calls `DeactivateRuleInDraft::run(...)`
+- Move rule up/down → swaps `sort_order` values
+- Create new draft version → calls `CreateRuleVersion::run(...)`
+- Submit draft for approval → calls `SubmitVersionForApproval::run(...)`
+- Approve version → calls `ApproveAndPublishVersion::run(...)`
+- Reject version → calls `RejectDraftVersion::run(...)`
+
+**Embedded sub-components:**
+- `<livewire:rules-version-history />` — version history table (visible to `rules.manage` users)
+- `<livewire:rules-compliance-list />` — non-compliance monitoring (visible to `rules.manage` users)
+- `<livewire:rules-agreement-history />` — full agreement audit trail (visible to admins only)
+
+**UI Elements:** Header/footer textareas; category list with reorder arrows and add button; rule list per category with status badges, edit/deactivate/reorder buttons; draft workflow section with submit/approve/reject buttons and rejection note; embedded sub-components.
+
+---
+
+### Rules Compliance List
+**File:** `resources/views/livewire/rules-compliance-list.blade.php`
+**Embedded in:** `admin-manage-rules-page`
+
+**Purpose:** Shows all Stowaway+ users who have not agreed to the current published version.
+
+**Authorization:** Visible only to users with `rules.manage` gate.
+
+**UI Elements:** Table with columns: User (name + email), Membership Level, Days Overdue (amber badge at 14+ days, red badge at 28+ days), Reminder Sent (date or "—").
+
+---
+
+### Rules Agreement History
+**File:** `resources/views/livewire/rules-agreement-history.blade.php`
+**Embedded in:** `admin-manage-rules-page`
+
+**Purpose:** Full searchable, paginated audit trail of all `user_rule_agreements` records.
+
+**Authorization:** Visible only to admins.
+
+**User Actions Available:**
+- Search by user name or email (live with debounce)
+
+**UI Elements:** Search input; table with columns: User (name + email), Version (badge), Agreed At (formatted datetime); pagination links.
+
+---
+
+### Rules Version History
+**File:** `resources/views/livewire/rules-version-history.blade.php`
+**Embedded in:** `admin-manage-rules-page`
+
+**Purpose:** Shows all published rule versions with approval metadata.
+
+**UI Elements:** Table with columns: Version number, Published date, Created By, Approved By.
+
+---
+
+### Dashboard View Rules Widget
+**File:** `resources/views/livewire/dashboard/view-rules.blade.php`
+
+**Purpose:** Dashboard widget for the community/onboarding section. Shows a "Read & Accept Rules" button for unagreed users, or "View Rules" for those who have already agreed.
+
+---
+
+## 8. Actions (Business Logic)
+
+### `AgreeToRulesVersion` (`app/Actions/AgreeToRulesVersion.php`)
+
+**Signature:** `handle(User $user, User $actingUser): void`
+
+**Step-by-step logic:**
+1. Fetches `RuleVersion::currentPublished()`. Returns early if none exists.
+2. Calls `UserRuleAgreement::updateOrCreate(['user_id', 'rule_version_id'], ['agreed_at' => now(), 'proxy_user_id' => null (self) or $actingUser->id (proxy)])`.
+3. Updates `$user->rules_accepted_at = now()` and `$user->rules_accepted_by_user_id = $actingUser->id`.
+4. If user is Drifter: logs activity `rules_accepted` with promotion message, calls `PromoteUser::run($user, MembershipLevel::Stowaway)`.
+5. Otherwise: logs activity `rules_accepted` with version number.
+6. If user is in a `RulesNonCompliance` brig: calls `ReleaseUserFromBrig::run($user, $user, '...', notify: false)`.
+
+**Called by:** `rules-page.blade.php` (both `agreeToRules()` and `agreeForChildren()`), `PutUserInRulesBrig` (not called), legacy code.
+
+---
+
+### `GetRulesAgreementStatus` (`app/Actions/GetRulesAgreementStatus.php`)
+
+**Signature:** `handle(User $user): array`
+
+**Returns:**
+```php
+[
+    'has_agreed' => bool,
+    'current_version' => ?RuleVersion,
+    'categories' => Collection,  // RuleCategory objects with ->rules collection
+]
+```
+Each rule object in the categories collection is annotated with:
+- `agreement_status`: `'new'` | `'updated'` | `'unchanged'`
+- `previous_rule`: the superseded Rule object (only for `'updated'`)
+
+**Classification logic:**
+1. Builds set of all rule IDs the user has ever agreed to (across all versions).
+2. Builds set of rule IDs in the user's most recently agreed version.
+3. For each rule in the current version:
+   - If rule ID was in any prior agreed version → `unchanged`
+   - If rule's `supersedes_rule_id` was in the previous version → `updated`
+   - Otherwise → `new`
+
+**Called by:** `rules-page.blade.php`
+
+---
+
+### `CreateRuleVersion` (`app/Actions/CreateRuleVersion.php`)
+
+**Signature:** `handle(User $createdBy): RuleVersion`
+
+**Step-by-step logic:**
+1. Computes next `version_number` (max existing + 1, minimum 1).
+2. Creates `RuleVersion` with status `draft`.
+3. Copies all currently active rules from the latest published version into `rule_version_rules` with `deactivate_on_publish = false`.
+
+**Called by:** `admin-manage-rules-page.blade.php`
+
+---
+
+### `AddRuleToDraft` (`app/Actions/AddRuleToDraft.php`)
+
+**Signature:** `handle(RuleVersion $draft, RuleCategory $category, string $title, string $description, User $createdBy): Rule`
+
+**Step-by-step logic:**
+1. Creates `Rule` with status `draft`, `created_by_user_id = $createdBy->id`.
+2. Attaches rule to draft version via `rule_version_rules` with `deactivate_on_publish = false`.
+
+**Called by:** `admin-manage-rules-page.blade.php`
+
+---
+
+### `UpdateRuleInDraft` (`app/Actions/UpdateRuleInDraft.php`)
+
+**Signature:** `handle(RuleVersion $draft, Rule $oldRule, string $newTitle, string $newDescription, User $createdBy, ?RuleCategory $newCategory): Rule`
+
+**Step-by-step logic:**
+1. Creates new `Rule` with `supersedes_rule_id = $oldRule->id`, status `draft`.
+2. Attaches new rule to draft version with `deactivate_on_publish = false`.
+3. Updates the pivot for old rule to set `deactivate_on_publish = true`.
+
+**Called by:** `admin-manage-rules-page.blade.php`
+
+---
+
+### `DeactivateRuleInDraft` (`app/Actions/DeactivateRuleInDraft.php`)
+
+**Signature:** `handle(RuleVersion $draft, Rule $rule): void`
+
+**Step-by-step logic:**
+1. Updates the `rule_version_rules` pivot for this rule in this version to set `deactivate_on_publish = true`.
+
+**Called by:** `admin-manage-rules-page.blade.php`
+
+---
+
+### `SubmitVersionForApproval` (`app/Actions/SubmitVersionForApproval.php`)
+
+**Signature:** `handle(RuleVersion $version, User $submittedBy): void`
+
+**Step-by-step logic:**
+1. Validates `$version->status === 'draft'`.
+2. Sets status to `submitted`.
+
+**Called by:** `admin-manage-rules-page.blade.php`
+
+---
+
+### `ApproveAndPublishVersion` (`app/Actions/ApproveAndPublishVersion.php`)
+
+**Signature:** `handle(RuleVersion $version, User $approvedBy): void`
+
+**Step-by-step logic:**
+1. Validates `$version->status === 'submitted'`.
+2. Validates `$approvedBy->id !== $version->created_by_user_id` (two-person rule).
+3. Sets `approved_by_user_id = $approvedBy->id`, `status = published`, `published_at = now()`.
+4. Activates all draft rules in the version (sets `status = active`).
+5. Deactivates rules marked with `deactivate_on_publish = true` (sets `status = inactive`).
+6. Sends `RulesVersionPublishedNotification` to all Stowaway+ users.
+
+**Called by:** `admin-manage-rules-page.blade.php`
+
+---
+
+### `RejectDraftVersion` (`app/Actions/RejectDraftVersion.php`)
+
+**Signature:** `handle(RuleVersion $version, User $rejectedBy, string $rejectionNote): void`
+
+**Step-by-step logic:**
+1. Validates `$version->status === 'submitted'`.
+2. Sets `status = draft`, stores `rejection_note`.
+
+**Called by:** `admin-manage-rules-page.blade.php`
+
+---
+
+### `PutUserInRulesBrig` (`app/Actions/PutUserInRulesBrig.php`)
+
+**Signature:** `handle(User $user): void`
+
+**Step-by-step logic:**
+1. Checks if user is already in any brig. If so, returns silently.
+2. Finds the system admin user (`system@lighthouse.local`) as the acting admin, or falls back to `$user` itself.
+3. Calls `PutUserInBrig::run($user, $admin, '...', brigType: BrigType::RulesNonCompliance)` with no expiry and no appeal delay.
+
+**Called by:** `CheckRulesAgreementJob`
+
+---
+
+### `SendRulesAgreementReminder` (`app/Actions/SendRulesAgreementReminder.php`)
+
+**Signature:** `handle(User $user, RuleVersion $version): void`
+
+**Step-by-step logic:**
+1. Sends `RulesAgreementReminderNotification` via `TicketNotificationService`.
+2. Sets `$user->rules_reminder_sent_at = now()`.
+
+**Called by:** `CheckRulesAgreementJob`
+
+---
+
+### `UpdateRulesHeaderFooter` (`app/Actions/UpdateRulesHeaderFooter.php`)
+
+**Signature:** `handle(string $header, string $footer): void`
+
+**Step-by-step logic:**
+1. Saves `SiteConfig::setValue('rules_header', $header)`.
+2. Saves `SiteConfig::setValue('rules_footer', $footer)`.
+
+**Called by:** `admin-manage-rules-page.blade.php`
+
+---
+
+### `AgreeToRules` (`app/Actions/AgreeToRules.php`) — Legacy
+
+**Signature:** `handle(User $user, User $actingUser): array`
+
+**Returns:** `['success' => bool, 'message' => string]`
+
+Legacy action from before the versioned rules system. Only handles Drifter-level users agreeing. Not used in the new flow. Retained for compatibility.
+
+---
+
+## 9. Notifications
+
+### `RulesAgreementReminderNotification` (`app/Notifications/RulesAgreementReminderNotification.php`)
+
+**Triggered by:** `SendRulesAgreementReminder` action (called from `CheckRulesAgreementJob`)
+**Recipient:** The Stowaway+ user who has not agreed after 14+ days
+**Channels:** Mail (primary); Pushover (optional)
+**Mail subject:** "Reminder: Please Agree to the Updated Community Rules"
+**Content summary:** Warns the user that they must agree to the current rules version; notes they have approximately 2 more weeks before brig placement. Includes a button linking to `route('rules.show')`.
+**Queued:** Yes (`ShouldQueue`)
+
+---
+
+### `RulesVersionPublishedNotification` (`app/Notifications/RulesVersionPublishedNotification.php`)
+
+**Triggered by:** `ApproveAndPublishVersion` action
+**Recipient:** All Stowaway+ users (bulk send when a new version is published)
+**Channels:** Mail (primary); Pushover (optional)
+**Mail subject:** "Community Rules Updated — Please Review and Agree"
+**Content summary:** Notifies the user that a new rules version has been published and that continued access requires re-agreement. Includes a button linking to the dashboard (which will redirect to `rules.show` via middleware).
+**Queued:** Yes (`ShouldQueue`)
+
+---
+
+## 10. Background Jobs
+
+### `CheckRulesAgreementJob` (`app/Jobs/CheckRulesAgreementJob.php`)
+
+**Triggered by:** Laravel scheduler (daily at 07:00)
+**Implements:** `ShouldQueue`
+
+**What it does:**
+1. Fetches the current published `RuleVersion`. Exits if none or no `published_at`.
+2. Queries all `user_rule_agreements` for the current version to get agreed user IDs.
+3. Finds all Stowaway+ users (`membership_level >= Stowaway`) who are NOT in that agreed set.
+4. Computes days since `published_at`.
+5. For each unagreed user:
+   - If `days >= 28` and user is not already in a `RulesNonCompliance` brig → calls `PutUserInRulesBrig::run($user)`
+   - Else if `days >= 14` and `rules_reminder_sent_at` is null → calls `SendRulesAgreementReminder::run($user, $version)`
+6. The 28-day brig check takes priority over the 14-day reminder check.
+
+**Queue/Delay:** Runs daily; `withoutOverlapping(10)` (10-minute timeout lock); `onOneServer()` to prevent duplicate runs in multi-server deployments.
+
+---
+
+## 11. Console Commands & Scheduled Tasks
+
+### Scheduled: `CheckRulesAgreementJob`
+
+**File:** `app/Jobs/CheckRulesAgreementJob.php`
+**Scheduled in:** `routes/console.php`
+**Schedule expression:** `dailyAt('07:00')->withoutOverlapping(10)->onOneServer()`
+**What it does:** Sends reminders at 14+ days and places non-compliant users in rules brig at 28+ days after a version is published.
+
+No standalone Artisan commands for this feature.
+
+---
+
+## 12. Services
+
+### `TicketNotificationService` (`app/Services/TicketNotificationService.php`)
+
+Used by `SendRulesAgreementReminder` and `ApproveAndPublishVersion` to send notifications. See the Notification System documentation for full details.
+
+No rules-specific service class exists.
+
+---
+
+## 13. Activity Log Entries
+
+| Action String | Logged By | Subject Model | Description |
+|---------------|-----------|---------------|-------------|
+| `rules_accepted` | `AgreeToRulesVersion` | User (the agreeing user) | "User agreed to rules version {N}." or "User accepted community rules and was promoted to Stowaway." or "Community rules agreed on behalf of user by {parent name} (parent). User promoted to Stowaway." |
+
+---
+
+## 14. Data Flow Diagrams
+
+### User Agreeing to Rules (Self)
+
+```
+User visits /dashboard
+  -> GET /dashboard (middleware: auth, verified, ensure-dob, ensure-rules-agreed)
+    -> EnsureRulesAgreed::handle()
+      -> $user->hasAgreedToCurrentRules() = false
+        -> redirect to /rules
+
+User is on /rules page
+  -> rules-page Volt component loads
+    -> GetRulesAgreementStatus::run(auth()->user())
+      -> Queries user_rule_agreements for current version
+      -> Classifies each rule as new/updated/unchanged
+      -> Returns {has_agreed: false, categories: [...]
+
+User checks all rule checkboxes -> sticky "Agree" button enables
+User clicks "I Have Read and Agree to All Rules"
+  -> wire:click="agreeToRules"
+    -> allChecked() validates all rules are checked
+    -> AgreeToRulesVersion::run($user, $user)
+      -> UserRuleAgreement::updateOrCreate(proxy_user_id: null)
+      -> $user->rules_accepted_at = now()
+      -> If Drifter: PromoteUser::run($user, Stowaway)
+      -> RecordActivity::run($user, 'rules_accepted', ...)
+      -> If in RulesNonCompliance brig: ReleaseUserFromBrig::run(...)
+    -> Flux::toast('Rules accepted successfully!')
+    -> redirect to /dashboard
+```
+
+---
+
+### Parent Proxy Agreement
+
+```
+Parent visits /dashboard
+  -> EnsureRulesAgreed::handle()
+    -> $parent->hasAgreedToCurrentRules() = true (parent has agreed)
+    -> $parent->unagreedChildren()->isNotEmpty() = true
+      -> redirect to /rules
+
+Parent is on /rules page
+  -> GetRulesAgreementStatus::run($parent) = {has_agreed: true}
+  -> $this->unagreedChildren = [$child1, $child2]
+  -> Page shows proxy agreement section with child checkboxes
+
+Parent checks child accounts, clicks "Submit Proxy Agreement"
+  -> wire:click="agreeForChildren"
+    -> For each selected child:
+      -> AgreeToRulesVersion::run($child, $parent)
+        -> UserRuleAgreement::updateOrCreate(proxy_user_id: $parent->id)
+        -> $child->rules_accepted_by_user_id = $parent->id
+        -> If Drifter child: PromoteUser::run($child, Stowaway)
+        -> RecordActivity::run($child, 'rules_accepted', 'agreed on behalf by {parent}')
+        -> If child in brig: ReleaseUserFromBrig::run(...)
+    -> Flux::toast("Rules accepted for N child account(s).")
+    -> If all children now agreed: redirect to /dashboard
+```
+
+---
+
+### New Version Publication Workflow
+
+```
+Staff (Rules - Manage) opens rules admin page
+  -> Creates draft version: CreateRuleVersion::run($staff)
+    -> RuleVersion created (status: draft, version_number: N+1)
+    -> Active rules from current published version seeded into rule_version_rules
+
+Staff adds new rule:
+  -> AddRuleToDraft::run($draft, $category, $title, $description, $staff)
+    -> Rule created (status: draft)
+    -> Linked to draft via rule_version_rules (deactivate_on_publish: false)
+
+Staff edits existing rule:
+  -> UpdateRuleInDraft::run($draft, $oldRule, ...)
+    -> New Rule created (status: draft, supersedes_rule_id: $oldRule->id)
+    -> New rule linked to draft (deactivate_on_publish: false)
+    -> Old rule pivot updated (deactivate_on_publish: true)
+
+Staff submits for approval:
+  -> SubmitVersionForApproval::run($draft, $staff)
+    -> version.status = 'submitted'
+
+Different staff (Rules - Approve) reviews and approves:
+  -> ApproveAndPublishVersion::run($version, $approver)
+    -> Validates: status === 'submitted' AND approver ≠ creator
+    -> version.status = 'published', published_at = now()
+    -> All draft rules in version: status → 'active'
+    -> All deactivate_on_publish rules: status → 'inactive'
+    -> RulesVersionPublishedNotification sent to all Stowaway+ users
+
+Daily at 07:00, CheckRulesAgreementJob runs:
+  -> Finds Stowaway+ users who have not agreed
+  -> At 14+ days: SendRulesAgreementReminder::run($user, $version)
+    -> RulesAgreementReminderNotification sent to user
+    -> $user->rules_reminder_sent_at = now()
+  -> At 28+ days: PutUserInRulesBrig::run($user)
+    -> PutUserInBrig::run($user, $admin, BrigType::RulesNonCompliance)
+
+User who was bricked finally agrees:
+  -> AgreeToRulesVersion::run($user, $user)
+    -> UserRuleAgreement created
+    -> ReleaseUserFromBrig::run($user, $user, ..., notify: false)
+    -> Brig auto-lifted
+```
+
+---
+
+### Discipline Report with Violated Rules
+
+```
+Staff opens user profile -> clicks "New Report"
+  -> create-report-modal opens
+    -> getActiveRulesProperty() loads all active rules grouped by category
+    -> Staff selects rules via checkbox list (formRuleIds)
+
+Staff submits report:
+  -> wire:click="createReport" in discipline-reports-card
+    -> CreateDisciplineReport::run(..., ruleIds: [1, 3, 7])
+      -> DisciplineReport::create(...)
+      -> $report->violatedRules()->sync($ruleIds)
+      -> RecordActivity::run(...)
+    -> Modals close, toast shown
+
+On view-report page:
+  -> $report->load([..., 'violatedRules'])
+  -> Rules displayed as red badges in report details card
+```
+
+---
+
+## 15. Configuration
+
+| Key | Storage | Purpose |
+|-----|---------|---------|
+| `rules_header` | `SiteConfig` key/value table | Markdown text displayed above the rules list (e.g. scripture quote) |
+| `rules_footer` | `SiteConfig` key/value table | Markdown text displayed below the rules list (e.g. officer discretion disclaimer) |
+
+Both values are editable from the rules admin page by users with the `rules.manage` gate. They are seeded by `database/migrations/2026_04_09_000002_seed_rules_data.php` with the community's existing scripture quote and disclaimer text.
+
+No environment variables are specific to this feature.
+
+---
+
+## 16. Test Coverage
+
+### Test Files
+
+| File | Tests | What It Covers |
+|------|-------|----------------|
+| `tests/Feature/Rules/RulesSchemaTest.php` | ~15 | Database schema, seeded data, BrigType enum, SiteConfig keys |
+| `tests/Feature/Rules/DashboardGateTest.php` | 3 | Middleware: redirect for non-agreed, pass-through for agreed, rules page accessible without agreement |
+| `tests/Feature/Rules/ComplianceAndHistoryTest.php` | 3 | Compliance query accuracy, Drifter exclusion, agreement history records |
+| `tests/Feature/Rules/ParentProxyAgreementTest.php` | 8 | Proxy user tracking, Drifter promotion via proxy, brig lift via proxy, unagreedChildren(), dashboard gate for parents, cross-account isolation |
+| `tests/Feature/Actions/Rules/CreateRuleVersionTest.php` | ~3 | Draft creation, version_number increment, active rule seeding |
+| `tests/Feature/Actions/Rules/AddRuleToDraftTest.php` | ~3 | Rule creation, pivot linking, status tracking |
+| `tests/Feature/Actions/Rules/UpdateRuleInDraftTest.php` | ~4 | Replacement rule creation, supersedes_rule_id, deactivate_on_publish flag |
+| `tests/Feature/Actions/Rules/DeactivateRuleInDraftTest.php` | ~2 | Pivot deactivate_on_publish flag set without immediate deactivation |
+| `tests/Feature/Actions/Rules/AgreeToRulesVersionTest.php` | 6 | Agreement record creation, idempotency, Drifter promotion, brig lift |
+| `tests/Feature/Actions/Rules/GetRulesAgreementStatusTest.php` | 6 | new/updated/unchanged classification logic |
+| `tests/Feature/Actions/Rules/VersionApprovalTest.php` | ~8 | Submit/approve/reject workflow, creator ≠ approver validation, rule activation/deactivation, notification sending |
+| `tests/Feature/Actions/Rules/UpdateRulesHeaderFooterTest.php` | ~2 | SiteConfig storage |
+| `tests/Feature/Actions/Rules/ReorderRulesTest.php` | ~4 | Category and rule sort_order swapping |
+| `tests/Feature/Jobs/CheckRulesAgreementJobTest.php` | 7 | 14-day reminder (once), 28-day brig (no double-brig), Drifter exclusion, already-agreed exclusion |
+| `tests/Feature/Actions/DisciplineReports/DisciplineReportRuleLinkingTest.php` | 5 | Create with rules, create without rules, update replaces rules, update clears rules, relationship titles |
+| `tests/Feature/Gates/RulesGatesTest.php` | ~4 | rules.manage and rules.approve gate authorization |
+
+### Test Case Inventory
+
+**`ParentProxyAgreementTest.php`:**
+- it records proxy_user_id when parent agrees on behalf of child
+- it does not set proxy_user_id when user agrees for themselves
+- it promotes Drifter child to Stowaway when parent agrees on their behalf
+- it lifts rules_non_compliance brig when parent agrees on behalf of child
+- it unagreedChildren returns only children who have not agreed
+- it dashboard gate redirects parent with unagreed children to rules page
+- it dashboard gate allows parent through when all children have agreed
+- it proxy agreement does not cross-contaminate: agreeing for one child does not agree for another
+
+**`CheckRulesAgreementJobTest.php`:**
+- it sends a reminder to users overdue 14+ days who have not had a reminder
+- it does not send a reminder if already sent
+- it does not send a reminder if overdue less than 14 days
+- it places a user in rules brig when overdue 28+ days
+- it does not double-brig a user already in rules_non_compliance brig
+- it does not act on users who have already agreed
+- it does not act on Drifter-level users
+
+**`ComplianceAndHistoryTest.php`:**
+- it compliance query returns users who have not agreed to the current version
+- it compliance query excludes Drifter users
+- it agreement history returns all user_rule_agreements records
+
+**`DashboardGateTest.php`:**
+- it redirects unagreed users to rules page
+- it allows agreed users through to dashboard
+- it rules page is accessible without agreement
+
+**`DisciplineReportRuleLinkingTest.php`:**
+- it creates a discipline report with violated rules
+- it creates a discipline report with no violated rules when none provided
+- it updates a discipline report with new violated rules
+- it clears violated rules when empty array passed on update
+- it violatedRules relationship returns rules with titles
+
+**`AgreeToRulesVersionTest.php`:**
+- it records a user_rule_agreements entry for the current version
+- it is idempotent (safe to call twice)
+- it promotes a Drifter user to Stowaway
+- it auto-lifts rules_non_compliance brig on agreement
+- it sets rules_accepted_at and rules_accepted_by_user_id
+- it does nothing when no published version exists
+
+**`GetRulesAgreementStatusTest.php`:**
+- it returns has_agreed false for unagreed user
+- it returns has_agreed true for agreed user
+- it classifies rules as new when user has never agreed
+- it classifies rules as unchanged when user previously agreed to same rule
+- it classifies rules as updated when rule supersedes one user agreed to
+- it returns previous_rule for updated rules
+
+### Coverage Gaps
+
+- No Livewire component tests for `rules-page.blade.php` (the proxy agreement flow in particular)
+- No Livewire component tests for `admin-manage-rules-page.blade.php` (complex multi-step admin workflow)
+- No test for `RulesVersionPublishedNotification` content/delivery
+- No end-to-end test for the full version lifecycle (create draft → add rules → submit → approve → publish → users notified)
+- No test verifying the rules compliance list UI correctly computes days-overdue
+- Brig placement in `CheckRulesAgreementJob` only verifies `isInBrig()` — no test verifies the specific `brig_type` on the newly created brig entry
+
+---
+
+## 17. File Map
+
+**Models:**
+- `app/Models/Rule.php`
+- `app/Models/RuleVersion.php`
+- `app/Models/RuleCategory.php`
+- `app/Models/UserRuleAgreement.php`
+- `app/Models/User.php` (additions: ruleAgreements, hasAgreedToCurrentRules, unagreedChildren)
+- `app/Models/DisciplineReport.php` (addition: violatedRules)
+
+**Enums:**
+- `app/Enums/BrigType.php` (RulesNonCompliance case)
+
+**Actions:**
+- `app/Actions/AgreeToRulesVersion.php`
+- `app/Actions/AgreeToRules.php` (legacy)
+- `app/Actions/GetRulesAgreementStatus.php`
+- `app/Actions/CreateRuleVersion.php`
+- `app/Actions/AddRuleToDraft.php`
+- `app/Actions/UpdateRuleInDraft.php`
+- `app/Actions/DeactivateRuleInDraft.php`
+- `app/Actions/SubmitVersionForApproval.php`
+- `app/Actions/ApproveAndPublishVersion.php`
+- `app/Actions/RejectDraftVersion.php`
+- `app/Actions/PutUserInRulesBrig.php`
+- `app/Actions/SendRulesAgreementReminder.php`
+- `app/Actions/UpdateRulesHeaderFooter.php`
+
+**Policies:** None specific to this feature.
+
+**Gates:** `app/Providers/AuthServiceProvider.php` — gates: `rules.manage`, `rules.approve`
+
+**Middleware:**
+- `app/Http/Middleware/EnsureRulesAgreed.php`
+- `bootstrap/app.php` (alias registration: `ensure-rules-agreed`)
+
+**Notifications:**
+- `app/Notifications/RulesAgreementReminderNotification.php`
+- `app/Notifications/RulesVersionPublishedNotification.php`
+
+**Jobs:**
+- `app/Jobs/CheckRulesAgreementJob.php`
+
+**Services:** Uses `app/Services/TicketNotificationService.php` (shared service)
+
+**Volt Components:**
+- `resources/views/livewire/rules-page.blade.php`
+- `resources/views/livewire/admin-manage-rules-page.blade.php`
+- `resources/views/livewire/rules-compliance-list.blade.php`
+- `resources/views/livewire/rules-agreement-history.blade.php`
+- `resources/views/livewire/rules-version-history.blade.php`
+- `resources/views/livewire/dashboard/view-rules.blade.php`
+- `resources/views/livewire/users/discipline-reports-card.blade.php` (Rules Violated in create/edit/view modals)
+- `resources/views/livewire/reports/view-report.blade.php` (Rules Violated display)
+
+**Routes:**
+- `/rules` → `rules.show` (in `routes/web.php`)
+- `/dashboard` → uses `ensure-rules-agreed` middleware
+
+**Migrations:**
+- `database/migrations/2025_08_05_040555_update_users_add_rules_acceptance_field.php`
+- `database/migrations/2026_03_31_000001_add_rules_accepted_by_user_id_to_users.php`
+- `database/migrations/2026_04_09_000001_create_rules_tables.php`
+- `database/migrations/2026_04_09_000002_seed_rules_data.php`
+- `database/migrations/2026_04_09_000003_seed_rules_permission_roles.php`
+- `database/migrations/2026_04_09_000004_add_deactivate_on_publish_to_rule_version_rules.php`
+- `database/migrations/2026_04_09_000005_add_sort_order_to_rules.php`
+- `database/migrations/2026_04_09_000006_add_proxy_user_id_to_user_rule_agreements.php`
+
+**Console Commands:** None (uses job scheduling directly in `routes/console.php`)
+
+**Tests:**
+- `tests/Feature/Rules/RulesSchemaTest.php`
+- `tests/Feature/Rules/DashboardGateTest.php`
+- `tests/Feature/Rules/ComplianceAndHistoryTest.php`
+- `tests/Feature/Rules/ParentProxyAgreementTest.php`
+- `tests/Feature/Actions/Rules/CreateRuleVersionTest.php`
+- `tests/Feature/Actions/Rules/AddRuleToDraftTest.php`
+- `tests/Feature/Actions/Rules/UpdateRuleInDraftTest.php`
+- `tests/Feature/Actions/Rules/DeactivateRuleInDraftTest.php`
+- `tests/Feature/Actions/Rules/AgreeToRulesVersionTest.php`
+- `tests/Feature/Actions/Rules/GetRulesAgreementStatusTest.php`
+- `tests/Feature/Actions/Rules/VersionApprovalTest.php`
+- `tests/Feature/Actions/Rules/UpdateRulesHeaderFooterTest.php`
+- `tests/Feature/Actions/Rules/ReorderRulesTest.php`
+- `tests/Feature/Jobs/CheckRulesAgreementJobTest.php`
+- `tests/Feature/Actions/DisciplineReports/DisciplineReportRuleLinkingTest.php`
+- `tests/Feature/Gates/RulesGatesTest.php`
+
+**Config:** `SiteConfig` keys: `rules_header`, `rules_footer`
+
+---
+
+## 18. Known Issues & Improvement Opportunities
+
+1. **`EnsureRulesAgreed` N+1 query risk**: `$user->unagreedChildren()` calls `RuleVersion::currentPublished()` and does a `whereNotIn` subquery on every request that passes the middleware. For a parent with many children this is manageable, but caching the published version ID would reduce repeated queries.
+
+2. **`PutUserInRulesBrig` admin user fallback**: When placing a user in the rules brig, the action looks up `User::where('email', 'system@lighthouse.local')->first()` as the acting admin. If that account is deleted, it falls back to `$user` itself (the person being brigned). This is a fragile dependency; a dedicated system account lookup should be centralized.
+
+3. **No validation that `ruleIds` belong to active rules**: In `CreateDisciplineReport` and `UpdateDisciplineReport`, the `array $ruleIds` parameter is synced directly without validating that the IDs correspond to active rules. A deactivated or draft rule could theoretically be linked to a report.
+
+4. **Legacy `AgreeToRules` action**: The old `AgreeToRules` action still exists and only handles Drifter users. It is no longer called by the new rules page flow. It may be called from legacy parent-portal code. It should be audited and either removed or updated to delegate to `AgreeToRulesVersion`.
+
+5. **`CheckRulesAgreementJob` threshold vs. published_at**: The job computes "days since published" globally, not per-user. If a user was a Stowaway before the version was published and just joined, they all get the same 14-day/28-day window. This is intentional by design but may cause issues if users join the day before the brig threshold.
+
+6. **Missing coverage for admin UI**: The `admin-manage-rules-page` component is complex (23+ properties, 15+ methods, 4 modals) but has no Livewire component test. A regression in the approval workflow would go undetected by automated tests.
+
+7. **`rules_reminder_sent_at` not reset on new version**: When a new version is published, `rules_reminder_sent_at` is NOT cleared. This means if a user received a reminder for v1 but didn't agree, then v2 is published immediately after, the user won't receive a reminder for v2 until the 14-day threshold is met again — but the `rules_reminder_sent_at` check will prevent it if the old timestamp is recent. A `rules_reminder_sent_at` reset should be triggered when `ApproveAndPublishVersion` runs.
+
+8. **Proxy agreement UI only shows if parent has already agreed**: The proxy agreement section on the rules page requires `$status['has_agreed'] === true`. A Drifter parent who hasn't agreed themselves cannot see the proxy section. By design, but worth noting for support scenarios.

--- a/resources/library/books/staff-handbook/03-support-and-moderation/02-discipline-reports/01-creating-reports.md
+++ b/resources/library/books/staff-handbook/03-support-and-moderation/02-discipline-reports/01-creating-reports.md
@@ -24,6 +24,7 @@ All staff members (Junior Crew and above) can create and view discipline reports
    - **Actions Taken** -- what you did in response (minimum 5 characters). Supports Markdown.
    - **Severity** -- how serious the incident was (see below)
    - **Category** -- optional tag like Language, Harassment, Griefing, etc.
+   - **Rules Violated** -- optional. Select any Community Rules that were broken. Members can see these on the published report.
 5. Click **Save**
 
 The report is saved as a **Draft**. It won't be visible to the member until an Officer publishes it.

--- a/resources/library/books/staff-handbook/07-administration/05-rules-management/01-managing-rules-and-categories.md
+++ b/resources/library/books/staff-handbook/07-administration/05-rules-management/01-managing-rules-and-categories.md
@@ -1,0 +1,72 @@
+---
+title: "Managing Rules and Categories"
+visibility: officer
+order: 1
+summary: "How to add, edit, and organize rules and categories in a draft version."
+---
+
+## Overview
+
+The **Rules Admin page** is where you manage the Community Rules -- creating draft versions, editing rule content, organizing categories, and updating the header and footer text. All changes go into a draft first and only go live when published.
+
+To get there, open the Admin Control Panel and navigate to the **Rules** tab.
+
+## Who Can Do This
+
+Staff with the **Rules -- Manage** permission. This is separate from the **Rules -- Approve** permission (which is required to publish a version).
+
+## Working with Draft Versions
+
+The rules system uses **versions** -- a snapshot of the entire ruleset at a point in time. You can't edit rules directly in the published version. Instead:
+
+1. **Create a new draft** -- Click **Create New Draft** at the top of the page. The draft is seeded automatically with all currently active rules.
+2. Make your changes to the draft (add, edit, deactivate rules and categories).
+3. When ready, **submit** the draft for approval. A different staff member with the Rules -- Approve permission must then review and publish it.
+
+There can only be one active draft at a time. If a draft already exists, the Create button won't appear.
+
+## Adding a New Rule
+
+1. Find the **category** you want to add the rule to
+2. Click **Add Rule** within that category
+3. Enter a **title** (a short identifier like "No Spamming") and a **description** (Markdown is supported)
+4. Click **Add**
+
+The new rule appears in the draft with a **Draft** badge. It won't be active until the version is published.
+
+## Editing an Existing Rule
+
+Editing a rule in the draft creates a **replacement entry**. The original rule stays active until the version is published.
+
+1. Find the rule you want to edit in the draft
+2. Click **Edit**
+3. Update the title and/or description
+4. Click **Save**
+
+When the new version is published, the old rule is deactivated and the new one becomes active. Members will see the rule flagged as **UPDATED** when they re-agree, and they'll be able to view the previous version side-by-side.
+
+## Deactivating a Rule
+
+If a rule is being removed entirely:
+
+1. Find the rule in the draft
+2. Click **Deactivate**
+
+The rule is marked for deactivation and will be removed from the active set when the version publishes. The rule is never deleted from the database -- it stays in the record so old reports that reference it remain accurate.
+
+## Managing Categories
+
+At the top of each category, you can:
+- **Rename** the category
+- **Reorder** it using the up/down arrows
+- Reorder individual rules within the category the same way
+
+To add a new category, use the **Add Category** button at the bottom of the category list.
+
+## Editing Header and Footer Text
+
+The rules page has a **header** (shown above the rules) and **footer** (shown below). These support Markdown formatting.
+
+Scroll to the top of the Rules Admin page to find the **Header** and **Footer** text fields. Edit the content and click **Save Header & Footer**.
+
+These changes take effect immediately -- they don't need a new version to go live.

--- a/resources/library/books/staff-handbook/07-administration/05-rules-management/02-publishing-a-new-version.md
+++ b/resources/library/books/staff-handbook/07-administration/05-rules-management/02-publishing-a-new-version.md
@@ -1,0 +1,67 @@
+---
+title: "Publishing a New Rules Version"
+visibility: officer
+order: 2
+summary: "How to submit a draft for review and publish it as the new active version."
+---
+
+## Overview
+
+Publishing a new rules version is a two-person process. The person who created the draft **cannot** be the one who approves it -- a second reviewer is required. This is a deliberate safeguard to ensure rule changes are reviewed by more than one person before going live.
+
+## Who Can Do This
+
+- **Submit for approval:** Staff with the **Rules -- Manage** permission (the draft creator)
+- **Approve and publish:** Staff with the **Rules -- Approve** permission -- must be a different person from the draft creator
+- **Reject:** Staff with the **Rules -- Approve** permission
+
+## Submitting a Draft for Approval
+
+When your draft is ready:
+
+1. Open the **Rules Admin page** in the Admin Control Panel
+2. Review your draft one more time -- once submitted, you can't edit it
+3. Click **Submit for Approval**
+
+The draft status changes to **Submitted** and it's locked from further editing. The Approve/Reject buttons become available to anyone with the Rules -- Approve permission.
+
+## Approving and Publishing
+
+If you're the reviewer (and you did **not** create this draft):
+
+1. Open the **Rules Admin page**
+2. Review all changes -- new rules, edited rules, deactivated rules
+3. If everything looks good, click **Approve & Publish**
+4. Confirm the action
+
+When you publish:
+- All new rules in the draft become **active**
+- Rules marked for deactivation become **inactive**
+- All Stowaway+ members receive an **email notification** that the rules have been updated and they need to re-agree
+- The daily compliance check starts tracking the new version
+
+## Rejecting a Draft
+
+If changes are needed before publishing:
+
+1. Click **Reject**
+2. Enter a **rejection note** explaining what needs to change
+
+The draft returns to **Draft** status and the person who created it can make edits and resubmit. Your rejection note is visible to them on the Rules Admin page.
+
+## What Members Experience After Publishing
+
+When the new version is published:
+- Members who visit their **Dashboard** are redirected to the rules page until they agree
+- Rules that are new (didn't exist before) show a **NEW** badge
+- Rules that changed show an **UPDATED** badge with a link to see the previous wording
+- Members must check every rule individually before they can submit their agreement
+
+## Compliance Timeline
+
+The system automatically handles non-compliance:
+
+- **14 days** after publishing -- members who haven't agreed receive a reminder email
+- **28 days** after publishing -- members who still haven't agreed are placed in a **Rules Non-Compliance** restriction automatically. This lifts the instant they agree.
+
+You can monitor compliance from the **Compliance** section of the Rules Admin page.

--- a/resources/library/books/staff-handbook/07-administration/05-rules-management/03-monitoring-compliance.md
+++ b/resources/library/books/staff-handbook/07-administration/05-rules-management/03-monitoring-compliance.md
@@ -1,0 +1,43 @@
+---
+title: "Monitoring Compliance"
+visibility: officer
+order: 3
+summary: "How to check which members haven't agreed and view the full agreement history."
+---
+
+## Overview
+
+After a new rules version is published, the **Rules Admin page** shows two compliance tools: a list of members who haven't yet agreed, and a full history of all past agreements. Both are visible to staff with the Rules -- Manage permission or Admins.
+
+## Who Can See What
+
+| Tool | Who Can Access |
+|---|---|
+| **Compliance List** (who hasn't agreed) | Staff with Rules -- Manage |
+| **Agreement History** (full audit log) | Admins only |
+
+## Compliance List
+
+Scroll to the **Compliance** section of the Rules Admin page. You'll see a table of Stowaway+ members who have not yet agreed to the current version.
+
+Each row shows:
+- **Member name and email**
+- **Membership level**
+- **Days overdue** -- amber badge at 14+ days, red badge at 28+ days
+- **Reminder sent** -- when (or if) the automated reminder email was sent
+
+The system handles reminders and restrictions automatically -- you don't need to manually send reminders or place members in the Brig. But this list is useful for knowing where things stand, especially in the days after a new version is published.
+
+## Agreement History
+
+Scroll to the **Agreement History** section. This is a searchable, paginated log of every agreement ever recorded -- including which version was agreed to, when, and by whom.
+
+You can search by name or email to look up a specific member's agreement history. This is the authoritative audit record if there's ever a question about when someone agreed.
+
+## Restrictions Lift Automatically
+
+Members placed in the Rules Non-Compliance restriction don't need manual intervention from staff. The moment they agree to the current version, the restriction is lifted automatically. If a member asks why they're restricted, direct them to the [Community Rules page]({{url:/rules}}).
+
+## Parent Proxy Agreements
+
+If a parent agreed on behalf of their child, the agreement history will show the child's name and agreement date. The record notes that it was a proxy agreement submitted by their parent. This is normal and counts as valid agreement for all purposes.

--- a/resources/library/books/staff-handbook/07-administration/05-rules-management/_index.md
+++ b/resources/library/books/staff-handbook/07-administration/05-rules-management/_index.md
@@ -1,0 +1,8 @@
+---
+title: "Rules Management"
+visibility: officer
+order: 5
+summary: "How to manage the versioned Community Rules, publish updates, and monitor member compliance."
+---
+
+Procedures for managing the Community Rules -- creating and publishing new versions, editing rule content, and monitoring agreement compliance.

--- a/resources/library/books/user-handbook/06-community-policies/02-community-rules/01-understanding-the-rules.md
+++ b/resources/library/books/user-handbook/06-community-policies/02-community-rules/01-understanding-the-rules.md
@@ -1,0 +1,26 @@
+---
+title: "Understanding the Community Rules"
+visibility: public
+order: 1
+summary: "What the Lighthouse Community Rules are and how they're organized."
+---
+
+## What Are the Community Rules?
+
+The **Community Rules** are the expectations that every Lighthouse member agrees to follow. They cover things like how to treat others, what's appropriate to share, and how to conduct yourself both on the Minecraft server and in other community spaces.
+
+The rules are organized into **categories** -- groups of related rules that make them easier to read and understand. Each rule has a short title and a clear description of what it means.
+
+## Where to Find Them
+
+You can read the current rules anytime by visiting the [Community Rules page]({{url:/rules}}) while logged in. You don't need to agree again to read them -- the page is always available.
+
+## Versioned Rules
+
+Lighthouse maintains **versioned rules**. When the rules are updated, a new version is published. Each version is a complete snapshot of the rules as they stood at that point in time.
+
+When a new version is published, every member needs to review and agree to it. This ensures everyone is always working from the same set of current expectations -- not something that may have quietly changed without notice.
+
+## Agreeing Is Required
+
+Agreeing to the current rules is required to access the community. New members agree as part of joining, and existing members are asked to re-agree whenever a new version is published. For details on how the agreement process works, see [[books/user-handbook/community-policies/community-rules/agreeing-to-the-rules|Agreeing to the Rules]].

--- a/resources/library/books/user-handbook/06-community-policies/02-community-rules/02-agreeing-to-the-rules.md
+++ b/resources/library/books/user-handbook/06-community-policies/02-community-rules/02-agreeing-to-the-rules.md
@@ -1,0 +1,41 @@
+---
+title: "Agreeing to the Rules"
+visibility: users
+order: 2
+summary: "How to read and agree to the Community Rules as a new or returning member."
+---
+
+## Before You Begin
+
+Agreeing to the rules is required before you can access the community. If you're a brand-new member, you'll be redirected to the rules page automatically when you try to visit the Dashboard. Returning members will be redirected whenever a new version is published and your agreement is needed.
+
+## How to Agree
+
+1. Go to the [Community Rules page]({{url:/rules}}). If you haven't agreed yet, you'll see a notice at the top letting you know your agreement is needed.
+2. Read through each section. The rules are organized into categories to make them easier to follow.
+3. **Check the box** next to each rule as you read it. Every rule needs its own checkbox before you can submit -- this ensures you've read everything, not just scrolled past it.
+4. Once all the boxes are checked, the **"I Have Read and Agree to All Rules"** button at the bottom of the page becomes active.
+5. Click the button. You're all set.
+
+After agreeing, you'll be taken to your Dashboard right away.
+
+## What the Badges Mean
+
+When you're re-agreeing to an updated version of the rules, some rules may show a badge:
+
+- **NEW** -- This rule is brand new. It didn't exist in the version you last agreed to.
+- **UPDATED** -- This rule has changed. You can click to see the previous version and compare.
+
+Rules without a badge haven't changed since you last agreed, but you still need to check them to confirm you've reviewed them.
+
+## For New Members
+
+If this is your first time agreeing, every rule will be new to you -- so you won't see any badges. Just read through and check each one. After you agree, your account will be promoted to **Stowaway** status right away, and you'll be able to start the account setup process.
+
+## Parent Proxy Agreement
+
+If you're a parent and your child's account is linked to yours, you can agree on their behalf from the rules page. After completing your own agreement, scroll down to find the **Proxy Agreement** section. It lists any of your linked children who haven't yet agreed.
+
+Select the children you're agreeing for and click **Submit Proxy Agreement**. This records their agreement with a note that it was submitted by you as their parent.
+
+Your child can also agree independently any time by visiting the rules page from their own account.

--- a/resources/library/books/user-handbook/06-community-policies/02-community-rules/03-staying-current.md
+++ b/resources/library/books/user-handbook/06-community-policies/02-community-rules/03-staying-current.md
@@ -1,0 +1,36 @@
+---
+title: "When the Rules Are Updated"
+visibility: public
+order: 3
+summary: "What happens when a new version of the rules is published and what to expect."
+---
+
+## Rules Can Be Updated
+
+From time to time, Lighthouse publishes a new version of the Community Rules. This might happen when expectations are clarified, new rules are added, or existing ones are reworded for clarity. All changes are reviewed and approved by two staff members before they go live.
+
+When a new version is published, every member needs to review and agree to it. This page explains what happens next.
+
+## You'll Be Notified
+
+When a new version of the rules is published, you'll receive an **email notification** letting you know. The email includes a link directly to the rules page so you can review and agree right away.
+
+## The 14-Day Reminder
+
+If you haven't agreed within two weeks of a new version being published, you'll receive a **reminder email**. The reminder includes a note that your access may be restricted if you don't agree soon.
+
+You only receive this reminder once. If you get it, just visit the [Community Rules page]({{url:/rules}}) and complete your agreement.
+
+## Access Is Required
+
+If it's been a month since a new version was published and you still haven't agreed, your account may be temporarily restricted. You won't be able to access most of the site until you complete your agreement.
+
+The restriction is lifted automatically as soon as you agree -- there's no waiting period and no staff action needed. Just visit the [Community Rules page]({{url:/rules}}), check each rule, and click agree.
+
+## Nothing Is Deleted
+
+A restriction due to non-agreement doesn't affect your account data, linked accounts, or community history. Everything is waiting for you right where you left it as soon as you agree.
+
+## If the Rules Page Shows Your Agreement
+
+If you visit the rules page and see a message that you've already agreed to the current version, you're all set. You can return to the Dashboard or close the page.

--- a/resources/library/books/user-handbook/06-community-policies/02-community-rules/_index.md
+++ b/resources/library/books/user-handbook/06-community-policies/02-community-rules/_index.md
@@ -1,0 +1,8 @@
+---
+title: "Community Rules"
+visibility: public
+order: 2
+summary: "How to read, agree to, and stay current with the Lighthouse Community Rules."
+---
+
+This chapter explains how the Lighthouse Community Rules work, how to agree to them, and what happens when they're updated.

--- a/resources/views/dashboard.blade.php
+++ b/resources/views/dashboard.blade.php
@@ -7,109 +7,98 @@
         <div class="flex mb-4">
             <flux:heading>Community</flux:heading>
             <flux:spacer />
-            @if (auth()->user()->rules_accepted_at)
-                <livewire:dashboard.view-rules />
-            @endif
+            <flux:button href="{{ route('rules.show') }}" size="xs">View Rules</flux:button>
         </div>
 
-        @if (!auth()->user()->rules_accepted_at)
-            <div class="flex flex-col items-center justify-center py-12">
-                <flux:text class="text-center mb-6 text-lg">
-                    Welcome to Lighthouse! Please read and accept our community rules to get started.
-                </flux:text>
-                <livewire:dashboard.view-rules />
-            </div>
-        @else
-            @can('view-community-content')
-                @php $authUser = auth()->user(); @endphp
+        @can('view-community-content')
+            @php $authUser = auth()->user(); @endphp
 
-                @if($authUser->shouldShowOnboardingWizard())
-                    <livewire:onboarding.wizard />
-                @else
-                <div class="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-4">
-                    <livewire:dashboard.announcements-widget />
+            @if($authUser->shouldShowOnboardingWizard())
+                <livewire:onboarding.wizard />
+            @else
+            <div class="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-4">
+                <livewire:dashboard.announcements-widget />
 
-                    @php
-                        $showDiscordLink = $authUser->can('link-discord') && $authUser->discordAccounts()->active()->doesntExist();
-                        $showMinecraftLink = $authUser->can('link-minecraft-account') && $authUser->minecraftAccounts()->active()->doesntExist();
-                        $showSetupCard = $showDiscordLink || $showMinecraftLink;
-                    @endphp
+                @php
+                    $showDiscordLink = $authUser->can('link-discord') && $authUser->discordAccounts()->active()->doesntExist();
+                    $showMinecraftLink = $authUser->can('link-minecraft-account') && $authUser->minecraftAccounts()->active()->doesntExist();
+                    $showSetupCard = $showDiscordLink || $showMinecraftLink;
+                @endphp
 
-                    @if($showSetupCard)
-                        <flux:card class="border border-indigo-500/40 bg-indigo-950/20">
-                            <flux:heading size="md" class="text-indigo-300">Complete Your Setup</flux:heading>
-                            <flux:text variant="subtle" class="text-sm mt-1">
-                                Connect your accounts to get the most out of Lighthouse.
-                            </flux:text>
-                            <flux:separator variant="subtle" class="my-3" />
+                @if($showSetupCard)
+                    <flux:card class="border border-indigo-500/40 bg-indigo-950/20">
+                        <flux:heading size="md" class="text-indigo-300">Complete Your Setup</flux:heading>
+                        <flux:text variant="subtle" class="text-sm mt-1">
+                            Connect your accounts to get the most out of Lighthouse.
+                        </flux:text>
+                        <flux:separator variant="subtle" class="my-3" />
 
-                            <div class="flex flex-col gap-3">
-                                @if($showDiscordLink)
-                                    <div class="flex items-center justify-between">
-                                        <div>
-                                            <flux:text class="font-medium">Discord</flux:text>
-                                            <flux:text variant="subtle" class="text-sm">Get server roles and DM notifications</flux:text>
-                                        </div>
-                                        <flux:button href="{{ route('settings.discord-account') }}" size="sm" variant="primary">
-                                            Link Discord
-                                        </flux:button>
+                        <div class="flex flex-col gap-3">
+                            @if($showDiscordLink)
+                                <div class="flex items-center justify-between">
+                                    <div>
+                                        <flux:text class="font-medium">Discord</flux:text>
+                                        <flux:text variant="subtle" class="text-sm">Get server roles and DM notifications</flux:text>
                                     </div>
-                                @endif
+                                    <flux:button href="{{ route('settings.discord-account') }}" size="sm" variant="primary">
+                                        Link Discord
+                                    </flux:button>
+                                </div>
+                            @endif
 
-                                @if($showMinecraftLink)
-                                    <div class="flex items-center justify-between">
-                                        <div>
-                                            <flux:text class="font-medium">Minecraft</flux:text>
-                                            <flux:text variant="subtle" class="text-sm">Link your account to join the server</flux:text>
-                                        </div>
-                                        <flux:button href="{{ route('settings.minecraft-accounts') }}" size="sm" variant="primary">
-                                            Link Minecraft Account
-                                        </flux:button>
+                            @if($showMinecraftLink)
+                                <div class="flex items-center justify-between">
+                                    <div>
+                                        <flux:text class="font-medium">Minecraft</flux:text>
+                                        <flux:text variant="subtle" class="text-sm">Link your account to join the server</flux:text>
                                     </div>
-                                @endif
-                            </div>
-                        </flux:card>
-                    @else
-                        <flux:card>
-                            <flux:heading size="sm">My Account</flux:heading>
-                            <flux:separator variant="subtle" class="my-3" />
-                            <div class="flex flex-col gap-2">
-                                <flux:button href="{{ route('settings.discord-account') }}" size="xs" variant="ghost" class="justify-start">
-                                    Discord Account
-                                </flux:button>
-                                <flux:button href="{{ route('settings.minecraft-accounts') }}" size="xs" variant="ghost" class="justify-start">
-                                    Minecraft Accounts
-                                </flux:button>
-                                <flux:button href="{{ route('settings.notifications') }}" size="xs" variant="ghost" class="justify-start">
-                                    Notification Preferences
-                                </flux:button>
-                            </div>
-                        </flux:card>
-                    @endif
-
-                    <flux:card>
-                        <flux:heading>Donations</flux:heading>
-                        <flux:separator variant="subtle" class="my-2" />
-                        <div class="flex mt-4">
-                            <flux:button size="xs" href="{{ route('donate') }}" variant="primary" color="sky">Support Lighthouse</flux:button>
-                            <flux:spacer />
-                            <flux:button href="{{  config('lighthouse.stripe.customer_portal_url') }}" size="xs">Manage Subscription</flux:button>
+                                    <flux:button href="{{ route('settings.minecraft-accounts') }}" size="sm" variant="primary">
+                                        Link Minecraft Account
+                                    </flux:button>
+                                </div>
+                            @endif
                         </div>
                     </flux:card>
-                </div>
-
-                @can('view-community-stories')
-                    <div class="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-4 mt-4">
-                        <div class="md:col-span-2">
-                            <livewire:dashboard.community-question-widget />
+                @else
+                    <flux:card>
+                        <flux:heading size="sm">My Account</flux:heading>
+                        <flux:separator variant="subtle" class="my-3" />
+                        <div class="flex flex-col gap-2">
+                            <flux:button href="{{ route('settings.discord-account') }}" size="xs" variant="ghost" class="justify-start">
+                                Discord Account
+                            </flux:button>
+                            <flux:button href="{{ route('settings.minecraft-accounts') }}" size="xs" variant="ghost" class="justify-start">
+                                Minecraft Accounts
+                            </flux:button>
+                            <flux:button href="{{ route('settings.notifications') }}" size="xs" variant="ghost" class="justify-start">
+                                Notification Preferences
+                            </flux:button>
                         </div>
-                    </div>
-                @endcan
+                    </flux:card>
                 @endif
-            @else
-                <livewire:dashboard.in-brig-card />
+
+                <flux:card>
+                    <flux:heading>Donations</flux:heading>
+                    <flux:separator variant="subtle" class="my-2" />
+                    <div class="flex mt-4">
+                        <flux:button size="xs" href="{{ route('donate') }}" variant="primary" color="sky">Support Lighthouse</flux:button>
+                        <flux:spacer />
+                        <flux:button href="{{  config('lighthouse.stripe.customer_portal_url') }}" size="xs">Manage Subscription</flux:button>
+                    </div>
+                </flux:card>
+            </div>
+
+            @can('view-community-stories')
+                <div class="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-4 mt-4">
+                    <div class="md:col-span-2">
+                        <livewire:dashboard.community-question-widget />
+                    </div>
+                </div>
             @endcan
-        @endif
+            @endif
+        @else
+            <livewire:dashboard.in-brig-card />
+        @endcan
 
     </div>
 

--- a/resources/views/donation/index.blade.php
+++ b/resources/views/donation/index.blade.php
@@ -5,31 +5,33 @@
 
 
     <flux:heading class="mt-6">Community Support</flux:heading>
-    <flux:text>Here’s how the community is helping cover our monthly costs:</flux:text>
-    <flux:text variant="subtle" size="sm" class="my-1">(Amounts are currently updated at least every 2 weeks)</flux:text>
+    <flux:text>Here's how the community is helping cover our monthly costs:</flux:text>
 
     <div class="grid grid-cols-1 md:grid-cols-3 gap-4 my-6">
-        @php
-            $donationGoal = \App\Models\SiteConfig::getValue('donation_goal', (string) config('lighthouse.donation_goal', 60));
-            $currentMonthName = \App\Models\SiteConfig::getValue('donation_current_month_name', config('lighthouse.donation_current_month_name', ''));
-            $currentMonthAmount = \App\Models\SiteConfig::getValue('donation_current_month_amount', (string) config('lighthouse.donation_current_month_amount', 0));
-            $lastMonthName = \App\Models\SiteConfig::getValue('donation_last_month_name', config('lighthouse.donation_last_month_name', ''));
-            $lastMonthAmount = \App\Models\SiteConfig::getValue('donation_last_month_amount', (string) config('lighthouse.donation_last_month_amount', 0));
-        @endphp
-
-        @if($currentMonthName)
+        @foreach ($closedPeriods as $period)
+            @php $netPositive = $period['net'] >= 0; @endphp
             <flux:card class="overflow-hidden">
-                <flux:text>{{ $currentMonthName }}</flux:text>
-                <flux:heading size="xl" class="mt-2 tabular-nums flex">${{ $currentMonthAmount }} <flux:text class="text-lg mt-1 mx-4">/ ${{ $donationGoal }}</flux:text></flux:heading>
+                <flux:heading size="sm" class="mb-3">{{ $period['name'] }}</flux:heading>
+                <div class="space-y-2">
+                    <div class="flex justify-between text-sm">
+                        <span class="text-zinc-500">Income</span>
+                        <span class="font-mono text-green-600 dark:text-green-400">${{ number_format($period['income'] / 100, 2) }}</span>
+                    </div>
+                    <div class="flex justify-between text-sm">
+                        <span class="text-zinc-500">Expenses</span>
+                        <span class="font-mono text-red-600 dark:text-red-400">${{ number_format($period['expenses'] / 100, 2) }}</span>
+                    </div>
+                    <div class="flex justify-between text-sm font-semibold border-t border-zinc-200 dark:border-zinc-700 pt-2 mt-2">
+                        <span>Net</span>
+                        @if ($netPositive)
+                            <span class="font-mono text-green-600 dark:text-green-400">${{ number_format($period['net'] / 100, 2) }}</span>
+                        @else
+                            <span class="font-mono text-red-600 dark:text-red-400">-${{ number_format(abs($period['net']) / 100, 2) }}</span>
+                        @endif
+                    </div>
+                </div>
             </flux:card>
-        @endif
-
-        @if($lastMonthName)
-            <flux:card class="overflow-hidden">
-                <flux:text>{{ $lastMonthName }}</flux:text>
-                <flux:heading size="xl" class="mt-2 tabular-nums flex">${{ $lastMonthAmount }} <flux:text class="text-lg mt-1 mx-4">/ ${{ $donationGoal }}</flux:text></flux:heading>
-            </flux:card>
-        @endif
+        @endforeach
 
         @if(config('lighthouse.stripe.one_time_donation_url'))
             <flux:card class="overflow-hidden">

--- a/resources/views/livewire/admin-control-panel-tabs.blade.php
+++ b/resources/views/livewire/admin-control-panel-tabs.blade.php
@@ -85,6 +85,8 @@ new class extends Component {
             || $user->can('viewAny', \App\Models\StaffPosition::class)
             || $user->can('viewAny', \App\Models\BoardMember::class)
             || $user->can('manage-application-questions')
+            || $user->can('rules.manage')
+            || $user->can('rules.approve')
         );
     }
 
@@ -122,6 +124,7 @@ new class extends Component {
                 $user?->can('viewAny', \App\Models\StaffPosition::class) => 'staff-position-manager',
                 $user?->can('viewAny', \App\Models\BoardMember::class) => 'board-member-manager',
                 $user?->can('manage-application-questions') => 'application-questions',
+                $user?->can('rules.manage') || $user?->can('rules.approve') => 'rules-manager',
                 default => 'role-manager',
             },
             default => 'user-manager',
@@ -306,6 +309,9 @@ new class extends Component {
                 @can('manage-application-questions')
                     <flux:tab name="application-questions">App Questions</flux:tab>
                 @endcan
+                @canany(['rules.manage', 'rules.approve'])
+                    <flux:tab name="rules-manager">Rules</flux:tab>
+                @endcanany
             </flux:tabs>
 
             <flux:tab.panel name="site-settings">
@@ -342,6 +348,11 @@ new class extends Component {
                 @can('manage-application-questions')
                     <livewire:admin-manage-application-questions-page />
                 @endcan
+            </flux:tab.panel>
+            <flux:tab.panel name="rules-manager">
+                @canany(['rules.manage', 'rules.approve'])
+                    <livewire:admin-manage-rules-page />
+                @endcanany
             </flux:tab.panel>
         </flux:tab.group>
     @endif

--- a/resources/views/livewire/admin-manage-community-questions-page.blade.php
+++ b/resources/views/livewire/admin-manage-community-questions-page.blade.php
@@ -5,6 +5,7 @@ use App\Actions\UpdateCommunityQuestion;
 use App\Enums\CommunityQuestionStatus;
 use App\Models\CommunityQuestion;
 use Carbon\Carbon;
+use Carbon\CarbonTimeZone;
 use Flux\Flux;
 use Livewire\WithPagination;
 use Livewire\Volt\Component;
@@ -22,6 +23,29 @@ new class extends Component {
     public string $formStatus = 'draft';
     public ?string $formStartDate = null;
     public ?string $formEndDate = null;
+
+    protected function userTimezone(): string
+    {
+        return auth()->user()->timezone ?? 'America/New_York';
+    }
+
+    protected function toUtc(?string $datetime): ?Carbon
+    {
+        if (! filled($datetime)) {
+            return null;
+        }
+
+        return Carbon::parse($datetime, new CarbonTimeZone($this->userTimezone()))->utc();
+    }
+
+    protected function toLocal(?\DateTimeInterface $datetime): ?string
+    {
+        if (! $datetime) {
+            return null;
+        }
+
+        return Carbon::instance($datetime)->setTimezone($this->userTimezone())->format('Y-m-d\TH:i');
+    }
 
     public function sort(string $column): void
     {
@@ -62,8 +86,8 @@ new class extends Component {
         $this->formQuestionText = $question->question_text;
         $this->formDescription = $question->description ?? '';
         $this->formStatus = $question->status->value;
-        $this->formStartDate = $question->start_date?->format('Y-m-d\TH:i');
-        $this->formEndDate = $question->end_date?->format('Y-m-d\TH:i');
+        $this->formStartDate = $this->toLocal($question->start_date);
+        $this->formEndDate = $this->toLocal($question->end_date);
 
         Flux::modal('question-form-modal')->show();
     }
@@ -81,8 +105,8 @@ new class extends Component {
         ]);
 
         $status = CommunityQuestionStatus::from($this->formStatus);
-        $startDate = $this->formStartDate ? Carbon::parse($this->formStartDate) : null;
-        $endDate = $this->formEndDate ? Carbon::parse($this->formEndDate) : null;
+        $startDate = $this->toUtc($this->formStartDate);
+        $endDate = $this->toUtc($this->formEndDate);
 
         if ($this->editingId) {
             $question = CommunityQuestion::findOrFail($this->editingId);

--- a/resources/views/livewire/admin-manage-rules-page.blade.php
+++ b/resources/views/livewire/admin-manage-rules-page.blade.php
@@ -493,8 +493,10 @@ new class extends Component {
             <div class="flex items-center gap-2">
                 <flux:heading size="md" class="flex-1">{{ $category->name }}</flux:heading>
                 @can('rules.manage')
-                    <flux:button wire:click="moveCategoryUp({{ $category->id }})" size="sm" variant="ghost" icon="chevron-up" title="Move category up" />
-                    <flux:button wire:click="moveCategoryDown({{ $category->id }})" size="sm" variant="ghost" icon="chevron-down" title="Move category down" />
+                    @if($this->getDraft() && $this->getDraft()->status === 'draft')
+                        <flux:button wire:click="moveCategoryUp({{ $category->id }})" size="sm" variant="ghost" icon="chevron-up" title="Move category up" />
+                        <flux:button wire:click="moveCategoryDown({{ $category->id }})" size="sm" variant="ghost" icon="chevron-down" title="Move category down" />
+                    @endif
                     @if($this->getDraft() && $this->getDraft()->status === 'draft')
                         <flux:button wire:click="openEditCategoryModal({{ $category->id }})" size="sm" variant="ghost" icon="pencil-square" title="Edit category name" />
                     @endif
@@ -538,8 +540,10 @@ new class extends Component {
                         </div>
                         <div class="flex items-center gap-1 flex-shrink-0">
                             @can('rules.manage')
-                                <flux:button wire:click="moveRuleUp({{ $rule->id }})" size="sm" variant="ghost" icon="chevron-up" title="Move up" />
-                                <flux:button wire:click="moveRuleDown({{ $rule->id }})" size="sm" variant="ghost" icon="chevron-down" title="Move down" />
+                                @if($this->getDraft() && $this->getDraft()->status === 'draft')
+                                    <flux:button wire:click="moveRuleUp({{ $rule->id }})" size="sm" variant="ghost" icon="chevron-up" title="Move up" />
+                                    <flux:button wire:click="moveRuleDown({{ $rule->id }})" size="sm" variant="ghost" icon="chevron-down" title="Move down" />
+                                @endif
                                 @if($this->getDraft() && $this->getDraft()->status === 'draft' && ! $isDeactivating)
                                     @if($isDraftRule)
                                         <flux:button wire:click="openEditRuleModal({{ $rule->id }})" size="sm" variant="ghost" icon="pencil-square" title="Edit rule" />

--- a/resources/views/livewire/admin-manage-rules-page.blade.php
+++ b/resources/views/livewire/admin-manage-rules-page.blade.php
@@ -204,8 +204,8 @@ new class extends Component {
         $this->authorize('rules.manage');
 
         $draft = $this->getDraft();
-        if (! $draft) {
-            Flux::toast('No draft version found.', 'Error', variant: 'danger');
+        if (! $draft || $draft->status !== 'draft') {
+            Flux::toast('Cannot modify: draft is not in editable status.', 'Error', variant: 'danger');
 
             return;
         }
@@ -236,8 +236,8 @@ new class extends Component {
         ]);
 
         $draft = $this->getDraft();
-        if (! $draft) {
-            Flux::toast('Start a draft first.', 'Error', variant: 'danger');
+        if (! $draft || $draft->status !== 'draft') {
+            Flux::toast('Cannot modify: draft is not in editable status.', 'Error', variant: 'danger');
 
             return;
         }
@@ -273,8 +273,8 @@ new class extends Component {
         ]);
 
         $draft = $this->getDraft();
-        if (! $draft) {
-            Flux::toast('Start a draft first.', 'Error', variant: 'danger');
+        if (! $draft || $draft->status !== 'draft') {
+            Flux::toast('Cannot modify: draft is not in editable status.', 'Error', variant: 'danger');
 
             return;
         }
@@ -293,8 +293,8 @@ new class extends Component {
         $this->authorize('rules.manage');
 
         $draft = $this->getDraft();
-        if (! $draft) {
-            Flux::toast('Start a draft first.', 'Error', variant: 'danger');
+        if (! $draft || $draft->status !== 'draft') {
+            Flux::toast('Cannot modify: draft is not in editable status.', 'Error', variant: 'danger');
 
             return;
         }
@@ -489,7 +489,7 @@ new class extends Component {
                     @if($category->rules->isEmpty())
                         <flux:button wire:click="deleteCategory({{ $category->id }})" wire:confirm="Delete this category?" size="sm" variant="ghost" icon="trash" title="Delete category" />
                     @endif
-                    @if($this->getDraft())
+                    @if($this->getDraft() && $this->getDraft()->status === 'draft')
                         <flux:button wire:click="openAddRuleModal({{ $category->id }})" size="sm" variant="ghost" icon="plus" title="Add rule">Add Rule</flux:button>
                     @endif
                 @endcan
@@ -526,7 +526,7 @@ new class extends Component {
                             @can('rules.manage')
                                 <flux:button wire:click="moveRuleUp({{ $rule->id }})" size="sm" variant="ghost" icon="chevron-up" title="Move up" />
                                 <flux:button wire:click="moveRuleDown({{ $rule->id }})" size="sm" variant="ghost" icon="chevron-down" title="Move down" />
-                                @if($this->getDraft() && ! $isDeactivating)
+                                @if($this->getDraft() && $this->getDraft()->status === 'draft' && ! $isDeactivating)
                                     @if($isDraftRule)
                                         <flux:button wire:click="removeRuleFromDraft({{ $rule->id }})" wire:confirm="Remove this rule from the draft?" size="sm" variant="ghost" icon="trash" title="Remove from draft" />
                                     @else

--- a/resources/views/livewire/admin-manage-rules-page.blade.php
+++ b/resources/views/livewire/admin-manage-rules-page.blade.php
@@ -5,6 +5,7 @@ use App\Actions\ApproveAndPublishVersion;
 use App\Actions\CreateRuleVersion;
 use App\Actions\DeactivateRuleInDraft;
 use App\Actions\RejectDraftVersion;
+use App\Actions\RemoveRuleFromDraft;
 use App\Actions\SubmitVersionForApproval;
 use App\Actions\UpdateRuleInDraft;
 use App\Actions\UpdateRulesHeaderFooter;
@@ -33,6 +34,10 @@ new class extends Component {
     public ?int $editRuleCategoryId = null;
     public string $editRuleTitle = '';
     public string $editRuleDescription = '';
+
+    // Edit category
+    public ?int $editCategoryId = null;
+    public string $editCategoryName = '';
 
     // Reject modal
     public string $rejectionNote = '';
@@ -152,6 +157,62 @@ new class extends Component {
             $category->save();
             $next->save();
         }
+    }
+
+    public function openEditCategoryModal(int $categoryId): void
+    {
+        $this->authorize('rules.manage');
+
+        $category = RuleCategory::findOrFail($categoryId);
+        $this->editCategoryId = $categoryId;
+        $this->editCategoryName = $category->name;
+        Flux::modal('edit-category-modal')->show();
+    }
+
+    public function updateCategory(): void
+    {
+        $this->authorize('rules.manage');
+
+        $this->validate(['editCategoryName' => 'required|string|max:255']);
+
+        $category = RuleCategory::findOrFail($this->editCategoryId);
+        $category->update(['name' => $this->editCategoryName]);
+
+        $this->reset(['editCategoryId', 'editCategoryName']);
+        Flux::modal('edit-category-modal')->close();
+        Flux::toast('Category name updated.', 'Updated', variant: 'success');
+    }
+
+    public function deleteCategory(int $categoryId): void
+    {
+        $this->authorize('rules.manage');
+
+        $category = RuleCategory::findOrFail($categoryId);
+
+        if ($category->rules()->count() > 0) {
+            Flux::toast('Cannot delete a category that has rules. Move or remove all rules first.', 'Error', variant: 'danger');
+
+            return;
+        }
+
+        $category->delete();
+        Flux::toast('Category deleted.', 'Deleted', variant: 'success');
+    }
+
+    public function removeRuleFromDraft(int $ruleId): void
+    {
+        $this->authorize('rules.manage');
+
+        $draft = $this->getDraft();
+        if (! $draft) {
+            Flux::toast('No draft version found.', 'Error', variant: 'danger');
+
+            return;
+        }
+
+        $rule = Rule::findOrFail($ruleId);
+        RemoveRuleFromDraft::run($draft, $rule);
+        Flux::toast('Rule removed from draft.', 'Removed', variant: 'success');
     }
 
     public function openAddRuleModal(int $categoryId): void
@@ -424,6 +485,10 @@ new class extends Component {
                 @can('rules.manage')
                     <flux:button wire:click="moveCategoryUp({{ $category->id }})" size="sm" variant="ghost" icon="chevron-up" title="Move category up" />
                     <flux:button wire:click="moveCategoryDown({{ $category->id }})" size="sm" variant="ghost" icon="chevron-down" title="Move category down" />
+                    <flux:button wire:click="openEditCategoryModal({{ $category->id }})" size="sm" variant="ghost" icon="pencil-square" title="Edit category name" />
+                    @if($category->rules->isEmpty())
+                        <flux:button wire:click="deleteCategory({{ $category->id }})" wire:confirm="Delete this category?" size="sm" variant="ghost" icon="trash" title="Delete category" />
+                    @endif
                     @if($this->getDraft())
                         <flux:button wire:click="openAddRuleModal({{ $category->id }})" size="sm" variant="ghost" icon="plus" title="Add rule">Add Rule</flux:button>
                     @endif
@@ -462,9 +527,13 @@ new class extends Component {
                                 <flux:button wire:click="moveRuleUp({{ $rule->id }})" size="sm" variant="ghost" icon="chevron-up" title="Move up" />
                                 <flux:button wire:click="moveRuleDown({{ $rule->id }})" size="sm" variant="ghost" icon="chevron-down" title="Move down" />
                                 @if($this->getDraft() && ! $isDeactivating)
-                                    <flux:button wire:click="openEditRuleModal({{ $rule->id }})" size="sm" variant="ghost" icon="pencil-square" title="Edit / Replace" />
-                                    @if($rule->status === 'active')
-                                        <flux:button wire:click="deactivateRule({{ $rule->id }})" size="sm" variant="ghost" icon="trash" title="Mark for deactivation" />
+                                    @if($isDraftRule)
+                                        <flux:button wire:click="removeRuleFromDraft({{ $rule->id }})" wire:confirm="Remove this rule from the draft?" size="sm" variant="ghost" icon="trash" title="Remove from draft" />
+                                    @else
+                                        <flux:button wire:click="openEditRuleModal({{ $rule->id }})" size="sm" variant="ghost" icon="pencil-square" title="Edit / Replace" />
+                                        @if($rule->status === 'active')
+                                            <flux:button wire:click="deactivateRule({{ $rule->id }})" size="sm" variant="ghost" icon="trash" title="Mark for deactivation" />
+                                        @endif
                                     @endif
                                 @endif
                             @endcan
@@ -512,6 +581,20 @@ new class extends Component {
             <div class="flex gap-2 justify-end">
                 <flux:button x-on:click="$flux.modal('add-category-modal').close()" variant="ghost">Cancel</flux:button>
                 <flux:button wire:click="addCategory" variant="primary">Add Category</flux:button>
+            </div>
+        </flux:modal>
+
+        {{-- Edit Category Modal --}}
+        <flux:modal name="edit-category-modal" variant="flyout" class="space-y-4">
+            <flux:heading size="lg">Edit Category Name</flux:heading>
+            <flux:field>
+                <flux:label>Category Name <span class="text-red-500">*</span></flux:label>
+                <flux:input wire:model="editCategoryName" placeholder="e.g. Keep Language Clean" />
+                <flux:error name="editCategoryName" />
+            </flux:field>
+            <div class="flex gap-2 justify-end">
+                <flux:button x-on:click="$flux.modal('edit-category-modal').close()" variant="ghost">Cancel</flux:button>
+                <flux:button wire:click="updateCategory" variant="primary">Save</flux:button>
             </div>
         </flux:modal>
 

--- a/resources/views/livewire/admin-manage-rules-page.blade.php
+++ b/resources/views/livewire/admin-manage-rules-page.blade.php
@@ -281,7 +281,17 @@ new class extends Component {
 
         $oldRule = Rule::findOrFail($this->editRuleId);
         $newCategory = RuleCategory::findOrFail($this->editRuleCategoryId);
-        UpdateRuleInDraft::run($draft, $oldRule, $this->editRuleTitle, $this->editRuleDescription, auth()->user(), $newCategory);
+
+        if ($oldRule->status === 'draft') {
+            // Draft rules can be edited directly — no need to create a replacement
+            $oldRule->update([
+                'rule_category_id' => $newCategory->id,
+                'title' => $this->editRuleTitle,
+                'description' => $this->editRuleDescription,
+            ]);
+        } else {
+            UpdateRuleInDraft::run($draft, $oldRule, $this->editRuleTitle, $this->editRuleDescription, auth()->user(), $newCategory);
+        }
 
         $this->reset(['editRuleId', 'editRuleTitle', 'editRuleDescription', 'editRuleCategoryId']);
         Flux::modal('edit-rule-modal')->close();
@@ -532,6 +542,7 @@ new class extends Component {
                                 <flux:button wire:click="moveRuleDown({{ $rule->id }})" size="sm" variant="ghost" icon="chevron-down" title="Move down" />
                                 @if($this->getDraft() && $this->getDraft()->status === 'draft' && ! $isDeactivating)
                                     @if($isDraftRule)
+                                        <flux:button wire:click="openEditRuleModal({{ $rule->id }})" size="sm" variant="ghost" icon="pencil-square" title="Edit rule" />
                                         <flux:button wire:click="removeRuleFromDraft({{ $rule->id }})" wire:confirm="Remove this rule from the draft?" size="sm" variant="ghost" icon="trash" title="Remove from draft" />
                                     @else
                                         <flux:button wire:click="openEditRuleModal({{ $rule->id }})" size="sm" variant="ghost" icon="pencil-square" title="Edit / Replace" />

--- a/resources/views/livewire/admin-manage-rules-page.blade.php
+++ b/resources/views/livewire/admin-manage-rules-page.blade.php
@@ -490,6 +490,16 @@ new class extends Component {
         <livewire:rules-version-history />
     @endcanany
 
+    {{-- Compliance List --}}
+    @can('rules.manage')
+        <livewire:rules-compliance-list />
+    @endcan
+
+    {{-- Agreement History (admins only) --}}
+    @if(auth()->user()?->isAdmin())
+        <livewire:rules-agreement-history />
+    @endif
+
     {{-- Add Category Modal --}}
     @can('rules.manage')
         <flux:modal name="add-category-modal" variant="flyout" class="space-y-4">

--- a/resources/views/livewire/admin-manage-rules-page.blade.php
+++ b/resources/views/livewire/admin-manage-rules-page.blade.php
@@ -1,0 +1,455 @@
+<?php
+
+use App\Actions\AddRuleToDraft;
+use App\Actions\CreateRuleVersion;
+use App\Actions\DeactivateRuleInDraft;
+use App\Actions\UpdateRuleInDraft;
+use App\Actions\UpdateRulesHeaderFooter;
+use App\Models\Rule;
+use App\Models\RuleCategory;
+use App\Models\RuleVersion;
+use App\Models\SiteConfig;
+use Flux\Flux;
+use Livewire\Volt\Component;
+
+new class extends Component {
+    // Header/footer
+    public string $rulesHeader = '';
+    public string $rulesFooter = '';
+
+    // Add category
+    public string $newCategoryName = '';
+
+    // Add rule
+    public ?int $addRuleCategoryId = null;
+    public string $newRuleTitle = '';
+    public string $newRuleDescription = '';
+
+    // Edit/replace rule
+    public ?int $editRuleId = null;
+    public ?int $editRuleCategoryId = null;
+    public string $editRuleTitle = '';
+    public string $editRuleDescription = '';
+
+    public function mount(): void
+    {
+        $this->rulesHeader = SiteConfig::getValue('rules_header', '');
+        $this->rulesFooter = SiteConfig::getValue('rules_footer', '');
+    }
+
+    public function getCategories()
+    {
+        return RuleCategory::with(['rules' => fn ($q) => $q->orderBy('sort_order')])
+            ->orderBy('sort_order')
+            ->get();
+    }
+
+    public function getDraft(): ?RuleVersion
+    {
+        return RuleVersion::currentDraft();
+    }
+
+    public function getDraftRuleIds(): array
+    {
+        $draft = $this->getDraft();
+        if (! $draft) {
+            return [];
+        }
+
+        return $draft->rules()
+            ->wherePivot('deactivate_on_publish', false)
+            ->pluck('rules.id')
+            ->toArray();
+    }
+
+    public function getDeactivatingRuleIds(): array
+    {
+        $draft = $this->getDraft();
+        if (! $draft) {
+            return [];
+        }
+
+        return $draft->rules()
+            ->wherePivot('deactivate_on_publish', true)
+            ->pluck('rules.id')
+            ->toArray();
+    }
+
+    public function saveHeaderFooter(): void
+    {
+        $this->authorize('rules.manage');
+
+        $this->validate([
+            'rulesHeader' => 'nullable|string|max:5000',
+            'rulesFooter' => 'nullable|string|max:5000',
+        ]);
+
+        UpdateRulesHeaderFooter::run($this->rulesHeader, $this->rulesFooter);
+        Flux::toast('Rules header and footer saved.', 'Saved', variant: 'success');
+    }
+
+    public function startDraft(): void
+    {
+        $this->authorize('rules.manage');
+
+        if (RuleVersion::currentDraft()) {
+            Flux::toast('A draft already exists.', 'Error', variant: 'danger');
+
+            return;
+        }
+
+        CreateRuleVersion::run(auth()->user());
+        Flux::toast('Draft version created.', 'Draft Started', variant: 'success');
+    }
+
+    public function addCategory(): void
+    {
+        $this->authorize('rules.manage');
+
+        $this->validate(['newCategoryName' => 'required|string|max:255']);
+
+        $maxOrder = RuleCategory::max('sort_order') ?? 0;
+        RuleCategory::create(['name' => $this->newCategoryName, 'sort_order' => $maxOrder + 1]);
+
+        $this->newCategoryName = '';
+        Flux::modal('add-category-modal')->close();
+        Flux::toast('Category added.', 'Added', variant: 'success');
+    }
+
+    public function moveCategoryUp(int $categoryId): void
+    {
+        $this->authorize('rules.manage');
+
+        $category = RuleCategory::findOrFail($categoryId);
+        $prev = RuleCategory::where('sort_order', '<', $category->sort_order)
+            ->orderByDesc('sort_order')
+            ->first();
+
+        if ($prev) {
+            [$category->sort_order, $prev->sort_order] = [$prev->sort_order, $category->sort_order];
+            $category->save();
+            $prev->save();
+        }
+    }
+
+    public function moveCategoryDown(int $categoryId): void
+    {
+        $this->authorize('rules.manage');
+
+        $category = RuleCategory::findOrFail($categoryId);
+        $next = RuleCategory::where('sort_order', '>', $category->sort_order)
+            ->orderBy('sort_order')
+            ->first();
+
+        if ($next) {
+            [$category->sort_order, $next->sort_order] = [$next->sort_order, $category->sort_order];
+            $category->save();
+            $next->save();
+        }
+    }
+
+    public function openAddRuleModal(int $categoryId): void
+    {
+        $this->authorize('rules.manage');
+
+        $this->addRuleCategoryId = $categoryId;
+        $this->newRuleTitle = '';
+        $this->newRuleDescription = '';
+        Flux::modal('add-rule-modal')->show();
+    }
+
+    public function addRule(): void
+    {
+        $this->authorize('rules.manage');
+
+        $this->validate([
+            'newRuleTitle' => 'required|string|max:255',
+            'newRuleDescription' => 'required|string|max:10000',
+            'addRuleCategoryId' => 'required|integer|exists:rule_categories,id',
+        ]);
+
+        $draft = $this->getDraft();
+        if (! $draft) {
+            Flux::toast('Start a draft first.', 'Error', variant: 'danger');
+
+            return;
+        }
+
+        $category = RuleCategory::findOrFail($this->addRuleCategoryId);
+        AddRuleToDraft::run($draft, $category, $this->newRuleTitle, $this->newRuleDescription, auth()->user());
+
+        $this->reset(['newRuleTitle', 'newRuleDescription', 'addRuleCategoryId']);
+        Flux::modal('add-rule-modal')->close();
+        Flux::toast('Rule added to draft.', 'Added', variant: 'success');
+    }
+
+    public function openEditRuleModal(int $ruleId): void
+    {
+        $this->authorize('rules.manage');
+
+        $rule = Rule::findOrFail($ruleId);
+        $this->editRuleId = $ruleId;
+        $this->editRuleCategoryId = $rule->rule_category_id;
+        $this->editRuleTitle = $rule->title;
+        $this->editRuleDescription = $rule->description;
+        Flux::modal('edit-rule-modal')->show();
+    }
+
+    public function updateRule(): void
+    {
+        $this->authorize('rules.manage');
+
+        $this->validate([
+            'editRuleTitle' => 'required|string|max:255',
+            'editRuleDescription' => 'required|string|max:10000',
+            'editRuleCategoryId' => 'required|integer|exists:rule_categories,id',
+        ]);
+
+        $draft = $this->getDraft();
+        if (! $draft) {
+            Flux::toast('Start a draft first.', 'Error', variant: 'danger');
+
+            return;
+        }
+
+        $oldRule = Rule::findOrFail($this->editRuleId);
+        $newCategory = RuleCategory::findOrFail($this->editRuleCategoryId);
+        UpdateRuleInDraft::run($draft, $oldRule, $this->editRuleTitle, $this->editRuleDescription, auth()->user(), $newCategory);
+
+        $this->reset(['editRuleId', 'editRuleTitle', 'editRuleDescription', 'editRuleCategoryId']);
+        Flux::modal('edit-rule-modal')->close();
+        Flux::toast('Rule replaced in draft.', 'Updated', variant: 'success');
+    }
+
+    public function deactivateRule(int $ruleId): void
+    {
+        $this->authorize('rules.manage');
+
+        $draft = $this->getDraft();
+        if (! $draft) {
+            Flux::toast('Start a draft first.', 'Error', variant: 'danger');
+
+            return;
+        }
+
+        $rule = Rule::findOrFail($ruleId);
+        DeactivateRuleInDraft::run($draft, $rule);
+        Flux::toast('Rule marked for deactivation.', 'Deactivated', variant: 'success');
+    }
+
+    public function moveRuleUp(int $ruleId): void
+    {
+        $this->authorize('rules.manage');
+
+        $rule = Rule::findOrFail($ruleId);
+        $prev = Rule::where('rule_category_id', $rule->rule_category_id)
+            ->where('sort_order', '<', $rule->sort_order)
+            ->orderByDesc('sort_order')
+            ->first();
+
+        if ($prev) {
+            [$rule->sort_order, $prev->sort_order] = [$prev->sort_order, $rule->sort_order];
+            $rule->save();
+            $prev->save();
+        }
+    }
+
+    public function moveRuleDown(int $ruleId): void
+    {
+        $this->authorize('rules.manage');
+
+        $rule = Rule::findOrFail($ruleId);
+        $next = Rule::where('rule_category_id', $rule->rule_category_id)
+            ->where('sort_order', '>', $rule->sort_order)
+            ->orderBy('sort_order')
+            ->first();
+
+        if ($next) {
+            [$rule->sort_order, $next->sort_order] = [$next->sort_order, $rule->sort_order];
+            $rule->save();
+            $next->save();
+        }
+    }
+}; ?>
+
+<div class="space-y-8">
+    {{-- Header/Footer Editing --}}
+    @can('rules.manage')
+        <flux:card class="space-y-4">
+            <flux:heading size="md">Rules Header & Footer</flux:heading>
+            <flux:text variant="subtle">Markdown text displayed above and below the community rules page.</flux:text>
+
+            <flux:field>
+                <flux:label>Header (Markdown)</flux:label>
+                <flux:textarea wire:model="rulesHeader" rows="5" placeholder="Scripture quotes or introductory text..." />
+            </flux:field>
+
+            <flux:field>
+                <flux:label>Footer (Markdown)</flux:label>
+                <flux:textarea wire:model="rulesFooter" rows="3" placeholder="Officer discretion disclaimer or closing notes..." />
+            </flux:field>
+
+            <flux:button wire:click="saveHeaderFooter" variant="primary" size="sm">Save Header &amp; Footer</flux:button>
+        </flux:card>
+    @endcan
+
+    {{-- Draft Management --}}
+    <flux:card class="space-y-4">
+        <div class="flex items-center justify-between">
+            <div>
+                <flux:heading size="md">Draft Version</flux:heading>
+                @if($this->getDraft())
+                    <flux:text variant="subtle">
+                        Draft v{{ $this->getDraft()->version_number }} is open
+                        @if($this->getDraft()->status === 'submitted')
+                            — <flux:badge variant="warning" size="sm">Awaiting Approval</flux:badge>
+                        @else
+                            — <flux:badge variant="primary" size="sm">In Progress</flux:badge>
+                        @endif
+                    </flux:text>
+                @else
+                    <flux:text variant="subtle">No draft version is currently open.</flux:text>
+                @endif
+            </div>
+            @can('rules.manage')
+                @if(! $this->getDraft())
+                    <flux:button wire:click="startDraft" variant="primary" icon="document-plus">Start New Draft</flux:button>
+                @endif
+            @endcan
+        </div>
+    </flux:card>
+
+    {{-- Categories & Rules List --}}
+    @foreach($this->getCategories() as $category)
+        <flux:card wire:key="category-{{ $category->id }}" class="space-y-4">
+            <div class="flex items-center gap-2">
+                <flux:heading size="md" class="flex-1">{{ $category->name }}</flux:heading>
+                @can('rules.manage')
+                    <flux:button wire:click="moveCategoryUp({{ $category->id }})" size="sm" variant="ghost" icon="chevron-up" title="Move category up" />
+                    <flux:button wire:click="moveCategoryDown({{ $category->id }})" size="sm" variant="ghost" icon="chevron-down" title="Move category down" />
+                    @if($this->getDraft())
+                        <flux:button wire:click="openAddRuleModal({{ $category->id }})" size="sm" variant="ghost" icon="plus" title="Add rule">Add Rule</flux:button>
+                    @endif
+                @endcan
+            </div>
+
+            @forelse($category->rules as $rule)
+                @php
+                    $draftRuleIds = $this->getDraftRuleIds();
+                    $deactivatingIds = $this->getDeactivatingRuleIds();
+                    $isDeactivating = in_array($rule->id, $deactivatingIds);
+                    $isDraftRule = $rule->status === 'draft';
+                @endphp
+                <div wire:key="rule-{{ $rule->id }}" class="border rounded p-3 {{ $isDeactivating ? 'opacity-50 bg-red-50 dark:bg-red-950' : '' }}">
+                    <div class="flex items-start gap-2">
+                        <div class="flex-1">
+                            <div class="flex items-center gap-2 flex-wrap">
+                                <span class="font-medium text-sm">{{ $rule->title }}</span>
+                                @if($isDraftRule)
+                                    <flux:badge variant="success" size="sm">NEW</flux:badge>
+                                @endif
+                                @if($isDeactivating)
+                                    <flux:badge variant="danger" size="sm">Deactivating</flux:badge>
+                                @endif
+                                @if($rule->status === 'inactive')
+                                    <flux:badge variant="zinc" size="sm">Inactive</flux:badge>
+                                @endif
+                                @if($rule->supersedes_rule_id)
+                                    <flux:badge variant="warning" size="sm">Replaces #{{ $rule->supersedes_rule_id }}</flux:badge>
+                                @endif
+                            </div>
+                            <p class="text-sm text-zinc-500 mt-1">{{ Str::limit($rule->description, 120) }}</p>
+                        </div>
+                        <div class="flex items-center gap-1 flex-shrink-0">
+                            @can('rules.manage')
+                                <flux:button wire:click="moveRuleUp({{ $rule->id }})" size="sm" variant="ghost" icon="chevron-up" title="Move up" />
+                                <flux:button wire:click="moveRuleDown({{ $rule->id }})" size="sm" variant="ghost" icon="chevron-down" title="Move down" />
+                                @if($this->getDraft() && ! $isDeactivating)
+                                    <flux:button wire:click="openEditRuleModal({{ $rule->id }})" size="sm" variant="ghost" icon="pencil-square" title="Edit / Replace" />
+                                    @if($rule->status === 'active')
+                                        <flux:button wire:click="deactivateRule({{ $rule->id }})" size="sm" variant="ghost" icon="trash" title="Mark for deactivation" />
+                                    @endif
+                                @endif
+                            @endcan
+                        </div>
+                    </div>
+                </div>
+            @empty
+                <flux:text variant="subtle" class="text-sm">No rules in this category.</flux:text>
+            @endforelse
+        </flux:card>
+    @endforeach
+
+    @can('rules.manage')
+        <div class="flex justify-end">
+            <flux:modal.trigger name="add-category-modal">
+                <flux:button variant="ghost" icon="folder-plus">Add Category</flux:button>
+            </flux:modal.trigger>
+        </div>
+    @endcan
+
+    {{-- Add Category Modal --}}
+    @can('rules.manage')
+        <flux:modal name="add-category-modal" variant="flyout" class="space-y-4">
+            <flux:heading size="lg">Add Category</flux:heading>
+            <flux:field>
+                <flux:label>Category Name <span class="text-red-500">*</span></flux:label>
+                <flux:input wire:model="newCategoryName" placeholder="e.g. Keep Language Clean" />
+                <flux:error name="newCategoryName" />
+            </flux:field>
+            <div class="flex gap-2 justify-end">
+                <flux:button x-on:click="$flux.modal('add-category-modal').close()" variant="ghost">Cancel</flux:button>
+                <flux:button wire:click="addCategory" variant="primary">Add Category</flux:button>
+            </div>
+        </flux:modal>
+
+        {{-- Add Rule Modal --}}
+        <flux:modal name="add-rule-modal" variant="flyout" class="space-y-4">
+            <flux:heading size="lg">Add Rule to Draft</flux:heading>
+            <flux:field>
+                <flux:label>Title <span class="text-red-500">*</span></flux:label>
+                <flux:input wire:model="newRuleTitle" placeholder="e.g. No Griefing" />
+                <flux:error name="newRuleTitle" />
+            </flux:field>
+            <flux:field>
+                <flux:label>Description <span class="text-red-500">*</span></flux:label>
+                <flux:textarea wire:model="newRuleDescription" rows="4" placeholder="Full rule text (Markdown supported)..." />
+                <flux:error name="newRuleDescription" />
+            </flux:field>
+            <div class="flex gap-2 justify-end">
+                <flux:button x-on:click="$flux.modal('add-rule-modal').close()" variant="ghost">Cancel</flux:button>
+                <flux:button wire:click="addRule" variant="primary">Add Rule</flux:button>
+            </div>
+        </flux:modal>
+
+        {{-- Edit Rule Modal --}}
+        <flux:modal name="edit-rule-modal" variant="flyout" class="space-y-4">
+            <flux:heading size="lg">Edit / Replace Rule</flux:heading>
+            <flux:text variant="subtle" size="sm">A replacement rule will be created with the new text. The original rule will be deactivated when this version publishes.</flux:text>
+
+            <flux:field>
+                <flux:label>Category</flux:label>
+                <flux:select wire:model="editRuleCategoryId">
+                    @foreach($this->getCategories() as $cat)
+                        <flux:select.option value="{{ $cat->id }}">{{ $cat->name }}</flux:select.option>
+                    @endforeach
+                </flux:select>
+                <flux:error name="editRuleCategoryId" />
+            </flux:field>
+            <flux:field>
+                <flux:label>Title <span class="text-red-500">*</span></flux:label>
+                <flux:input wire:model="editRuleTitle" />
+                <flux:error name="editRuleTitle" />
+            </flux:field>
+            <flux:field>
+                <flux:label>Description <span class="text-red-500">*</span></flux:label>
+                <flux:textarea wire:model="editRuleDescription" rows="4" />
+                <flux:error name="editRuleDescription" />
+            </flux:field>
+            <div class="flex gap-2 justify-end">
+                <flux:button x-on:click="$flux.modal('edit-rule-modal').close()" variant="ghost">Cancel</flux:button>
+                <flux:button wire:click="updateRule" variant="primary">Save Replacement</flux:button>
+            </div>
+        </flux:modal>
+    @endcan
+</div>

--- a/resources/views/livewire/admin-manage-rules-page.blade.php
+++ b/resources/views/livewire/admin-manage-rules-page.blade.php
@@ -485,7 +485,9 @@ new class extends Component {
                 @can('rules.manage')
                     <flux:button wire:click="moveCategoryUp({{ $category->id }})" size="sm" variant="ghost" icon="chevron-up" title="Move category up" />
                     <flux:button wire:click="moveCategoryDown({{ $category->id }})" size="sm" variant="ghost" icon="chevron-down" title="Move category down" />
-                    <flux:button wire:click="openEditCategoryModal({{ $category->id }})" size="sm" variant="ghost" icon="pencil-square" title="Edit category name" />
+                    @if($this->getDraft() && $this->getDraft()->status === 'draft')
+                        <flux:button wire:click="openEditCategoryModal({{ $category->id }})" size="sm" variant="ghost" icon="pencil-square" title="Edit category name" />
+                    @endif
                     @if($category->rules->isEmpty())
                         <flux:button wire:click="deleteCategory({{ $category->id }})" wire:confirm="Delete this category?" size="sm" variant="ghost" icon="trash" title="Delete category" />
                     @endif

--- a/resources/views/livewire/admin-manage-rules-page.blade.php
+++ b/resources/views/livewire/admin-manage-rules-page.blade.php
@@ -522,7 +522,9 @@ new class extends Component {
                                     <flux:badge variant="warning" size="sm">Replaces #{{ $rule->supersedes_rule_id }}</flux:badge>
                                 @endif
                             </div>
-                            <p class="text-sm text-zinc-500 mt-1">{{ Str::limit($rule->description, 120) }}</p>
+                            <div class="prose prose-sm dark:prose-invert max-w-none mt-1">
+                                {!! Str::markdown($rule->description, ['html_input' => 'strip', 'allow_unsafe_links' => false]) !!}
+                            </div>
                         </div>
                         <div class="flex items-center gap-1 flex-shrink-0">
                             @can('rules.manage')

--- a/resources/views/livewire/admin-manage-rules-page.blade.php
+++ b/resources/views/livewire/admin-manage-rules-page.blade.php
@@ -1,8 +1,11 @@
 <?php
 
 use App\Actions\AddRuleToDraft;
+use App\Actions\ApproveAndPublishVersion;
 use App\Actions\CreateRuleVersion;
 use App\Actions\DeactivateRuleInDraft;
+use App\Actions\RejectDraftVersion;
+use App\Actions\SubmitVersionForApproval;
 use App\Actions\UpdateRuleInDraft;
 use App\Actions\UpdateRulesHeaderFooter;
 use App\Models\Rule;
@@ -30,6 +33,9 @@ new class extends Component {
     public ?int $editRuleCategoryId = null;
     public string $editRuleTitle = '';
     public string $editRuleDescription = '';
+
+    // Reject modal
+    public string $rejectionNote = '';
 
     public function mount(): void
     {
@@ -270,6 +276,60 @@ new class extends Component {
             $next->save();
         }
     }
+
+    public function submitForApproval(): void
+    {
+        $this->authorize('rules.manage');
+
+        $draft = $this->getDraft();
+        if (! $draft || $draft->status !== 'draft') {
+            Flux::toast('No draft available to submit.', 'Error', variant: 'danger');
+
+            return;
+        }
+
+        SubmitVersionForApproval::run($draft, auth()->user());
+        Flux::toast('Draft submitted for approval.', 'Submitted', variant: 'success');
+    }
+
+    public function approveDraft(): void
+    {
+        $this->authorize('rules.approve');
+
+        $draft = $this->getDraft();
+        if (! $draft || $draft->status !== 'submitted') {
+            Flux::toast('No submitted version available to approve.', 'Error', variant: 'danger');
+
+            return;
+        }
+
+        try {
+            ApproveAndPublishVersion::run($draft, auth()->user());
+            Flux::toast('Rules version published. All members notified.', 'Published', variant: 'success');
+        } catch (\Illuminate\Auth\Access\AuthorizationException $e) {
+            Flux::toast($e->getMessage(), 'Cannot Approve', variant: 'danger');
+        }
+    }
+
+    public function rejectDraft(): void
+    {
+        $this->authorize('rules.approve');
+
+        $this->validate(['rejectionNote' => 'required|string|min:10|max:2000']);
+
+        $draft = $this->getDraft();
+        if (! $draft || $draft->status !== 'submitted') {
+            Flux::toast('No submitted version available to reject.', 'Error', variant: 'danger');
+
+            return;
+        }
+
+        RejectDraftVersion::run($draft, auth()->user(), $this->rejectionNote);
+
+        $this->rejectionNote = '';
+        Flux::modal('reject-modal')->close();
+        Flux::toast('Draft rejected and returned for revision.', 'Rejected', variant: 'success');
+    }
 }; ?>
 
 <div class="space-y-8">
@@ -295,7 +355,7 @@ new class extends Component {
 
     {{-- Draft Management --}}
     <flux:card class="space-y-4">
-        <div class="flex items-center justify-between">
+        <div class="flex items-center justify-between flex-wrap gap-3">
             <div>
                 <flux:heading size="md">Draft Version</flux:heading>
                 @if($this->getDraft())
@@ -311,13 +371,50 @@ new class extends Component {
                     <flux:text variant="subtle">No draft version is currently open.</flux:text>
                 @endif
             </div>
-            @can('rules.manage')
-                @if(! $this->getDraft())
-                    <flux:button wire:click="startDraft" variant="primary" icon="document-plus">Start New Draft</flux:button>
-                @endif
-            @endcan
+            <div class="flex gap-2 flex-wrap">
+                @can('rules.manage')
+                    @if(! $this->getDraft())
+                        <flux:button wire:click="startDraft" variant="primary" icon="document-plus">Start New Draft</flux:button>
+                    @elseif($this->getDraft()->status === 'draft')
+                        <flux:button wire:click="submitForApproval" variant="primary" icon="paper-airplane">Submit for Approval</flux:button>
+                    @endif
+                @endcan
+                @can('rules.approve')
+                    @if($this->getDraft() && $this->getDraft()->status === 'submitted')
+                        <flux:button wire:click="approveDraft" variant="primary" icon="check-circle">Approve &amp; Publish</flux:button>
+                        <flux:modal.trigger name="reject-modal">
+                            <flux:button variant="danger" icon="x-circle">Reject</flux:button>
+                        </flux:modal.trigger>
+                    @endif
+                @endcan
+            </div>
         </div>
+
+        {{-- Rejection note visible to draft creator --}}
+        @if($this->getDraft() && $this->getDraft()->rejection_note && $this->getDraft()->status === 'draft')
+            <div class="border border-red-300 rounded p-3 bg-red-50 dark:bg-red-950 space-y-1">
+                <flux:text class="font-semibold text-red-700 dark:text-red-300">Rejected — Reviewer Feedback:</flux:text>
+                <flux:text class="text-sm text-red-600 dark:text-red-400">{{ $this->getDraft()->rejection_note }}</flux:text>
+            </div>
+        @endif
     </flux:card>
+
+    {{-- Reject Modal --}}
+    @can('rules.approve')
+        <flux:modal name="reject-modal" variant="flyout" class="space-y-4">
+            <flux:heading size="lg">Reject Draft Version</flux:heading>
+            <flux:text variant="subtle">Provide feedback for the draft creator explaining what needs to be changed.</flux:text>
+            <flux:field>
+                <flux:label>Feedback <span class="text-red-500">*</span></flux:label>
+                <flux:textarea wire:model="rejectionNote" rows="5" placeholder="Explain what needs to be changed before this version can be approved..." />
+                <flux:error name="rejectionNote" />
+            </flux:field>
+            <div class="flex gap-2 justify-end">
+                <flux:button x-on:click="$flux.modal('reject-modal').close()" variant="ghost">Cancel</flux:button>
+                <flux:button wire:click="rejectDraft" variant="danger">Reject Draft</flux:button>
+            </div>
+        </flux:modal>
+    @endcan
 
     {{-- Categories & Rules List --}}
     @foreach($this->getCategories() as $category)
@@ -387,6 +484,11 @@ new class extends Component {
             </flux:modal.trigger>
         </div>
     @endcan
+
+    {{-- Version History --}}
+    @canany(['rules.manage', 'rules.approve'])
+        <livewire:rules-version-history />
+    @endcanany
 
     {{-- Add Category Modal --}}
     @can('rules.manage')

--- a/resources/views/livewire/dashboard/ready-room-my-reports.blade.php
+++ b/resources/views/livewire/dashboard/ready-room-my-reports.blade.php
@@ -93,7 +93,13 @@ new class extends Component {
                 @foreach($report->answers->sortBy(fn ($a) => $a->question->sort_order) as $answer)
                     <div>
                         <flux:text class="font-semibold text-sm">{{ $answer->question->question_text }}</flux:text>
-                        <flux:text class="mt-1">{{ $answer->answer ?: 'No response' }}</flux:text>
+                        @if($answer->answer)
+                            <div class="prose prose-sm dark:prose-invert max-w-none mt-1">
+                                {!! Str::markdown($answer->answer, ['html_input' => 'strip', 'allow_unsafe_links' => false]) !!}
+                            </div>
+                        @else
+                            <flux:text class="mt-1">No response</flux:text>
+                        @endif
                     </div>
                 @endforeach
 

--- a/resources/views/livewire/finance/bank-reconciliation.blade.php
+++ b/resources/views/livewire/finance/bank-reconciliation.blade.php
@@ -102,9 +102,11 @@ new class extends Component {
     public function getIsBalancedProperty(): bool
     {
         // Allow $0.00 reconciliation (e.g. savings account with no activity):
-        // require the statement balance field to have been explicitly entered (non-empty)
-        // and the difference to be zero.
-        return $this->statementBalance !== '' && $this->difference === 0;
+        // require the statement balance field to have been explicitly entered (non-empty),
+        // the difference to be zero, and all transactions to be cleared.
+        return $this->statementBalance !== ''
+            && $this->difference === 0
+            && $this->unclearedLines->isEmpty();
     }
 
     public function markCleared(int $lineId): void

--- a/resources/views/livewire/finance/create-journal-entry.blade.php
+++ b/resources/views/livewire/finance/create-journal-entry.blade.php
@@ -374,7 +374,7 @@ new class extends Component
                             <flux:label>Tags <flux:badge size="sm" color="zinc">Optional</flux:badge></flux:label>
                             <div class="flex flex-wrap items-center gap-2">
                                 @foreach ($this->selectedTags as $tag)
-                                    <flux:badge color="{{ $tag['color'] }}" size="sm">
+                                    <flux:badge wire:key="income-tag-{{ $tag['id'] }}" color="{{ $tag['color'] }}" size="sm">
                                         {{ $tag['name'] }}
                                         <button wire:click="removeTag({{ $tag['id'] }})" class="ml-1 hover:opacity-70">×</button>
                                     </flux:badge>
@@ -450,7 +450,7 @@ new class extends Component
                             <flux:label>Tags <flux:badge size="sm" color="zinc">Optional</flux:badge></flux:label>
                             <div class="flex flex-wrap items-center gap-2">
                                 @foreach ($this->selectedTags as $tag)
-                                    <flux:badge color="{{ $tag['color'] }}" size="sm">
+                                    <flux:badge wire:key="expense-tag-{{ $tag['id'] }}" color="{{ $tag['color'] }}" size="sm">
                                         {{ $tag['name'] }}
                                         <button wire:click="removeTag({{ $tag['id'] }})" class="ml-1 hover:opacity-70">×</button>
                                     </flux:badge>

--- a/resources/views/livewire/finance/create-journal-entry.blade.php
+++ b/resources/views/livewire/finance/create-journal-entry.blade.php
@@ -354,20 +354,41 @@ new class extends Component
                         </flux:field>
                     </div>
 
-                    <flux:field>
-                        <flux:label>Donor Email <flux:badge size="sm" color="zinc">Optional</flux:badge></flux:label>
-                        <flux:input type="email" wire:model="donorEmail" placeholder="donor@example.com" />
-                    </flux:field>
+                    <div class="grid grid-cols-1 sm:grid-cols-3 gap-4">
+                        <flux:field>
+                            <flux:label>Donor Email <flux:badge size="sm" color="zinc">Optional</flux:badge></flux:label>
+                            <flux:input type="email" wire:model="donorEmail" placeholder="donor@example.com" />
+                        </flux:field>
 
-                    <flux:field>
-                        <flux:label>Restricted Fund <flux:badge size="sm" color="zinc">Optional</flux:badge></flux:label>
-                        <flux:select wire:model="restrictedFundId">
-                            <flux:select.option value="">None (unrestricted)</flux:select.option>
-                            @foreach ($this->activeFunds as $fund)
-                                <flux:select.option value="{{ $fund->id }}">{{ $fund->name }}</flux:select.option>
-                            @endforeach
-                        </flux:select>
-                    </flux:field>
+                        <flux:field>
+                            <flux:label>Restricted Fund <flux:badge size="sm" color="zinc">Optional</flux:badge></flux:label>
+                            <flux:select wire:model="restrictedFundId">
+                                <flux:select.option value="">None (unrestricted)</flux:select.option>
+                                @foreach ($this->activeFunds as $fund)
+                                    <flux:select.option value="{{ $fund->id }}">{{ $fund->name }}</flux:select.option>
+                                @endforeach
+                            </flux:select>
+                        </flux:field>
+
+                        <flux:field>
+                            <flux:label>Tags <flux:badge size="sm" color="zinc">Optional</flux:badge></flux:label>
+                            <div class="flex flex-wrap items-center gap-2">
+                                @foreach ($this->selectedTags as $tag)
+                                    <flux:badge color="{{ $tag['color'] }}" size="sm">
+                                        {{ $tag['name'] }}
+                                        <button wire:click="removeTag({{ $tag['id'] }})" class="ml-1 hover:opacity-70">×</button>
+                                    </flux:badge>
+                                @endforeach
+                                <flux:button
+                                    variant="outline"
+                                    size="sm"
+                                    wire:click="$dispatch('open-tag-search', { selectedTagIds: {{ json_encode($tagIds) }} })"
+                                >
+                                    + Add Tag
+                                </flux:button>
+                            </div>
+                        </flux:field>
+                    </div>
                 @endif
 
                 {{-- Expense-specific fields --}}
@@ -400,29 +421,50 @@ new class extends Component
                         </flux:field>
                     </div>
 
-                    <flux:field>
-                        <flux:label>Vendor <flux:badge size="sm" color="zinc">Optional</flux:badge></flux:label>
-                        <div class="flex items-center gap-2">
-                            @if ($vendorId)
-                                <flux:badge color="blue">{{ $vendorName }}</flux:badge>
-                                <flux:button variant="ghost" size="sm" wire:click="$set('vendorId', null)">Clear</flux:button>
-                            @else
-                                <flux:button variant="outline" size="sm" wire:click="$dispatch('open-vendor-search')">
-                                    Select Vendor
-                                </flux:button>
-                            @endif
-                        </div>
-                    </flux:field>
+                    <div class="grid grid-cols-1 sm:grid-cols-3 gap-4">
+                        <flux:field>
+                            <flux:label>Vendor <flux:badge size="sm" color="zinc">Optional</flux:badge></flux:label>
+                            <div class="flex items-center gap-2">
+                                @if ($vendorId)
+                                    <flux:badge color="blue">{{ $vendorName }}</flux:badge>
+                                    <flux:button variant="ghost" size="sm" wire:click="$set('vendorId', null)">Clear</flux:button>
+                                @else
+                                    <flux:button variant="outline" size="sm" wire:click="$dispatch('open-vendor-search')">
+                                        Select Vendor
+                                    </flux:button>
+                                @endif
+                            </div>
+                        </flux:field>
 
-                    <flux:field>
-                        <flux:label>Restricted Fund <flux:badge size="sm" color="zinc">Optional</flux:badge></flux:label>
-                        <flux:select wire:model="restrictedFundId">
-                            <flux:select.option value="">None</flux:select.option>
-                            @foreach ($this->activeFunds as $fund)
-                                <flux:select.option value="{{ $fund->id }}">{{ $fund->name }}</flux:select.option>
-                            @endforeach
-                        </flux:select>
-                    </flux:field>
+                        <flux:field>
+                            <flux:label>Restricted Fund <flux:badge size="sm" color="zinc">Optional</flux:badge></flux:label>
+                            <flux:select wire:model="restrictedFundId">
+                                <flux:select.option value="">None</flux:select.option>
+                                @foreach ($this->activeFunds as $fund)
+                                    <flux:select.option value="{{ $fund->id }}">{{ $fund->name }}</flux:select.option>
+                                @endforeach
+                            </flux:select>
+                        </flux:field>
+
+                        <flux:field>
+                            <flux:label>Tags <flux:badge size="sm" color="zinc">Optional</flux:badge></flux:label>
+                            <div class="flex flex-wrap items-center gap-2">
+                                @foreach ($this->selectedTags as $tag)
+                                    <flux:badge color="{{ $tag['color'] }}" size="sm">
+                                        {{ $tag['name'] }}
+                                        <button wire:click="removeTag({{ $tag['id'] }})" class="ml-1 hover:opacity-70">×</button>
+                                    </flux:badge>
+                                @endforeach
+                                <flux:button
+                                    variant="outline"
+                                    size="sm"
+                                    wire:click="$dispatch('open-tag-search', { selectedTagIds: {{ json_encode($tagIds) }} })"
+                                >
+                                    + Add Tag
+                                </flux:button>
+                            </div>
+                        </flux:field>
+                    </div>
                 @endif
 
                 {{-- Transfer-specific fields --}}
@@ -454,28 +496,6 @@ new class extends Component
                             <flux:error name="toAccountId" />
                         </flux:field>
                     </div>
-                @endif
-
-                {{-- Tags --}}
-                @if ($entryType !== 'transfer')
-                    <flux:field>
-                        <flux:label>Tags <flux:badge size="sm" color="zinc">Optional</flux:badge></flux:label>
-                        <div class="flex flex-wrap items-center gap-2">
-                            @foreach ($this->selectedTags as $tag)
-                                <flux:badge color="{{ $tag['color'] }}" size="sm">
-                                    {{ $tag['name'] }}
-                                    <button wire:click="removeTag({{ $tag['id'] }})" class="ml-1 hover:opacity-70">×</button>
-                                </flux:badge>
-                            @endforeach
-                            <flux:button
-                                variant="outline"
-                                size="sm"
-                                wire:click="$dispatch('open-tag-search', { selectedTagIds: {{ json_encode($tagIds) }} })"
-                            >
-                                + Add Tag
-                            </flux:button>
-                        </div>
-                    </flux:field>
                 @endif
             </div>
 

--- a/resources/views/livewire/meeting/department-report-cards.blade.php
+++ b/resources/views/livewire/meeting/department-report-cards.blade.php
@@ -95,7 +95,9 @@ new class extends Component {
                     <div class="flex items-center gap-3">
                         <flux:avatar size="sm" :src="$viewUser->avatarUrl()" />
                         <div>
-                            <flux:heading size="lg">{{ $viewUser->name }}</flux:heading>
+                            <flux:heading size="lg">
+                                <flux:link href="{{ route('profile.show', $viewUser) }}">{{ $viewUser->name }}</flux:link>
+                            </flux:heading>
                             @if($viewUser->staff_title)
                                 <flux:text variant="subtle" class="text-sm">{{ $viewUser->staff_title }}</flux:text>
                             @endif
@@ -111,7 +113,13 @@ new class extends Component {
                         @foreach($viewReport->answers->sortBy(fn ($a) => $a->question->sort_order) as $answer)
                             <div>
                                 <flux:text class="font-semibold text-sm">{{ $answer->question->question_text }}</flux:text>
-                                <flux:text class="mt-1">{{ $answer->answer ?: 'No response' }}</flux:text>
+                                @if($answer->answer)
+                                    <div class="prose prose-sm dark:prose-invert max-w-none mt-1">
+                                        {!! Str::markdown($answer->answer, ['html_input' => 'strip', 'allow_unsafe_links' => false]) !!}
+                                    </div>
+                                @else
+                                    <flux:text class="mt-1">No response</flux:text>
+                                @endif
                             </div>
                         @endforeach
                     @else

--- a/resources/views/livewire/meeting/payout-preview.blade.php
+++ b/resources/views/livewire/meeting/payout-preview.blade.php
@@ -5,6 +5,7 @@ use App\Enums\StaffRank;
 use App\Models\Meeting;
 use App\Models\MeetingReport;
 use App\Models\SiteConfig;
+use App\Models\User;
 use Livewire\Volt\Component;
 
 new class extends Component {
@@ -48,11 +49,19 @@ new class extends Component {
         $payoutAmounts = $this->payoutAmounts;
         $submittedUserIds = $this->submittedUserIds;
 
-        $rows = $attendees->map(function ($attendee) use ($payoutAmounts, $submittedUserIds) {
-            $rank = $attendee->staff_rank;
-            $attended = (bool) $attendee->pivot->attended;
-            $formSubmitted = in_array($attendee->id, $submittedUserIds);
-            $mcAccount = $attendee->primaryMinecraftAccount();
+        // Jr Crew don't attend meetings but are still eligible for payouts if
+        // they submitted their Staff Update Report. Include them separately.
+        $attendeeIds = $attendees->pluck('id');
+        $jrCrewSubmitters = User::where('staff_rank', StaffRank::JrCrew->value)
+            ->whereNotIn('id', $attendeeIds)
+            ->whereIn('id', $submittedUserIds)
+            ->orderBy('name')
+            ->get();
+
+        $buildRow = function (User $user, bool $attended) use ($payoutAmounts, $submittedUserIds) {
+            $rank = $user->staff_rank;
+            $formSubmitted = in_array($user->id, $submittedUserIds);
+            $mcAccount = $user->primaryMinecraftAccount();
             $amount = ($rank && $rank !== StaffRank::None) ? ($payoutAmounts[$rank->value] ?? 0) : 0;
 
             $eligible = true;
@@ -76,7 +85,7 @@ new class extends Component {
             }
 
             return [
-                'user'          => $attendee,
+                'user'          => $user,
                 'rank'          => $rank,
                 'attended'      => $attended,
                 'formSubmitted' => $formSubmitted,
@@ -84,9 +93,12 @@ new class extends Component {
                 'amount'        => $amount,
                 'eligible'      => $eligible,
                 'skipReason'    => $skipReason,
-                'department'    => $attendee->staff_department,
+                'department'    => $user->staff_department,
             ];
-        });
+        };
+
+        $rows = $attendees->map(fn ($a) => $buildRow($a, (bool) $a->pivot->attended))
+            ->concat($jrCrewSubmitters->map(fn ($a) => $buildRow($a, false)));
 
         // Sort by rank descending (Officer → Crew Member → Jr Crew), then name.
         return $rows->sortBy([

--- a/resources/views/livewire/reports/view-report.blade.php
+++ b/resources/views/livewire/reports/view-report.blade.php
@@ -15,7 +15,7 @@ new class extends Component
     public function mount(DisciplineReport $report): void
     {
         $this->authorize('view', $report);
-        $this->report = $report->load(['subject', 'reporter', 'publisher', 'category']);
+        $this->report = $report->load(['subject', 'reporter', 'publisher', 'category', 'violatedRules']);
     }
 
     #[Computed]
@@ -107,6 +107,17 @@ new class extends Component
                     {!! Str::markdown($report->actions_taken, ['html_input' => 'strip', 'allow_unsafe_links' => false]) !!}
                 </div>
             </div>
+
+            @if($report->violatedRules->isNotEmpty())
+                <div>
+                    <flux:text class="font-bold text-sm">Rules Violated</flux:text>
+                    <div class="mt-1 flex flex-wrap gap-1">
+                        @foreach($report->violatedRules as $rule)
+                            <flux:badge color="red" size="sm">{{ $rule->title }}</flux:badge>
+                        @endforeach
+                    </div>
+                </div>
+            @endif
         </div>
     </flux:card>
 

--- a/resources/views/livewire/rules-agreement-history.blade.php
+++ b/resources/views/livewire/rules-agreement-history.blade.php
@@ -1,11 +1,11 @@
 <?php
 
-use App\Models\User;
 use App\Models\UserRuleAgreement;
 use Livewire\Volt\Component;
 use Livewire\WithPagination;
 
-new class extends Component {
+new class extends Component
+{
     use WithPagination;
 
     public string $search = '';
@@ -19,8 +19,10 @@ new class extends Component {
     {
         return UserRuleAgreement::with(['user', 'ruleVersion'])
             ->when($this->search, function ($q) {
-                $q->whereHas('user', fn ($uq) => $uq->where('name', 'like', '%'.$this->search.'%')
-                    ->orWhere('email', 'like', '%'.$this->search.'%'));
+                $q->whereHas('user', fn ($uq) => $uq->where(function ($inner) {
+                    $inner->where('name', 'like', '%'.$this->search.'%')
+                        ->orWhere('email', 'like', '%'.$this->search.'%');
+                }));
             })
             ->orderByDesc('agreed_at')
             ->paginate(25);

--- a/resources/views/livewire/rules-agreement-history.blade.php
+++ b/resources/views/livewire/rules-agreement-history.blade.php
@@ -1,0 +1,67 @@
+<?php
+
+use App\Models\User;
+use App\Models\UserRuleAgreement;
+use Livewire\Volt\Component;
+use Livewire\WithPagination;
+
+new class extends Component {
+    use WithPagination;
+
+    public string $search = '';
+
+    public function updatedSearch(): void
+    {
+        $this->resetPage();
+    }
+
+    public function getAgreements()
+    {
+        return UserRuleAgreement::with(['user', 'ruleVersion'])
+            ->when($this->search, function ($q) {
+                $q->whereHas('user', fn ($uq) => $uq->where('name', 'like', '%'.$this->search.'%')
+                    ->orWhere('email', 'like', '%'.$this->search.'%'));
+            })
+            ->orderByDesc('agreed_at')
+            ->paginate(25);
+    }
+}; ?>
+
+<div class="space-y-4">
+    <flux:heading size="xl">Rules Agreement History</flux:heading>
+    <flux:text variant="subtle">Full record of which users have agreed to which rules versions.</flux:text>
+
+    <flux:input wire:model.live.debounce="search" placeholder="Search by name or email..." icon="magnifying-glass" class="max-w-xs" />
+
+    <flux:table>
+        <flux:table.columns>
+            <flux:table.column>User</flux:table.column>
+            <flux:table.column>Version</flux:table.column>
+            <flux:table.column>Agreed At</flux:table.column>
+        </flux:table.columns>
+        <flux:table.rows>
+            @forelse ($this->getAgreements() as $agreement)
+                <flux:table.row wire:key="agreement-{{ $agreement->id }}">
+                    <flux:table.cell>
+                        <div class="font-medium">{{ $agreement->user?->name ?? '—' }}</div>
+                        <div class="text-xs text-zinc-400">{{ $agreement->user?->email ?? '' }}</div>
+                    </flux:table.cell>
+                    <flux:table.cell>
+                        <flux:badge variant="primary" size="sm">v{{ $agreement->ruleVersion?->version_number ?? '?' }}</flux:badge>
+                    </flux:table.cell>
+                    <flux:table.cell>
+                        {{ $agreement->agreed_at?->format('M j, Y g:ia') ?? '—' }}
+                    </flux:table.cell>
+                </flux:table.row>
+            @empty
+                <flux:table.row>
+                    <flux:table.cell colspan="3">
+                        <flux:text variant="subtle">No agreement records found.</flux:text>
+                    </flux:table.cell>
+                </flux:table.row>
+            @endforelse
+        </flux:table.rows>
+    </flux:table>
+
+    {{ $this->getAgreements()->links() }}
+</div>

--- a/resources/views/livewire/rules-agreement-history.blade.php
+++ b/resources/views/livewire/rules-agreement-history.blade.php
@@ -10,6 +10,11 @@ new class extends Component
 
     public string $search = '';
 
+    public function mount(): void
+    {
+        $this->authorize('rules.manage');
+    }
+
     public function updatedSearch(): void
     {
         $this->resetPage();

--- a/resources/views/livewire/rules-compliance-list.blade.php
+++ b/resources/views/livewire/rules-compliance-list.blade.php
@@ -6,6 +6,11 @@ use App\Models\User;
 use Livewire\Volt\Component;
 
 new class extends Component {
+    public function mount(): void
+    {
+        $this->authorize('rules.manage');
+    }
+
     public function getComplianceData(): array
     {
         $version = RuleVersion::currentPublished();

--- a/resources/views/livewire/rules-compliance-list.blade.php
+++ b/resources/views/livewire/rules-compliance-list.blade.php
@@ -1,0 +1,86 @@
+<?php
+
+use App\Enums\MembershipLevel;
+use App\Models\RuleVersion;
+use App\Models\User;
+use Livewire\Volt\Component;
+
+new class extends Component {
+    public function getComplianceData(): array
+    {
+        $version = RuleVersion::currentPublished();
+
+        if (! $version) {
+            return ['version' => null, 'users' => collect()];
+        }
+
+        $agreedUserIds = $version->agreements()->pluck('user_id');
+
+        $users = User::whereNotIn('id', $agreedUserIds)
+            ->where('membership_level', '>=', MembershipLevel::Stowaway->value)
+            ->orderBy('name')
+            ->get();
+
+        return ['version' => $version, 'users' => $users];
+    }
+}; ?>
+
+<div class="space-y-4">
+    <flux:heading size="xl">Rules Compliance</flux:heading>
+    <flux:text variant="subtle">Users who have not yet agreed to the current published version.</flux:text>
+
+    @php $data = $this->getComplianceData(); @endphp
+
+    @if (!$data['version'])
+        <flux:text variant="subtle">No published rules version found.</flux:text>
+    @elseif ($data['users']->isEmpty())
+        <flux:text class="text-green-400">All members have agreed to the current rules version.</flux:text>
+    @else
+        @php $daysSincePublish = (int) $data['version']->published_at->diffInDays(now()); @endphp
+        <flux:text variant="subtle" class="text-sm">
+            Version {{ $data['version']->version_number }} published
+            {{ $data['version']->published_at->format('M j, Y') }}
+            ({{ $daysSincePublish }} {{ Str::plural('day', $daysSincePublish) }} ago)
+            — {{ $data['users']->count() }} {{ Str::plural('user', $data['users']->count()) }} pending
+        </flux:text>
+
+        <flux:table>
+            <flux:table.columns>
+                <flux:table.column>User</flux:table.column>
+                <flux:table.column>Level</flux:table.column>
+                <flux:table.column>Days Overdue</flux:table.column>
+                <flux:table.column>Reminder Sent</flux:table.column>
+            </flux:table.columns>
+            <flux:table.rows>
+                @foreach ($data['users'] as $user)
+                    <flux:table.row wire:key="compliance-{{ $user->id }}">
+                        <flux:table.cell>
+                            <div class="font-medium">{{ $user->name }}</div>
+                            <div class="text-xs text-zinc-400">{{ $user->email }}</div>
+                        </flux:table.cell>
+                        <flux:table.cell>
+                            <flux:badge size="sm" variant="outline">{{ $user->membership_level->label() }}</flux:badge>
+                        </flux:table.cell>
+                        <flux:table.cell>
+                            @php $days = $daysSincePublish; @endphp
+                            @if ($days >= 28)
+                                <flux:badge color="red" size="sm">{{ $days }}d — Brig Eligible</flux:badge>
+                            @elseif ($days >= 14)
+                                <flux:badge color="amber" size="sm">{{ $days }}d — Reminder Due</flux:badge>
+                            @else
+                                <span class="text-zinc-400 text-sm">{{ $days }}d</span>
+                            @endif
+                        </flux:table.cell>
+                        <flux:table.cell>
+                            @if ($user->rules_reminder_sent_at)
+                                <span class="text-zinc-300 text-sm">{{ $user->rules_reminder_sent_at->format('M j, Y') }}</span>
+                            @else
+                                <span class="text-zinc-500 text-sm">Not sent</span>
+                            @endif
+                        </flux:table.cell>
+                    </flux:table.row>
+                @endforeach
+            </flux:table.rows>
+        </flux:table>
+    @endif
+</div>

--- a/resources/views/livewire/rules-page.blade.php
+++ b/resources/views/livewire/rules-page.blade.php
@@ -8,10 +8,16 @@ use Livewire\Volt\Component;
 
 new class extends Component {
     public array $checked = [];
+    public array $childAgreements = [];
 
     public function getAgreementStatus(): array
     {
         return GetRulesAgreementStatus::run(auth()->user());
+    }
+
+    public function getUnagreedChildrenProperty()
+    {
+        return auth()->user()->unagreedChildren();
     }
 
     public function allChecked(): bool
@@ -46,6 +52,36 @@ new class extends Component {
 
         $this->redirect(route('dashboard'), navigate: true);
     }
+
+    public function agreeForChildren(): void
+    {
+        $selectedIds = array_keys(array_filter($this->childAgreements));
+
+        if (empty($selectedIds)) {
+            Flux::toast('Please select at least one child account.', 'No Selection', variant: 'danger');
+
+            return;
+        }
+
+        $parent = auth()->user();
+        $unagreedChildren = $this->unagreedChildren;
+
+        foreach ($selectedIds as $childId) {
+            $child = $unagreedChildren->firstWhere('id', (int) $childId);
+            if ($child) {
+                AgreeToRulesVersion::run($child, $parent);
+            }
+        }
+
+        $count = count($selectedIds);
+        Flux::toast("Rules accepted for {$count} child account(s).", 'Proxy Agreement Submitted', variant: 'success');
+
+        $this->childAgreements = [];
+
+        if ($parent->unagreedChildren()->isEmpty()) {
+            $this->redirect(route('dashboard'), navigate: true);
+        }
+    }
 }; ?>
 
 <x-layouts.app>
@@ -62,6 +98,14 @@ new class extends Component {
                 <flux:heading size="lg" class="text-amber-300">Rules Agreement Required</flux:heading>
                 <flux:text class="mt-1 text-amber-200/80">
                     Please read and check each rule below, then click the agree button to continue.
+                </flux:text>
+            </div>
+        @elseif ($status['has_agreed'] && $this->unagreedChildren->isNotEmpty())
+            <div class="bg-blue-950/30 border border-blue-500/40 rounded-lg px-6 py-4">
+                <flux:heading size="lg" class="text-blue-300">Proxy Agreement Required</flux:heading>
+                <flux:text class="mt-1 text-blue-200/80">
+                    You have agreed to the rules, but some of your linked child accounts have not.
+                    Scroll down to complete proxy agreement on their behalf.
                 </flux:text>
             </div>
         @endif
@@ -152,6 +196,41 @@ new class extends Component {
                 <flux:text variant="subtle">You have agreed to the current version of the rules.</flux:text>
                 <div class="mt-3">
                     <flux:button href="{{ route('dashboard') }}" variant="ghost">Back to Dashboard</flux:button>
+                </div>
+            </div>
+        @endif
+
+        @if ($status['has_agreed'] && $this->unagreedChildren->isNotEmpty())
+            <div class="bg-blue-950/30 border border-blue-500/40 rounded-lg px-6 py-6 space-y-4">
+                <div>
+                    <flux:heading size="lg" class="text-blue-300">Proxy Agreement Required</flux:heading>
+                    <flux:text class="mt-1 text-blue-200/80">
+                        The following child accounts linked to yours have not yet agreed to the current rules.
+                        As their parent or guardian, you may agree on their behalf.
+                    </flux:text>
+                </div>
+
+                <div class="space-y-2">
+                    @foreach ($this->unagreedChildren as $child)
+                        <label wire:key="child-{{ $child->id }}" class="flex items-center gap-3 cursor-pointer bg-zinc-800/50 rounded-lg px-4 py-3 hover:bg-zinc-800/80 transition">
+                            <input type="checkbox" wire:model="childAgreements.{{ $child->id }}"
+                                class="w-4 h-4 rounded border-zinc-600 bg-zinc-700 text-indigo-500 focus:ring-indigo-500" />
+                            <flux:avatar size="xs" :src="$child->avatarUrl()" :initials="$child->initials()" />
+                            <div>
+                                <flux:text class="font-semibold text-sm">{{ $child->name }}</flux:text>
+                                <flux:text variant="subtle" class="text-xs">{{ $child->membership_level->label() }}</flux:text>
+                            </div>
+                        </label>
+                    @endforeach
+                </div>
+
+                <div class="flex items-center justify-between pt-2">
+                    <flux:text variant="subtle" class="text-xs">
+                        By submitting, you confirm you have read the rules on behalf of the selected child account(s).
+                    </flux:text>
+                    <flux:button wire:click="agreeForChildren" variant="primary" color="blue">
+                        Submit Proxy Agreement
+                    </flux:button>
                 </div>
             </div>
         @endif

--- a/resources/views/livewire/rules-page.blade.php
+++ b/resources/views/livewire/rules-page.blade.php
@@ -1,0 +1,160 @@
+<?php
+
+use App\Actions\AgreeToRulesVersion;
+use App\Actions\GetRulesAgreementStatus;
+use App\Models\SiteConfig;
+use Flux\Flux;
+use Livewire\Volt\Component;
+
+new class extends Component {
+    public array $checked = [];
+
+    public function getAgreementStatus(): array
+    {
+        return GetRulesAgreementStatus::run(auth()->user());
+    }
+
+    public function allChecked(): bool
+    {
+        $status = $this->getAgreementStatus();
+        $totalRules = $status['categories']->sum(fn ($cat) => $cat->rules->count());
+
+        if ($totalRules === 0) {
+            return false;
+        }
+
+        return count(array_filter($this->checked)) >= $totalRules;
+    }
+
+    public function agreeToRules(): void
+    {
+        $status = $this->getAgreementStatus();
+
+        if ($status['has_agreed']) {
+            return;
+        }
+
+        if (! $this->allChecked()) {
+            Flux::toast('Please check all rules before submitting.', 'Not Ready', variant: 'danger');
+
+            return;
+        }
+
+        AgreeToRulesVersion::run(auth()->user(), auth()->user());
+
+        Flux::toast('Rules accepted successfully!', 'Success', variant: 'success');
+
+        $this->redirect(route('dashboard'), navigate: true);
+    }
+}; ?>
+
+<x-layouts.app>
+    @php
+        $status = $this->getAgreementStatus();
+        $header = \App\Models\SiteConfig::getValue('rules_header', '');
+        $footer = \App\Models\SiteConfig::getValue('rules_footer', '');
+    @endphp
+
+    <div class="max-w-3xl mx-auto py-8 px-4 space-y-8">
+
+        @if (!$status['has_agreed'] && $status['current_version'])
+            <div class="bg-amber-950/30 border border-amber-500/40 rounded-lg px-6 py-4">
+                <flux:heading size="lg" class="text-amber-300">Rules Agreement Required</flux:heading>
+                <flux:text class="mt-1 text-amber-200/80">
+                    Please read and check each rule below, then click the agree button to continue.
+                </flux:text>
+            </div>
+        @endif
+
+        @if ($header)
+            <div class="prose prose-invert max-w-none">
+                {!! Str::markdown($header, ['html_input' => 'strip', 'allow_unsafe_links' => false]) !!}
+            </div>
+        @endif
+
+        @foreach ($status['categories'] as $category)
+            <div class="space-y-3">
+                <flux:heading size="lg">{{ $category->name }}</flux:heading>
+
+                @foreach ($category->rules as $rule)
+                    <div class="bg-zinc-800/60 border border-zinc-700/50 rounded-lg p-4 space-y-2">
+                        <div class="flex items-start gap-3">
+                            @if (!$status['has_agreed'])
+                                <div class="pt-0.5">
+                                    <input
+                                        type="checkbox"
+                                        wire:model="checked.{{ $rule->id }}"
+                                        id="rule-{{ $rule->id }}"
+                                        class="w-4 h-4 rounded border-zinc-600 bg-zinc-700 text-indigo-500 focus:ring-indigo-500"
+                                    />
+                                </div>
+                            @endif
+
+                            <div class="flex-1 min-w-0">
+                                <div class="flex flex-wrap items-center gap-2 mb-1">
+                                    <label for="rule-{{ $rule->id }}" class="font-semibold text-zinc-100 cursor-pointer">
+                                        {{ $rule->title }}
+                                    </label>
+
+                                    @if ($rule->agreement_status === 'new')
+                                        <flux:badge color="green" size="sm">NEW</flux:badge>
+                                    @elseif ($rule->agreement_status === 'updated')
+                                        <flux:badge color="amber" size="sm">UPDATED</flux:badge>
+                                    @endif
+                                </div>
+
+                                <div class="prose prose-sm prose-invert max-w-none text-zinc-300">
+                                    {!! Str::markdown($rule->description, ['html_input' => 'strip', 'allow_unsafe_links' => false]) !!}
+                                </div>
+
+                                @if ($rule->agreement_status === 'updated' && $rule->previous_rule)
+                                    <details class="mt-3">
+                                        <summary class="text-xs text-zinc-400 cursor-pointer hover:text-zinc-200 select-none">
+                                            View previous version of this rule
+                                        </summary>
+                                        <div class="mt-2 pl-3 border-l-2 border-zinc-600 space-y-1">
+                                            <flux:text variant="subtle" class="text-xs font-medium uppercase tracking-wide">Previous</flux:text>
+                                            <div class="prose prose-sm prose-invert max-w-none text-zinc-400">
+                                                {!! Str::markdown($rule->previous_rule->description, ['html_input' => 'strip', 'allow_unsafe_links' => false]) !!}
+                                            </div>
+                                        </div>
+                                    </details>
+                                @endif
+                            </div>
+                        </div>
+                    </div>
+                @endforeach
+            </div>
+        @endforeach
+
+        @if ($footer)
+            <div class="prose prose-invert max-w-none text-zinc-400">
+                {!! Str::markdown($footer, ['html_input' => 'strip', 'allow_unsafe_links' => false]) !!}
+            </div>
+        @endif
+
+        @if (!$status['has_agreed'] && $status['current_version'])
+            <div class="sticky bottom-4 bg-zinc-900/95 backdrop-blur border border-zinc-700 rounded-lg px-6 py-4 flex items-center justify-between shadow-lg">
+                <flux:text variant="subtle" class="text-sm">
+                    Check all rules above to enable the agree button.
+                </flux:text>
+                <flux:button
+                    wire:click="agreeToRules"
+                    variant="primary"
+                    color="amber"
+                    :disabled="!$this->allChecked()"
+                >
+                    I Have Read and Agree to All Rules
+                </flux:button>
+            </div>
+        @elseif ($status['has_agreed'])
+            <div class="text-center py-4">
+                <flux:text variant="subtle">You have agreed to the current version of the rules.</flux:text>
+                <div class="mt-3">
+                    <flux:button href="{{ route('dashboard') }}" variant="ghost">Back to Dashboard</flux:button>
+                </div>
+            </div>
+        @endif
+
+    </div>
+</x-layouts.app>

--- a/resources/views/livewire/rules-page.blade.php
+++ b/resources/views/livewire/rules-page.blade.php
@@ -24,13 +24,13 @@ new #[Layout('components.layouts.app')] class extends Component {
     public function allChecked(): bool
     {
         $status = $this->getAgreementStatus();
-        $totalRules = $status['categories']->sum(fn ($cat) => $cat->rules->count());
+        $totalCategories = $status['categories']->count();
 
-        if ($totalRules === 0) {
+        if ($totalCategories === 0) {
             return false;
         }
 
-        return count(array_filter($this->checked)) >= $totalRules;
+        return count(array_filter($this->checked)) >= $totalCategories;
     }
 
     public function agreeToRules(): void
@@ -97,7 +97,7 @@ new #[Layout('components.layouts.app')] class extends Component {
             <div class="bg-amber-950/30 border border-amber-500/40 rounded-lg px-6 py-4">
                 <flux:heading size="lg" class="text-amber-300">Rules Agreement Required</flux:heading>
                 <flux:text class="mt-1 text-amber-200/80">
-                    Please read and check each rule below, then click the agree button to continue.
+                    Please read each category below and check the agreement box at the bottom of each category, then click the agree button to continue.
                 </flux:text>
             </div>
         @elseif ($status['has_agreed'] && $this->unagreedChildren->isNotEmpty())
@@ -149,15 +149,15 @@ new #[Layout('components.layouts.app')] class extends Component {
                                 </div>
                             </details>
                         @endif
-
-                        @if (!$status['has_agreed'])
-                            <div class="flex items-center gap-3 pt-2 border-t border-zinc-700/50">
-                                <flux:switch wire:model.live="checked.{{ $rule->id }}" />
-                                <flux:text class="text-sm">I have read and agree to this rule</flux:text>
-                            </div>
-                        @endif
                     </div>
                 @endforeach
+
+                @if (!$status['has_agreed'])
+                    <div class="flex items-center gap-3 p-4 bg-zinc-800/40 border border-zinc-700/50 rounded-lg">
+                        <flux:switch wire:model.live="checked.{{ $category->id }}" />
+                        <flux:text class="text-sm">I have read and agree to all rules in the <span class="font-semibold text-zinc-100">{{ $category->name }}</span> category</flux:text>
+                    </div>
+                @endif
             </div>
         @endforeach
 
@@ -170,7 +170,7 @@ new #[Layout('components.layouts.app')] class extends Component {
         @if (!$status['has_agreed'] && $status['current_version'])
             <div class="sticky bottom-4 bg-zinc-900/95 backdrop-blur border border-zinc-700 rounded-lg px-6 py-4 flex items-center justify-between shadow-lg">
                 <flux:text variant="subtle" class="text-sm">
-                    Check all rules above to enable the agree button.
+                    Check all categories above to enable the agree button.
                 </flux:text>
                 <flux:button
                     wire:click="agreeToRules"

--- a/resources/views/livewire/rules-page.blade.php
+++ b/resources/views/livewire/rules-page.blade.php
@@ -4,9 +4,10 @@ use App\Actions\AgreeToRulesVersion;
 use App\Actions\GetRulesAgreementStatus;
 use App\Models\SiteConfig;
 use Flux\Flux;
+use Livewire\Attributes\Layout;
 use Livewire\Volt\Component;
 
-new class extends Component {
+new #[Layout('components.layouts.app')] class extends Component {
     public array $checked = [];
     public array $childAgreements = [];
 
@@ -84,14 +85,13 @@ new class extends Component {
     }
 }; ?>
 
-<x-layouts.app>
-    @php
-        $status = $this->getAgreementStatus();
-        $header = \App\Models\SiteConfig::getValue('rules_header', '');
-        $footer = \App\Models\SiteConfig::getValue('rules_footer', '');
-    @endphp
+@php
+    $status = $this->getAgreementStatus();
+    $header = \App\Models\SiteConfig::getValue('rules_header', '');
+    $footer = \App\Models\SiteConfig::getValue('rules_footer', '');
+@endphp
 
-    <div class="max-w-3xl mx-auto py-8 px-4 space-y-8">
+<div class="max-w-3xl mx-auto py-8 px-4 space-y-8">
 
         @if (!$status['has_agreed'] && $status['current_version'])
             <div class="bg-amber-950/30 border border-amber-500/40 rounded-lg px-6 py-4">
@@ -235,5 +235,4 @@ new class extends Component {
             </div>
         @endif
 
-    </div>
-</x-layouts.app>
+</div>

--- a/resources/views/livewire/rules-page.blade.php
+++ b/resources/views/livewire/rules-page.blade.php
@@ -117,17 +117,17 @@ new #[Layout('components.layouts.app')] class extends Component {
         @endif
 
         @foreach ($status['categories'] as $category)
-            <div class="space-y-3">
+            <div wire:key="rules-category-{{ $category->id }}" class="space-y-3">
                 <flux:heading size="lg">{{ $category->name }}</flux:heading>
 
                 @foreach ($category->rules as $rule)
-                    <div class="bg-zinc-800/60 border border-zinc-700/50 rounded-lg p-4 space-y-2">
+                    <div wire:key="rules-rule-{{ $rule->id }}" class="bg-zinc-800/60 border border-zinc-700/50 rounded-lg p-4 space-y-2">
                         <div class="flex items-start gap-3">
                             @if (!$status['has_agreed'])
                                 <div class="pt-0.5">
                                     <input
                                         type="checkbox"
-                                        wire:model="checked.{{ $rule->id }}"
+                                        wire:model.live="checked.{{ $rule->id }}"
                                         id="rule-{{ $rule->id }}"
                                         class="w-4 h-4 rounded border-zinc-600 bg-zinc-700 text-indigo-500 focus:ring-indigo-500"
                                     />

--- a/resources/views/livewire/rules-page.blade.php
+++ b/resources/views/livewire/rules-page.blade.php
@@ -181,7 +181,7 @@ new #[Layout('components.layouts.app')] class extends Component {
                     I Have Read and Agree to All Rules
                 </flux:button>
             </div>
-        @elseif ($status['has_agreed'])
+        @elseif ($status['has_agreed'] && $this->unagreedChildren->isEmpty())
             <div class="text-center py-4">
                 <flux:text variant="subtle">You have agreed to the current version of the rules.</flux:text>
                 <div class="mt-3">

--- a/resources/views/livewire/rules-page.blade.php
+++ b/resources/views/livewire/rules-page.blade.php
@@ -121,51 +121,41 @@ new #[Layout('components.layouts.app')] class extends Component {
                 <flux:heading size="lg">{{ $category->name }}</flux:heading>
 
                 @foreach ($category->rules as $rule)
-                    <div wire:key="rules-rule-{{ $rule->id }}" class="bg-zinc-800/60 border border-zinc-700/50 rounded-lg p-4 space-y-2">
-                        <div class="flex items-start gap-3">
-                            @if (!$status['has_agreed'])
-                                <div class="pt-0.5">
-                                    <input
-                                        type="checkbox"
-                                        wire:model.live="checked.{{ $rule->id }}"
-                                        id="rule-{{ $rule->id }}"
-                                        class="w-4 h-4 rounded border-zinc-600 bg-zinc-700 text-indigo-500 focus:ring-indigo-500"
-                                    />
-                                </div>
+                    <div wire:key="rules-rule-{{ $rule->id }}" class="bg-zinc-800/60 border border-zinc-700/50 rounded-lg p-4 space-y-3">
+                        <div class="flex flex-wrap items-center gap-2">
+                            <span class="font-semibold text-zinc-100">{{ $rule->title }}</span>
+
+                            @if ($rule->agreement_status === 'new')
+                                <flux:badge color="green" size="sm">NEW</flux:badge>
+                            @elseif ($rule->agreement_status === 'updated')
+                                <flux:badge color="amber" size="sm">UPDATED</flux:badge>
                             @endif
-
-                            <div class="flex-1 min-w-0">
-                                <div class="flex flex-wrap items-center gap-2 mb-1">
-                                    <label for="rule-{{ $rule->id }}" class="font-semibold text-zinc-100 cursor-pointer">
-                                        {{ $rule->title }}
-                                    </label>
-
-                                    @if ($rule->agreement_status === 'new')
-                                        <flux:badge color="green" size="sm">NEW</flux:badge>
-                                    @elseif ($rule->agreement_status === 'updated')
-                                        <flux:badge color="amber" size="sm">UPDATED</flux:badge>
-                                    @endif
-                                </div>
-
-                                <div class="prose prose-sm prose-invert max-w-none text-zinc-300">
-                                    {!! Str::markdown($rule->description, ['html_input' => 'strip', 'allow_unsafe_links' => false]) !!}
-                                </div>
-
-                                @if ($rule->agreement_status === 'updated' && $rule->previous_rule)
-                                    <details class="mt-3">
-                                        <summary class="text-xs text-zinc-400 cursor-pointer hover:text-zinc-200 select-none">
-                                            View previous version of this rule
-                                        </summary>
-                                        <div class="mt-2 pl-3 border-l-2 border-zinc-600 space-y-1">
-                                            <flux:text variant="subtle" class="text-xs font-medium uppercase tracking-wide">Previous</flux:text>
-                                            <div class="prose prose-sm prose-invert max-w-none text-zinc-400">
-                                                {!! Str::markdown($rule->previous_rule->description, ['html_input' => 'strip', 'allow_unsafe_links' => false]) !!}
-                                            </div>
-                                        </div>
-                                    </details>
-                                @endif
-                            </div>
                         </div>
+
+                        <div class="prose prose-sm prose-invert max-w-none text-zinc-300">
+                            {!! Str::markdown($rule->description, ['html_input' => 'strip', 'allow_unsafe_links' => false]) !!}
+                        </div>
+
+                        @if ($rule->agreement_status === 'updated' && $rule->previous_rule)
+                            <details class="mt-1">
+                                <summary class="text-xs text-zinc-400 cursor-pointer hover:text-zinc-200 select-none">
+                                    View previous version of this rule
+                                </summary>
+                                <div class="mt-2 pl-3 border-l-2 border-zinc-600 space-y-1">
+                                    <flux:text variant="subtle" class="text-xs font-medium uppercase tracking-wide">Previous</flux:text>
+                                    <div class="prose prose-sm prose-invert max-w-none text-zinc-400">
+                                        {!! Str::markdown($rule->previous_rule->description, ['html_input' => 'strip', 'allow_unsafe_links' => false]) !!}
+                                    </div>
+                                </div>
+                            </details>
+                        @endif
+
+                        @if (!$status['has_agreed'])
+                            <div class="flex items-center gap-3 pt-2 border-t border-zinc-700/50">
+                                <flux:switch wire:model.live="checked.{{ $rule->id }}" />
+                                <flux:text class="text-sm">I have read and agree to this rule</flux:text>
+                            </div>
+                        @endif
                     </div>
                 @endforeach
             </div>

--- a/resources/views/livewire/rules-version-history.blade.php
+++ b/resources/views/livewire/rules-version-history.blade.php
@@ -1,0 +1,52 @@
+<?php
+
+use App\Models\RuleVersion;
+use Livewire\Volt\Component;
+
+new class extends Component {
+    public function getVersions()
+    {
+        return RuleVersion::with(['createdBy', 'approvedBy'])
+            ->where('status', 'published')
+            ->orderByDesc('version_number')
+            ->get();
+    }
+}; ?>
+
+<div class="space-y-4">
+    <flux:heading size="xl">Rules Version History</flux:heading>
+    <flux:text variant="subtle">All published versions of the community rules.</flux:text>
+
+    <flux:table>
+        <flux:table.columns>
+            <flux:table.column>Version</flux:table.column>
+            <flux:table.column>Published</flux:table.column>
+            <flux:table.column>Created By</flux:table.column>
+            <flux:table.column>Approved By</flux:table.column>
+        </flux:table.columns>
+        <flux:table.rows>
+            @forelse($this->getVersions() as $version)
+                <flux:table.row wire:key="version-{{ $version->id }}">
+                    <flux:table.cell>
+                        <flux:badge variant="primary" size="sm">v{{ $version->version_number }}</flux:badge>
+                    </flux:table.cell>
+                    <flux:table.cell>
+                        {{ $version->published_at?->format('M j, Y') ?? '—' }}
+                    </flux:table.cell>
+                    <flux:table.cell>
+                        {{ $version->createdBy?->name ?? '—' }}
+                    </flux:table.cell>
+                    <flux:table.cell>
+                        {{ $version->approvedBy?->name ?? '—' }}
+                    </flux:table.cell>
+                </flux:table.row>
+            @empty
+                <flux:table.row>
+                    <flux:table.cell colspan="4">
+                        <flux:text variant="subtle">No published versions yet.</flux:text>
+                    </flux:table.cell>
+                </flux:table.row>
+            @endforelse
+        </flux:table.rows>
+    </flux:table>
+</div>

--- a/resources/views/livewire/users/discipline-reports-card.blade.php
+++ b/resources/views/livewire/users/discipline-reports-card.blade.php
@@ -303,7 +303,6 @@ new class extends Component {
                 <flux:table.columns>
                     <flux:table.column>Date</flux:table.column>
                     <flux:table.column>Category</flux:table.column>
-                    <flux:table.column>Description</flux:table.column>
                     <flux:table.column>Severity</flux:table.column>
                     <flux:table.column></flux:table.column>
                 </flux:table.columns>
@@ -314,20 +313,17 @@ new class extends Component {
                                 {{ ($report->published_at ?? $report->created_at)->format('M j, Y') }}
                             </flux:table.cell>
                             <flux:table.cell>
-                                @if($report->category)
-                                    <flux:badge color="{{ $report->category->color }}" size="sm">
-                                        {{ $report->category->name }}
-                                    </flux:badge>
-                                @else
-                                    <flux:text variant="subtle">—</flux:text>
-                                @endif
-                            </flux:table.cell>
-                            <flux:table.cell>
-                                <div class="flex items-center gap-2">
+                                <div class="flex flex-wrap items-center gap-1">
                                     @if($report->isDraft())
                                         <flux:badge color="amber" size="sm">Draft</flux:badge>
                                     @endif
-                                    <flux:text class="truncate max-w-xs">{{ Str::limit($report->description, 60) }}</flux:text>
+                                    @if($report->category)
+                                        <flux:badge color="{{ $report->category->color }}" size="sm">
+                                            {{ $report->category->name }}
+                                        </flux:badge>
+                                    @else
+                                        <flux:text variant="subtle">—</flux:text>
+                                    @endif
                                 </div>
                             </flux:table.cell>
                             <flux:table.cell>

--- a/resources/views/livewire/users/discipline-reports-card.blade.php
+++ b/resources/views/livewire/users/discipline-reports-card.blade.php
@@ -9,6 +9,7 @@ use App\Enums\ReportSeverity;
 use App\Enums\StaffRank;
 use App\Models\DisciplineReport;
 use App\Models\ReportCategory;
+use App\Models\Rule as RuleModel;
 use App\Models\Thread;
 use App\Models\User;
 use Flux\Flux;
@@ -31,6 +32,7 @@ new class extends Component {
     public string $formActionsTaken = '';
     public string $formSeverity = '';
     public string $formCategory = '';
+    public array $formRuleIds = [];
 
     // Editing state
     #[Locked]
@@ -86,6 +88,15 @@ new class extends Component {
         return ReportCategory::orderBy('name')->get();
     }
 
+    public function getActiveRulesProperty()
+    {
+        return RuleModel::where('status', 'active')
+            ->with('ruleCategory')
+            ->orderBy('sort_order')
+            ->get()
+            ->groupBy(fn ($rule) => $rule->ruleCategory?->name ?? 'Uncategorized');
+    }
+
     public function openCreateModal(): void
     {
         $this->authorize('create', DisciplineReport::class);
@@ -118,6 +129,7 @@ new class extends Component {
             ReportSeverity::from($this->formSeverity),
             $this->formWitnesses ?: null,
             $category,
+            array_map('intval', $this->formRuleIds),
         );
 
         $this->resetForm();
@@ -137,6 +149,7 @@ new class extends Component {
         $this->formActionsTaken = $report->actions_taken;
         $this->formSeverity = $report->severity->value;
         $this->formCategory = (string) ($report->report_category_id ?? '');
+        $this->formRuleIds = $report->violatedRules()->pluck('rules.id')->map(fn ($id) => (string) $id)->all();
 
         Flux::modal('edit-report-modal')->show();
     }
@@ -165,6 +178,7 @@ new class extends Component {
             ReportSeverity::from($this->formSeverity),
             $this->formWitnesses ?: null,
             $category,
+            array_map('intval', $this->formRuleIds),
         );
 
         $this->resetForm();
@@ -189,7 +203,7 @@ new class extends Component {
             return null;
         }
 
-        return DisciplineReport::with(['subject', 'reporter', 'publisher', 'category'])
+        return DisciplineReport::with(['subject', 'reporter', 'publisher', 'category', 'violatedRules'])
             ->find($this->viewingReportId);
     }
 
@@ -255,6 +269,7 @@ new class extends Component {
         $this->formActionsTaken = '';
         $this->formSeverity = '';
         $this->formCategory = '';
+        $this->formRuleIds = [];
     }
 }; ?>
 
@@ -399,6 +414,28 @@ new class extends Component {
                 <flux:error name="formSeverity" />
             </flux:field>
 
+            @if($this->activeRules->isNotEmpty())
+                <flux:field>
+                    <flux:label>Rules Violated</flux:label>
+                    <div class="space-y-3 mt-1 max-h-48 overflow-y-auto border border-zinc-200 dark:border-zinc-700 rounded-lg p-3">
+                        @foreach($this->activeRules as $categoryName => $rules)
+                            <div>
+                                <flux:text class="text-xs font-semibold text-zinc-500 uppercase tracking-wide mb-1">{{ $categoryName }}</flux:text>
+                                <div class="space-y-1">
+                                    @foreach($rules as $rule)
+                                        <label wire:key="create-rule-{{ $rule->id }}" class="flex items-start gap-2 cursor-pointer">
+                                            <input type="checkbox" wire:model="formRuleIds" value="{{ $rule->id }}" class="mt-0.5 rounded border-zinc-300 dark:border-zinc-600" />
+                                            <span class="text-sm">{{ $rule->title }}</span>
+                                        </label>
+                                    @endforeach
+                                </div>
+                            </div>
+                        @endforeach
+                    </div>
+                    <flux:description>Select any rules this incident violated (optional).</flux:description>
+                </flux:field>
+            @endif
+
             <div class="flex gap-2 justify-end">
                 <flux:button variant="ghost" x-on:click="$flux.modal('create-report-modal').close()">Cancel</flux:button>
                 <flux:button wire:click="createReport" variant="primary">Create Report</flux:button>
@@ -457,6 +494,28 @@ new class extends Component {
                 <flux:error name="formSeverity" />
             </flux:field>
 
+            @if($this->activeRules->isNotEmpty())
+                <flux:field>
+                    <flux:label>Rules Violated</flux:label>
+                    <div class="space-y-3 mt-1 max-h-48 overflow-y-auto border border-zinc-200 dark:border-zinc-700 rounded-lg p-3">
+                        @foreach($this->activeRules as $categoryName => $rules)
+                            <div>
+                                <flux:text class="text-xs font-semibold text-zinc-500 uppercase tracking-wide mb-1">{{ $categoryName }}</flux:text>
+                                <div class="space-y-1">
+                                    @foreach($rules as $rule)
+                                        <label wire:key="edit-rule-{{ $rule->id }}" class="flex items-start gap-2 cursor-pointer">
+                                            <input type="checkbox" wire:model="formRuleIds" value="{{ $rule->id }}" class="mt-0.5 rounded border-zinc-300 dark:border-zinc-600" />
+                                            <span class="text-sm">{{ $rule->title }}</span>
+                                        </label>
+                                    @endforeach
+                                </div>
+                            </div>
+                        @endforeach
+                    </div>
+                    <flux:description>Select any rules this incident violated (optional).</flux:description>
+                </flux:field>
+            @endif
+
             <div class="flex gap-2 justify-end">
                 <flux:button variant="ghost" x-on:click="$flux.modal('edit-report-modal').close()">Cancel</flux:button>
                 <flux:button wire:click="updateReport" variant="primary">Save Changes</flux:button>
@@ -508,6 +567,18 @@ new class extends Component {
                         {!! Str::markdown($viewReport->actions_taken, ['html_input' => 'strip', 'allow_unsafe_links' => false]) !!}
                     </div>
                 </div>
+
+                @php $viewViolatedRules = $viewReport->violatedRules; @endphp
+                @if($viewViolatedRules->isNotEmpty())
+                    <div>
+                        <flux:text class="font-bold text-sm">Rules Violated</flux:text>
+                        <div class="mt-1 flex flex-wrap gap-1">
+                            @foreach($viewViolatedRules as $rule)
+                                <flux:badge color="red" size="sm">{{ $rule->title }}</flux:badge>
+                            @endforeach
+                        </div>
+                    </div>
+                @endif
 
                 @if($isStaffViewing)
                     <flux:separator variant="subtle" />

--- a/routes/console.php
+++ b/routes/console.php
@@ -68,3 +68,9 @@ Schedule::job(new \App\Jobs\EscalateUnassignedTickets)
 // Cleanup unreferenced blog images monthly
 Schedule::job(new \App\Jobs\CleanupUnreferencedBlogImages)
     ->monthly();
+
+// Check rules agreement compliance daily and send reminders / place brigs
+Schedule::job(new \App\Jobs\CheckRulesAgreementJob)
+    ->dailyAt('07:00')
+    ->withoutOverlapping(10)
+    ->onOneServer();

--- a/routes/web.php
+++ b/routes/web.php
@@ -15,8 +15,12 @@ Route::get('/', function () {
 })->name('home');
 
 Route::view('dashboard', 'dashboard')
-    ->middleware(['auth', 'verified', 'ensure-dob'])
+    ->middleware(['auth', 'verified', 'ensure-dob', 'ensure-rules-agreed'])
     ->name('dashboard');
+
+Volt::route('/rules', 'rules-page')
+    ->middleware(['auth', 'verified', 'ensure-dob'])
+    ->name('rules.show');
 
 Volt::route('/contact', 'contact.contact-form')->name('contact.index');
 Volt::route('/contact/thread/{token}', 'contact.guest-thread')->name('contact.thread');

--- a/tests/Feature/Actions/DisciplineReports/DisciplineReportRuleLinkingTest.php
+++ b/tests/Feature/Actions/DisciplineReports/DisciplineReportRuleLinkingTest.php
@@ -1,0 +1,145 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Actions\CreateDisciplineReport;
+use App\Actions\UpdateDisciplineReport;
+use App\Enums\ReportLocation;
+use App\Enums\ReportSeverity;
+use App\Models\Rule;
+use App\Models\RuleCategory;
+use App\Models\User;
+
+uses()->group('discipline-reports', 'rules');
+
+it('creates a discipline report with violated rules', function () {
+    $reporter = officerCommand();
+    $subject = User::factory()->create();
+    $category = RuleCategory::first();
+
+    $rule1 = Rule::create(['rule_category_id' => $category->id, 'title' => 'No Griefing', 'description' => 'Do not grief.', 'status' => 'active', 'sort_order' => 900]);
+    $rule2 = Rule::create(['rule_category_id' => $category->id, 'title' => 'No Spamming', 'description' => 'Do not spam.', 'status' => 'active', 'sort_order' => 901]);
+
+    $report = CreateDisciplineReport::run(
+        $subject,
+        $reporter,
+        'Test incident description',
+        ReportLocation::Minecraft,
+        'Verbal warning given',
+        ReportSeverity::Minor,
+        null,
+        null,
+        [$rule1->id, $rule2->id],
+    );
+
+    expect($report->violatedRules()->pluck('rules.id')->toArray())
+        ->toContain($rule1->id)
+        ->toContain($rule2->id);
+});
+
+it('creates a discipline report with no violated rules when none provided', function () {
+    $reporter = officerCommand();
+    $subject = User::factory()->create();
+
+    $report = CreateDisciplineReport::run(
+        $subject,
+        $reporter,
+        'Test incident description',
+        ReportLocation::Minecraft,
+        'Verbal warning given',
+        ReportSeverity::Minor,
+    );
+
+    expect($report->violatedRules()->count())->toBe(0);
+});
+
+it('updates a discipline report with new violated rules', function () {
+    $reporter = officerCommand();
+    $subject = User::factory()->create();
+    $category = RuleCategory::first();
+
+    $rule1 = Rule::create(['rule_category_id' => $category->id, 'title' => 'No Griefing 2', 'description' => 'Do not grief.', 'status' => 'active', 'sort_order' => 910]);
+    $rule2 = Rule::create(['rule_category_id' => $category->id, 'title' => 'No Spamming 2', 'description' => 'Do not spam.', 'status' => 'active', 'sort_order' => 911]);
+
+    $report = CreateDisciplineReport::run(
+        $subject,
+        $reporter,
+        'Test incident',
+        ReportLocation::Minecraft,
+        'Warning given',
+        ReportSeverity::Minor,
+        null,
+        null,
+        [$rule1->id],
+    );
+
+    UpdateDisciplineReport::run(
+        $report,
+        $reporter,
+        'Updated description',
+        ReportLocation::Minecraft,
+        'Warning given',
+        ReportSeverity::Minor,
+        null,
+        null,
+        [$rule2->id],
+    );
+
+    $ids = $report->fresh()->violatedRules()->pluck('rules.id')->toArray();
+    expect($ids)->toContain($rule2->id)
+        ->and($ids)->not->toContain($rule1->id);
+});
+
+it('clears violated rules when empty array passed on update', function () {
+    $reporter = officerCommand();
+    $subject = User::factory()->create();
+    $category = RuleCategory::first();
+
+    $rule = Rule::create(['rule_category_id' => $category->id, 'title' => 'No Hacking', 'description' => 'No hacks.', 'status' => 'active', 'sort_order' => 920]);
+
+    $report = CreateDisciplineReport::run(
+        $subject,
+        $reporter,
+        'Test incident',
+        ReportLocation::Minecraft,
+        'Warning given',
+        ReportSeverity::Minor,
+        null,
+        null,
+        [$rule->id],
+    );
+
+    UpdateDisciplineReport::run(
+        $report,
+        $reporter,
+        'Updated description',
+        ReportLocation::Minecraft,
+        'Warning given',
+        ReportSeverity::Minor,
+    );
+
+    expect($report->fresh()->violatedRules()->count())->toBe(0);
+});
+
+it('violatedRules relationship returns rules with titles', function () {
+    $reporter = officerCommand();
+    $subject = User::factory()->create();
+    $category = RuleCategory::first();
+
+    $rule = Rule::create(['rule_category_id' => $category->id, 'title' => 'Respect Others', 'description' => 'Be respectful.', 'status' => 'active', 'sort_order' => 930]);
+
+    $report = CreateDisciplineReport::run(
+        $subject,
+        $reporter,
+        'Test incident',
+        ReportLocation::Minecraft,
+        'Warning given',
+        ReportSeverity::Minor,
+        null,
+        null,
+        [$rule->id],
+    );
+
+    $violated = $report->violatedRules()->first();
+    expect($violated->title)->toBe('Respect Others');
+});

--- a/tests/Feature/Actions/Rules/AddRuleToDraftTest.php
+++ b/tests/Feature/Actions/Rules/AddRuleToDraftTest.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Actions\AddRuleToDraft;
+use App\Actions\CreateRuleVersion;
+use App\Models\RuleCategory;
+use App\Models\User;
+
+uses()->group('rules', 'actions');
+
+it('creates a rule in draft status linked to the version', function () {
+    $user = User::factory()->create();
+    $draft = CreateRuleVersion::run($user);
+    $category = RuleCategory::first();
+
+    $rule = AddRuleToDraft::run($draft, $category, 'New Rule', 'Rule description.', $user);
+
+    expect($rule->status)->toBe('draft')
+        ->and($rule->title)->toBe('New Rule')
+        ->and($rule->description)->toBe('Rule description.')
+        ->and($rule->rule_category_id)->toBe($category->id)
+        ->and($rule->created_by_user_id)->toBe($user->id);
+});
+
+it('links the new rule to the draft version with deactivate_on_publish false', function () {
+    $user = User::factory()->create();
+    $draft = CreateRuleVersion::run($user);
+    $category = RuleCategory::first();
+
+    $rule = AddRuleToDraft::run($draft, $category, 'New Rule', 'Description.', $user);
+
+    $pivot = $draft->rules()->where('rules.id', $rule->id)->first()?->pivot;
+
+    expect($pivot)->not->toBeNull()
+        ->and((bool) $pivot->deactivate_on_publish)->toBeFalse();
+});
+
+it('persists the rule to the database', function () {
+    $user = User::factory()->create();
+    $draft = CreateRuleVersion::run($user);
+    $category = RuleCategory::first();
+
+    $rule = AddRuleToDraft::run($draft, $category, 'Persisted Rule', 'Some text.', $user);
+
+    $this->assertDatabaseHas('rules', [
+        'id' => $rule->id,
+        'title' => 'Persisted Rule',
+        'status' => 'draft',
+    ]);
+});

--- a/tests/Feature/Actions/Rules/AgreeToRulesVersionTest.php
+++ b/tests/Feature/Actions/Rules/AgreeToRulesVersionTest.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Actions\AgreeToRulesVersion;
+use App\Actions\PutUserInBrig;
+use App\Enums\BrigType;
+use App\Enums\MembershipLevel;
+use App\Models\RuleVersion;
+use App\Models\User;
+use App\Services\MinecraftRconService;
+
+uses()->group('rules', 'actions', 'agreement');
+
+it('records a user_rule_agreements entry for the current published version', function () {
+    $user = User::factory()->withoutRulesAgreed()->create(['membership_level' => MembershipLevel::Stowaway]);
+
+    AgreeToRulesVersion::run($user, $user);
+
+    $version = RuleVersion::currentPublished();
+    expect($user->ruleAgreements()->where('rule_version_id', $version->id)->exists())->toBeTrue();
+});
+
+it('promotes a Drifter to Stowaway when they agree', function () {
+    $user = User::factory()->withoutRulesAgreed()->create(['membership_level' => MembershipLevel::Drifter]);
+
+    AgreeToRulesVersion::run($user, $user);
+
+    expect($user->fresh()->membership_level)->toBe(MembershipLevel::Stowaway);
+});
+
+it('does not promote a non-Drifter when they agree', function () {
+    $user = User::factory()->withoutRulesAgreed()->create(['membership_level' => MembershipLevel::Traveler]);
+
+    AgreeToRulesVersion::run($user, $user);
+
+    expect($user->fresh()->membership_level)->toBe(MembershipLevel::Traveler);
+});
+
+it('auto-lifts a rules_non_compliance brig when the user agrees', function () {
+    $this->mock(MinecraftRconService::class)
+        ->shouldReceive('executeCommand')
+        ->andReturn(['success' => true, 'response' => null, 'error' => null]);
+
+    $admin = User::factory()->create();
+    $user = User::factory()->withoutRulesAgreed()->create(['membership_level' => MembershipLevel::Stowaway]);
+
+    PutUserInBrig::run($user, $admin, 'Non-compliance with rules.', brigType: BrigType::RulesNonCompliance);
+    expect($user->fresh()->isInBrig())->toBeTrue();
+
+    AgreeToRulesVersion::run($user, $user);
+
+    expect($user->fresh()->isInBrig())->toBeFalse();
+});
+
+it('does not lift a non-rules brig when the user agrees', function () {
+    $this->mock(MinecraftRconService::class)
+        ->shouldReceive('executeCommand')
+        ->andReturn(['success' => true, 'response' => null, 'error' => null]);
+
+    $admin = User::factory()->create();
+    $user = User::factory()->withoutRulesAgreed()->create(['membership_level' => MembershipLevel::Stowaway]);
+
+    PutUserInBrig::run($user, $admin, 'Disciplinary action.');
+    expect($user->fresh()->isInBrig())->toBeTrue();
+
+    AgreeToRulesVersion::run($user, $user);
+
+    expect($user->fresh()->isInBrig())->toBeTrue();
+});
+
+it('is idempotent when called multiple times', function () {
+    $user = User::factory()->withoutRulesAgreed()->create(['membership_level' => MembershipLevel::Stowaway]);
+
+    AgreeToRulesVersion::run($user, $user);
+    AgreeToRulesVersion::run($user, $user);
+
+    $version = RuleVersion::currentPublished();
+    expect($user->ruleAgreements()->where('rule_version_id', $version->id)->count())->toBe(1);
+});

--- a/tests/Feature/Actions/Rules/CreateRuleVersionTest.php
+++ b/tests/Feature/Actions/Rules/CreateRuleVersionTest.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Actions\CreateRuleVersion;
+use App\Models\RuleVersion;
+use App\Models\User;
+
+uses()->group('rules', 'actions');
+
+it('creates a draft version with the next version number', function () {
+    $user = User::factory()->create();
+    $published = RuleVersion::currentPublished();
+    $expectedNumber = $published ? $published->version_number + 1 : 1;
+
+    $draft = CreateRuleVersion::run($user);
+
+    expect($draft->version_number)->toBe($expectedNumber)
+        ->and($draft->status)->toBe('draft')
+        ->and($draft->created_by_user_id)->toBe($user->id);
+});
+
+it('seeds the draft with all active rules from the published version', function () {
+    $user = User::factory()->create();
+    $published = RuleVersion::currentPublished();
+
+    $draft = CreateRuleVersion::run($user);
+
+    $publishedActiveRuleIds = $published->activeRules()->pluck('rules.id')->sort()->values();
+    $draftActiveRuleIds = $draft->activeRules()->pluck('rules.id')->sort()->values();
+
+    expect($draftActiveRuleIds->toArray())->toEqual($publishedActiveRuleIds->toArray());
+});
+
+it('persists the new draft to the database', function () {
+    $user = User::factory()->create();
+
+    $draft = CreateRuleVersion::run($user);
+
+    $this->assertDatabaseHas('rule_versions', [
+        'id' => $draft->id,
+        'status' => 'draft',
+        'created_by_user_id' => $user->id,
+    ]);
+});
+
+it('only one draft can be created (no two draft versions exist at once)', function () {
+    $user = User::factory()->create();
+
+    $draft1 = CreateRuleVersion::run($user);
+
+    expect($draft1->status)->toBe('draft');
+    expect(RuleVersion::currentDraft())->not->toBeNull();
+});

--- a/tests/Feature/Actions/Rules/CreateRuleVersionTest.php
+++ b/tests/Feature/Actions/Rules/CreateRuleVersionTest.php
@@ -24,6 +24,8 @@ it('seeds the draft with all active rules from the published version', function 
     $user = User::factory()->create();
     $published = RuleVersion::currentPublished();
 
+    expect($published)->not->toBeNull('No published version exists — seed migration may not have run.');
+
     $draft = CreateRuleVersion::run($user);
 
     $publishedActiveRuleIds = $published->activeRules()->pluck('rules.id')->sort()->values();
@@ -48,7 +50,8 @@ it('only one draft can be created (no two draft versions exist at once)', functi
     $user = User::factory()->create();
 
     $draft1 = CreateRuleVersion::run($user);
+    $draft2 = CreateRuleVersion::run($user);
 
-    expect($draft1->status)->toBe('draft');
-    expect(RuleVersion::currentDraft())->not->toBeNull();
+    expect($draft1->id)->toBe($draft2->id)
+        ->and(RuleVersion::where('status', 'draft')->count())->toBe(1);
 });

--- a/tests/Feature/Actions/Rules/DeactivateRuleInDraftTest.php
+++ b/tests/Feature/Actions/Rules/DeactivateRuleInDraftTest.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Actions\CreateRuleVersion;
+use App\Actions\DeactivateRuleInDraft;
+use App\Models\Rule;
+use App\Models\User;
+
+uses()->group('rules', 'actions');
+
+it('marks the rule for deactivation on publish', function () {
+    $user = User::factory()->create();
+    $draft = CreateRuleVersion::run($user);
+    $rule = Rule::where('status', 'active')->first();
+
+    DeactivateRuleInDraft::run($draft, $rule);
+
+    $pivot = $draft->rules()->where('rules.id', $rule->id)->first()?->pivot;
+    expect($pivot)->not->toBeNull()
+        ->and((bool) $pivot->deactivate_on_publish)->toBeTrue();
+});
+
+it('does not immediately deactivate the rule', function () {
+    $user = User::factory()->create();
+    $draft = CreateRuleVersion::run($user);
+    $rule = Rule::where('status', 'active')->first();
+
+    DeactivateRuleInDraft::run($draft, $rule);
+
+    expect($rule->fresh()->status)->toBe('active');
+});
+
+it('adds the rule to the draft version if not already present', function () {
+    $user = User::factory()->create();
+
+    // Create a draft without seeding (fresh version, no published to copy from)
+    $draft = \App\Models\RuleVersion::create([
+        'version_number' => 99,
+        'status' => 'draft',
+        'created_by_user_id' => $user->id,
+    ]);
+    $rule = Rule::where('status', 'active')->first();
+
+    DeactivateRuleInDraft::run($draft, $rule);
+
+    $this->assertDatabaseHas('rule_version_rules', [
+        'rule_version_id' => $draft->id,
+        'rule_id' => $rule->id,
+        'deactivate_on_publish' => true,
+    ]);
+});

--- a/tests/Feature/Actions/Rules/GetRulesAgreementStatusTest.php
+++ b/tests/Feature/Actions/Rules/GetRulesAgreementStatusTest.php
@@ -1,0 +1,117 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Actions\AddRuleToDraft;
+use App\Actions\AgreeToRulesVersion;
+use App\Actions\ApproveAndPublishVersion;
+use App\Actions\CreateRuleVersion;
+use App\Actions\GetRulesAgreementStatus;
+use App\Actions\UpdateRuleInDraft;
+use App\Enums\MembershipLevel;
+use App\Models\RuleCategory;
+use App\Models\User;
+
+uses()->group('rules', 'actions', 'agreement');
+
+it('returns has_agreed true when user has agreed to the current version', function () {
+    $user = User::factory()->create(['membership_level' => MembershipLevel::Stowaway]);
+    // Factory auto-creates agreement; verify it's there
+    $status = GetRulesAgreementStatus::run($user);
+
+    expect($status['has_agreed'])->toBeTrue();
+});
+
+it('returns has_agreed false when user has not agreed to the current version', function () {
+    $user = User::factory()->withoutRulesAgreed()->create(['membership_level' => MembershipLevel::Stowaway]);
+
+    $status = GetRulesAgreementStatus::run($user);
+
+    expect($status['has_agreed'])->toBeFalse();
+});
+
+it('classifies rules as unchanged when the user has already agreed to them', function () {
+    $user = User::factory()->create(['membership_level' => MembershipLevel::Stowaway]);
+    // Factory auto-agrees to v1; now create a second version with the same rules
+    $creator = User::factory()->create();
+    $approver = User::factory()->create();
+    $draft = CreateRuleVersion::run($creator);
+    $draft->status = 'submitted';
+    $draft->save();
+    ApproveAndPublishVersion::run($draft, $approver);
+
+    // User has agreed to v1 but not v2 yet — all rules carried over from v1 are 'unchanged'
+    $status = GetRulesAgreementStatus::run($user);
+
+    expect($status['has_agreed'])->toBeFalse();
+    $allStatuses = $status['categories']->flatMap(fn ($cat) => $cat->rules->pluck('agreement_status'))->unique()->values()->all();
+    expect($allStatuses)->toContain('unchanged')
+        ->and($allStatuses)->not->toContain('new')
+        ->and($allStatuses)->not->toContain('updated');
+});
+
+it('classifies a brand-new rule as new', function () {
+    $user = User::factory()->create(['membership_level' => MembershipLevel::Stowaway]);
+    AgreeToRulesVersion::run($user, $user);
+
+    $creator = User::factory()->create();
+    $approver = User::factory()->create();
+    $draft = CreateRuleVersion::run($creator);
+
+    $category = RuleCategory::first();
+    AddRuleToDraft::run($draft, $category, 'Brand New Rule', 'This rule is brand new.', $creator);
+
+    $draft->status = 'submitted';
+    $draft->save();
+    ApproveAndPublishVersion::run($draft, $approver);
+
+    $status = GetRulesAgreementStatus::run($user);
+
+    $newRules = $status['categories']
+        ->flatMap(fn ($cat) => $cat->rules)
+        ->filter(fn ($r) => $r->agreement_status === 'new');
+
+    expect($newRules->count())->toBe(1)
+        ->and($newRules->first()->title)->toBe('Brand New Rule');
+});
+
+it('classifies a replacement rule as updated with the previous rule text', function () {
+    $user = User::factory()->create(['membership_level' => MembershipLevel::Stowaway]);
+    AgreeToRulesVersion::run($user, $user);
+
+    $creator = User::factory()->create();
+    $approver = User::factory()->create();
+    $draft = CreateRuleVersion::run($creator);
+
+    // Update an existing active rule
+    $activeRule = \App\Models\Rule::where('status', 'active')->first();
+    UpdateRuleInDraft::run($draft, $activeRule, 'Updated Title', 'New updated description.', $creator);
+
+    $draft->status = 'submitted';
+    $draft->save();
+    ApproveAndPublishVersion::run($draft, $approver);
+
+    $status = GetRulesAgreementStatus::run($user);
+
+    $updatedRules = $status['categories']
+        ->flatMap(fn ($cat) => $cat->rules)
+        ->filter(fn ($r) => $r->agreement_status === 'updated');
+
+    expect($updatedRules->count())->toBe(1);
+    $updated = $updatedRules->first();
+    expect($updated->title)->toBe('Updated Title')
+        ->and($updated->previous_rule)->not->toBeNull()
+        ->and($updated->previous_rule->id)->toBe($activeRule->id);
+});
+
+it('returns has_agreed true when there is no published version', function () {
+    // Clear all published versions
+    \App\Models\RuleVersion::query()->update(['status' => 'draft']);
+
+    $user = User::factory()->create();
+
+    $status = GetRulesAgreementStatus::run($user);
+
+    expect($status['has_agreed'])->toBeTrue()
+        ->and($status['current_version'])->toBeNull();
+});

--- a/tests/Feature/Actions/Rules/RemoveRuleFromDraftTest.php
+++ b/tests/Feature/Actions/Rules/RemoveRuleFromDraftTest.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Actions\AddRuleToDraft;
+use App\Actions\CreateRuleVersion;
+use App\Actions\RemoveRuleFromDraft;
+use App\Actions\UpdateRuleInDraft;
+use App\Models\Rule;
+use App\Models\RuleCategory;
+use App\Models\RuleVersion;
+use App\Models\User;
+use Illuminate\Auth\Access\AuthorizationException;
+
+uses()->group('rules', 'actions');
+
+it('removes a draft rule from the version and deletes it', function () {
+    $user = User::factory()->create();
+    $draft = CreateRuleVersion::run($user);
+    $category = RuleCategory::first();
+    $rule = AddRuleToDraft::run($draft, $category, 'Temp Rule', 'Temporary.', $user);
+
+    RemoveRuleFromDraft::run($draft, $rule);
+
+    $this->assertDatabaseMissing('rules', ['id' => $rule->id]);
+    $this->assertDatabaseMissing('rule_version_rules', ['rule_id' => $rule->id]);
+});
+
+it('removes the deactivation mark on the superseded rule when removing a replacement', function () {
+    $user = User::factory()->create();
+    $draft = CreateRuleVersion::run($user);
+    $category = RuleCategory::first();
+    $activeRule = Rule::where('status', 'active')->first();
+
+    $replacement = UpdateRuleInDraft::run($draft, $activeRule, 'Updated Title', 'Updated description.', $user);
+
+    // Confirm the active rule is marked for deactivation in the draft
+    $pivot = $draft->rules()->where('rules.id', $activeRule->id)->first()?->pivot;
+    expect((bool) $pivot->deactivate_on_publish)->toBeTrue();
+
+    RemoveRuleFromDraft::run($draft, $replacement);
+
+    // The replacement rule is gone
+    $this->assertDatabaseMissing('rules', ['id' => $replacement->id]);
+
+    // The active rule is no longer in the draft at all
+    expect($draft->rules()->where('rules.id', $activeRule->id)->exists())->toBeFalse();
+});
+
+it('throws when the draft is not in draft status', function () {
+    $user = User::factory()->create();
+    $category = RuleCategory::first();
+
+    $submittedVersion = RuleVersion::create([
+        'version_number' => 99,
+        'status' => 'submitted',
+        'created_by_user_id' => $user->id,
+    ]);
+
+    $rule = Rule::factory()->create([
+        'rule_category_id' => $category->id,
+        'status' => 'draft',
+        'created_by_user_id' => $user->id,
+    ]);
+
+    expect(fn () => RemoveRuleFromDraft::run($submittedVersion, $rule))
+        ->toThrow(AuthorizationException::class);
+});
+
+it('throws when the rule is not in draft status', function () {
+    $user = User::factory()->create();
+    $draft = CreateRuleVersion::run($user);
+    $activeRule = Rule::where('status', 'active')->first();
+
+    expect(fn () => RemoveRuleFromDraft::run($draft, $activeRule))
+        ->toThrow(AuthorizationException::class);
+});

--- a/tests/Feature/Actions/Rules/RemoveRuleFromDraftTest.php
+++ b/tests/Feature/Actions/Rules/RemoveRuleFromDraftTest.php
@@ -16,8 +16,8 @@ uses()->group('rules', 'actions');
 
 it('removes a draft rule from the version and deletes it', function () {
     $user = User::factory()->create();
+    $category = RuleCategory::factory()->create();
     $draft = CreateRuleVersion::run($user);
-    $category = RuleCategory::first();
     $rule = AddRuleToDraft::run($draft, $category, 'Temp Rule', 'Temporary.', $user);
 
     RemoveRuleFromDraft::run($draft, $rule);
@@ -28,9 +28,8 @@ it('removes a draft rule from the version and deletes it', function () {
 
 it('removes the deactivation mark on the superseded rule when removing a replacement', function () {
     $user = User::factory()->create();
+    $activeRule = Rule::factory()->create(['status' => 'active']);
     $draft = CreateRuleVersion::run($user);
-    $category = RuleCategory::first();
-    $activeRule = Rule::where('status', 'active')->first();
 
     $replacement = UpdateRuleInDraft::run($draft, $activeRule, 'Updated Title', 'Updated description.', $user);
 
@@ -49,19 +48,8 @@ it('removes the deactivation mark on the superseded rule when removing a replace
 
 it('throws when the draft is not in draft status', function () {
     $user = User::factory()->create();
-    $category = RuleCategory::first();
-
-    $submittedVersion = RuleVersion::create([
-        'version_number' => 99,
-        'status' => 'submitted',
-        'created_by_user_id' => $user->id,
-    ]);
-
-    $rule = Rule::factory()->create([
-        'rule_category_id' => $category->id,
-        'status' => 'draft',
-        'created_by_user_id' => $user->id,
-    ]);
+    $submittedVersion = RuleVersion::factory()->submitted()->create();
+    $rule = Rule::factory()->draft()->create();
 
     expect(fn () => RemoveRuleFromDraft::run($submittedVersion, $rule))
         ->toThrow(AuthorizationException::class);
@@ -70,8 +58,17 @@ it('throws when the draft is not in draft status', function () {
 it('throws when the rule is not in draft status', function () {
     $user = User::factory()->create();
     $draft = CreateRuleVersion::run($user);
-    $activeRule = Rule::where('status', 'active')->first();
+    $activeRule = Rule::factory()->create(['status' => 'active']);
 
     expect(fn () => RemoveRuleFromDraft::run($draft, $activeRule))
+        ->toThrow(AuthorizationException::class);
+});
+
+it('throws when the rule is not attached to the given draft', function () {
+    $user = User::factory()->create();
+    $draft = CreateRuleVersion::run($user);
+    $unattachedRule = Rule::factory()->draft()->create();
+
+    expect(fn () => RemoveRuleFromDraft::run($draft, $unattachedRule))
         ->toThrow(AuthorizationException::class);
 });

--- a/tests/Feature/Actions/Rules/ReorderRulesTest.php
+++ b/tests/Feature/Actions/Rules/ReorderRulesTest.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\Rule;
+use App\Models\RuleCategory;
+use App\Models\User;
+use Livewire\Volt\Volt;
+
+use function Pest\Laravel\actingAs;
+
+uses()->group('rules', 'admin-ui');
+
+it('moving a category down swaps sort_order with the next category', function () {
+    $user = User::factory()->withRole('Rules - Manage')->create();
+
+    $cat1 = RuleCategory::create(['name' => 'Cat A', 'sort_order' => 100]);
+    $cat2 = RuleCategory::create(['name' => 'Cat B', 'sort_order' => 200]);
+
+    actingAs($user);
+
+    Volt::test('admin-manage-rules-page')
+        ->call('moveCategoryDown', $cat1->id);
+
+    expect($cat1->fresh()->sort_order)->toBe(200)
+        ->and($cat2->fresh()->sort_order)->toBe(100);
+});
+
+it('moving a rule down swaps sort_order with the rule below', function () {
+    $user = User::factory()->withRole('Rules - Manage')->create();
+
+    $category = RuleCategory::first();
+    $rule1 = Rule::create([
+        'rule_category_id' => $category->id,
+        'title' => 'Test Rule Above',
+        'description' => 'Test',
+        'status' => 'active',
+        'sort_order' => 500,
+    ]);
+    $rule2 = Rule::create([
+        'rule_category_id' => $category->id,
+        'title' => 'Test Rule Below',
+        'description' => 'Test',
+        'status' => 'active',
+        'sort_order' => 510,
+    ]);
+
+    actingAs($user);
+
+    Volt::test('admin-manage-rules-page')
+        ->call('moveRuleDown', $rule1->id);
+
+    expect($rule1->fresh()->sort_order)->toBe(510)
+        ->and($rule2->fresh()->sort_order)->toBe(500);
+});
+
+it('denies moveCategoryUp to user without rules.manage', function () {
+    $user = User::factory()->create();
+
+    $category = RuleCategory::first();
+
+    actingAs($user);
+
+    Volt::test('admin-manage-rules-page')
+        ->call('moveCategoryUp', $category->id)
+        ->assertForbidden();
+});
+
+it('denies startDraft to user without rules.manage', function () {
+    $user = User::factory()->create();
+
+    actingAs($user);
+
+    Volt::test('admin-manage-rules-page')
+        ->call('startDraft')
+        ->assertForbidden();
+});

--- a/tests/Feature/Actions/Rules/UpdateRuleInDraftTest.php
+++ b/tests/Feature/Actions/Rules/UpdateRuleInDraftTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 use App\Actions\CreateRuleVersion;
 use App\Actions\UpdateRuleInDraft;
 use App\Models\Rule;
+use App\Models\RuleVersion;
 use App\Models\User;
 
 uses()->group('rules', 'actions');
@@ -12,7 +13,8 @@ uses()->group('rules', 'actions');
 it('creates a replacement rule with supersedes_rule_id pointing to the old rule', function () {
     $user = User::factory()->create();
     $draft = CreateRuleVersion::run($user);
-    $oldRule = Rule::where('status', 'active')->first();
+    $oldRule = Rule::factory()->create(['status' => 'active']);
+    $draft->rules()->attach($oldRule->id, ['deactivate_on_publish' => false]);
 
     $replacement = UpdateRuleInDraft::run($draft, $oldRule, 'Updated Title', 'Updated description.', $user);
 
@@ -24,7 +26,8 @@ it('creates a replacement rule with supersedes_rule_id pointing to the old rule'
 it('adds the replacement rule to the draft with deactivate_on_publish false', function () {
     $user = User::factory()->create();
     $draft = CreateRuleVersion::run($user);
-    $oldRule = Rule::where('status', 'active')->first();
+    $oldRule = Rule::factory()->create(['status' => 'active']);
+    $draft->rules()->attach($oldRule->id, ['deactivate_on_publish' => false]);
 
     $replacement = UpdateRuleInDraft::run($draft, $oldRule, 'Updated Title', 'New text.', $user);
 
@@ -36,7 +39,8 @@ it('adds the replacement rule to the draft with deactivate_on_publish false', fu
 it('marks the old rule for deactivation on publish', function () {
     $user = User::factory()->create();
     $draft = CreateRuleVersion::run($user);
-    $oldRule = Rule::where('status', 'active')->first();
+    $oldRule = Rule::factory()->create(['status' => 'active']);
+    $draft->rules()->attach($oldRule->id, ['deactivate_on_publish' => false]);
 
     UpdateRuleInDraft::run($draft, $oldRule, 'Updated Title', 'New text.', $user);
 
@@ -48,9 +52,18 @@ it('marks the old rule for deactivation on publish', function () {
 it('does not immediately deactivate the old rule', function () {
     $user = User::factory()->create();
     $draft = CreateRuleVersion::run($user);
-    $oldRule = Rule::where('status', 'active')->first();
+    $oldRule = Rule::factory()->create(['status' => 'active']);
+    $draft->rules()->attach($oldRule->id, ['deactivate_on_publish' => false]);
 
     UpdateRuleInDraft::run($draft, $oldRule, 'Updated Title', 'New text.', $user);
 
     expect($oldRule->fresh()->status)->toBe('active');
 });
+
+it('throws if the version is not a draft', function () {
+    $user = User::factory()->create();
+    $version = RuleVersion::factory()->create(['status' => 'submitted']);
+    $oldRule = Rule::factory()->create(['status' => 'active']);
+
+    UpdateRuleInDraft::run($version, $oldRule, 'Title', 'Desc.', $user);
+})->throws(InvalidArgumentException::class);

--- a/tests/Feature/Actions/Rules/UpdateRuleInDraftTest.php
+++ b/tests/Feature/Actions/Rules/UpdateRuleInDraftTest.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Actions\CreateRuleVersion;
+use App\Actions\UpdateRuleInDraft;
+use App\Models\Rule;
+use App\Models\User;
+
+uses()->group('rules', 'actions');
+
+it('creates a replacement rule with supersedes_rule_id pointing to the old rule', function () {
+    $user = User::factory()->create();
+    $draft = CreateRuleVersion::run($user);
+    $oldRule = Rule::where('status', 'active')->first();
+
+    $replacement = UpdateRuleInDraft::run($draft, $oldRule, 'Updated Title', 'Updated description.', $user);
+
+    expect($replacement->supersedes_rule_id)->toBe($oldRule->id)
+        ->and($replacement->title)->toBe('Updated Title')
+        ->and($replacement->status)->toBe('draft');
+});
+
+it('adds the replacement rule to the draft with deactivate_on_publish false', function () {
+    $user = User::factory()->create();
+    $draft = CreateRuleVersion::run($user);
+    $oldRule = Rule::where('status', 'active')->first();
+
+    $replacement = UpdateRuleInDraft::run($draft, $oldRule, 'Updated Title', 'New text.', $user);
+
+    $pivot = $draft->rules()->where('rules.id', $replacement->id)->first()?->pivot;
+    expect($pivot)->not->toBeNull()
+        ->and((bool) $pivot->deactivate_on_publish)->toBeFalse();
+});
+
+it('marks the old rule for deactivation on publish', function () {
+    $user = User::factory()->create();
+    $draft = CreateRuleVersion::run($user);
+    $oldRule = Rule::where('status', 'active')->first();
+
+    UpdateRuleInDraft::run($draft, $oldRule, 'Updated Title', 'New text.', $user);
+
+    $oldPivot = $draft->rules()->where('rules.id', $oldRule->id)->first()?->pivot;
+    expect($oldPivot)->not->toBeNull()
+        ->and((bool) $oldPivot->deactivate_on_publish)->toBeTrue();
+});
+
+it('does not immediately deactivate the old rule', function () {
+    $user = User::factory()->create();
+    $draft = CreateRuleVersion::run($user);
+    $oldRule = Rule::where('status', 'active')->first();
+
+    UpdateRuleInDraft::run($draft, $oldRule, 'Updated Title', 'New text.', $user);
+
+    expect($oldRule->fresh()->status)->toBe('active');
+});

--- a/tests/Feature/Actions/Rules/UpdateRulesHeaderFooterTest.php
+++ b/tests/Feature/Actions/Rules/UpdateRulesHeaderFooterTest.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Actions\UpdateRulesHeaderFooter;
+use App\Models\SiteConfig;
+
+uses()->group('rules', 'actions');
+
+it('saves rules_header to SiteConfig', function () {
+    UpdateRulesHeaderFooter::run('# New Header', 'Footer text.');
+
+    expect(SiteConfig::getValue('rules_header'))->toBe('# New Header');
+});
+
+it('saves rules_footer to SiteConfig', function () {
+    UpdateRulesHeaderFooter::run('Header text.', 'New footer content.');
+
+    expect(SiteConfig::getValue('rules_footer'))->toBe('New footer content.');
+});
+
+it('overwrites existing header and footer values', function () {
+    SiteConfig::setValue('rules_header', 'Old header');
+    SiteConfig::setValue('rules_footer', 'Old footer');
+
+    UpdateRulesHeaderFooter::run('New header', 'New footer');
+
+    expect(SiteConfig::getValue('rules_header'))->toBe('New header')
+        ->and(SiteConfig::getValue('rules_footer'))->toBe('New footer');
+});

--- a/tests/Feature/Actions/Rules/VersionApprovalTest.php
+++ b/tests/Feature/Actions/Rules/VersionApprovalTest.php
@@ -1,0 +1,152 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Actions\AddRuleToDraft;
+use App\Actions\ApproveAndPublishVersion;
+use App\Actions\CreateRuleVersion;
+use App\Actions\DeactivateRuleInDraft;
+use App\Actions\RejectDraftVersion;
+use App\Actions\SubmitVersionForApproval;
+use App\Models\Rule;
+use App\Models\RuleCategory;
+use App\Models\User;
+use App\Notifications\RulesVersionPublishedNotification;
+use Illuminate\Auth\Access\AuthorizationException;
+use Illuminate\Support\Facades\Notification;
+
+uses()->group('rules', 'actions', 'approval');
+
+// == SubmitVersionForApproval == //
+
+it('transitions a draft version to submitted', function () {
+    $user = User::factory()->create();
+    $draft = CreateRuleVersion::run($user);
+
+    SubmitVersionForApproval::run($draft, $user);
+
+    expect($draft->fresh()->status)->toBe('submitted');
+});
+
+it('throws if trying to submit a non-draft version', function () {
+    $user = User::factory()->create();
+    $draft = CreateRuleVersion::run($user);
+    $draft->status = 'submitted';
+    $draft->save();
+
+    expect(fn () => SubmitVersionForApproval::run($draft, $user))
+        ->toThrow(AuthorizationException::class);
+});
+
+// == ApproveAndPublishVersion == //
+
+it('transitions a submitted version to published', function () {
+    $creator = User::factory()->create();
+    $approver = User::factory()->create();
+    $draft = CreateRuleVersion::run($creator);
+    $draft->status = 'submitted';
+    $draft->save();
+
+    ApproveAndPublishVersion::run($draft, $approver);
+
+    $version = $draft->fresh();
+    expect($version->status)->toBe('published')
+        ->and($version->approved_by_user_id)->toBe($approver->id)
+        ->and($version->published_at)->not->toBeNull();
+});
+
+it('activates draft rules in the version when approved', function () {
+    $creator = User::factory()->create();
+    $approver = User::factory()->create();
+    $draft = CreateRuleVersion::run($creator);
+
+    $category = RuleCategory::first();
+    $newRule = AddRuleToDraft::run($draft, $category, 'New Rule', 'Description.', $creator);
+
+    $draft->status = 'submitted';
+    $draft->save();
+
+    ApproveAndPublishVersion::run($draft, $approver);
+
+    expect($newRule->fresh()->status)->toBe('active');
+});
+
+it('deactivates rules marked for deactivation when approved', function () {
+    $creator = User::factory()->create();
+    $approver = User::factory()->create();
+    $draft = CreateRuleVersion::run($creator);
+
+    $activeRule = Rule::where('status', 'active')->first();
+    DeactivateRuleInDraft::run($draft, $activeRule);
+
+    $draft->status = 'submitted';
+    $draft->save();
+
+    ApproveAndPublishVersion::run($draft, $approver);
+
+    expect($activeRule->fresh()->status)->toBe('inactive');
+});
+
+it('throws if the approver is the same as the creator', function () {
+    $creator = User::factory()->create();
+    $draft = CreateRuleVersion::run($creator);
+    $draft->status = 'submitted';
+    $draft->save();
+
+    expect(fn () => ApproveAndPublishVersion::run($draft, $creator))
+        ->toThrow(AuthorizationException::class);
+});
+
+it('throws if trying to approve a non-submitted version', function () {
+    $creator = User::factory()->create();
+    $approver = User::factory()->create();
+    $draft = CreateRuleVersion::run($creator);
+    // still in draft status
+
+    expect(fn () => ApproveAndPublishVersion::run($draft, $approver))
+        ->toThrow(AuthorizationException::class);
+});
+
+it('fires re-agreement notification for all active users when approved', function () {
+    Notification::fake();
+
+    $stowaway = User::factory()->create(['membership_level' => \App\Enums\MembershipLevel::Stowaway]);
+    $traveler = User::factory()->create(['membership_level' => \App\Enums\MembershipLevel::Traveler]);
+    $creator = User::factory()->create();
+    $approver = User::factory()->create();
+
+    $draft = CreateRuleVersion::run($creator);
+    $draft->status = 'submitted';
+    $draft->save();
+
+    ApproveAndPublishVersion::run($draft, $approver);
+
+    Notification::assertSentTo($stowaway, RulesVersionPublishedNotification::class);
+    Notification::assertSentTo($traveler, RulesVersionPublishedNotification::class);
+});
+
+// == RejectDraftVersion == //
+
+it('transitions a submitted version back to draft', function () {
+    $creator = User::factory()->create();
+    $approver = User::factory()->create();
+    $draft = CreateRuleVersion::run($creator);
+    $draft->status = 'submitted';
+    $draft->save();
+
+    RejectDraftVersion::run($draft, $approver, 'Please fix the wording on rule 3.');
+
+    $version = $draft->fresh();
+    expect($version->status)->toBe('draft')
+        ->and($version->rejection_note)->toBe('Please fix the wording on rule 3.');
+});
+
+it('throws if trying to reject a non-submitted version', function () {
+    $creator = User::factory()->create();
+    $approver = User::factory()->create();
+    $draft = CreateRuleVersion::run($creator);
+    // still in draft status
+
+    expect(fn () => RejectDraftVersion::run($draft, $approver, 'Some note.'))
+        ->toThrow(AuthorizationException::class);
+});

--- a/tests/Feature/Gates/RulesGatesTest.php
+++ b/tests/Feature/Gates/RulesGatesTest.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\User;
+
+uses()->group('rules', 'gates');
+
+// == rules.manage == //
+
+it('grants rules.manage to user with Rules - Manage role', function () {
+    $user = User::factory()->withRole('Rules - Manage')->create();
+
+    expect($user->can('rules.manage'))->toBeTrue();
+});
+
+it('denies rules.manage to user with only Rules - Approve role', function () {
+    $user = User::factory()->withRole('Rules - Approve')->create();
+
+    expect($user->can('rules.manage'))->toBeFalse();
+});
+
+it('denies rules.manage to user with no rules role', function () {
+    $user = User::factory()->create();
+
+    expect($user->can('rules.manage'))->toBeFalse();
+});
+
+// == rules.approve == //
+
+it('grants rules.approve to user with Rules - Approve role', function () {
+    $user = User::factory()->withRole('Rules - Approve')->create();
+
+    expect($user->can('rules.approve'))->toBeTrue();
+});
+
+it('denies rules.approve to user with only Rules - Manage role', function () {
+    $user = User::factory()->withRole('Rules - Manage')->create();
+
+    expect($user->can('rules.approve'))->toBeFalse();
+});
+
+it('denies rules.approve to user with no rules role', function () {
+    $user = User::factory()->create();
+
+    expect($user->can('rules.approve'))->toBeFalse();
+});

--- a/tests/Feature/Jobs/CheckRulesAgreementJobTest.php
+++ b/tests/Feature/Jobs/CheckRulesAgreementJobTest.php
@@ -1,0 +1,134 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Enums\BrigType;
+use App\Enums\MembershipLevel;
+use App\Jobs\CheckRulesAgreementJob;
+use App\Models\RuleVersion;
+use App\Models\User;
+use App\Notifications\RulesAgreementReminderNotification;
+use App\Services\MinecraftRconService;
+use Illuminate\Support\Facades\Notification;
+
+uses()->group('rules', 'jobs');
+
+it('sends a reminder to users overdue 14+ days who have not had a reminder', function () {
+    Notification::fake();
+
+    $version = RuleVersion::currentPublished();
+    $version->published_at = now()->subDays(14);
+    $version->save();
+
+    $user = User::factory()->withoutRulesAgreed()->create(['membership_level' => MembershipLevel::Stowaway]);
+
+    (new CheckRulesAgreementJob)->handle();
+
+    Notification::assertSentTo($user, RulesAgreementReminderNotification::class);
+    expect($user->fresh()->rules_reminder_sent_at)->not->toBeNull();
+});
+
+it('does not send a reminder if already sent', function () {
+    Notification::fake();
+
+    $version = RuleVersion::currentPublished();
+    $version->published_at = now()->subDays(14);
+    $version->save();
+
+    $user = User::factory()->withoutRulesAgreed()->create([
+        'membership_level' => MembershipLevel::Stowaway,
+        'rules_reminder_sent_at' => now()->subDays(2),
+    ]);
+
+    (new CheckRulesAgreementJob)->handle();
+
+    Notification::assertNotSentTo($user, RulesAgreementReminderNotification::class);
+});
+
+it('does not send a reminder if overdue less than 14 days', function () {
+    Notification::fake();
+
+    $version = RuleVersion::currentPublished();
+    $version->published_at = now()->subDays(10);
+    $version->save();
+
+    $user = User::factory()->withoutRulesAgreed()->create(['membership_level' => MembershipLevel::Stowaway]);
+
+    (new CheckRulesAgreementJob)->handle();
+
+    Notification::assertNotSentTo($user, RulesAgreementReminderNotification::class);
+});
+
+it('places a user in rules brig when overdue 28+ days', function () {
+    $this->mock(MinecraftRconService::class)
+        ->shouldReceive('executeCommand')
+        ->andReturn(['success' => true, 'response' => null, 'error' => null]);
+
+    Notification::fake();
+
+    $version = RuleVersion::currentPublished();
+    $version->published_at = now()->subDays(28);
+    $version->save();
+
+    $user = User::factory()->withoutRulesAgreed()->create(['membership_level' => MembershipLevel::Stowaway]);
+
+    (new CheckRulesAgreementJob)->handle();
+
+    expect($user->fresh()->isInBrig())->toBeTrue()
+        ->and($user->fresh()->brig_type)->toBe(BrigType::RulesNonCompliance);
+});
+
+it('does not double-brig a user already in rules_non_compliance brig', function () {
+    $this->mock(MinecraftRconService::class)
+        ->shouldReceive('executeCommand')
+        ->andReturn(['success' => true, 'response' => null, 'error' => null]);
+
+    Notification::fake();
+
+    $version = RuleVersion::currentPublished();
+    $version->published_at = now()->subDays(28);
+    $version->save();
+
+    $user = User::factory()->withoutRulesAgreed()->create(['membership_level' => MembershipLevel::Stowaway]);
+    \App\Actions\PutUserInBrig::run(
+        $user,
+        $user,
+        'Already in rules brig.',
+        brigType: BrigType::RulesNonCompliance,
+    );
+
+    expect(fn () => (new CheckRulesAgreementJob)->handle())->not->toThrow(\Throwable::class);
+    // Still only one brig entry — the user count for brigs has not changed
+    expect($user->fresh()->isInBrig())->toBeTrue();
+});
+
+it('does not act on users who have already agreed', function () {
+    Notification::fake();
+
+    $version = RuleVersion::currentPublished();
+    $version->published_at = now()->subDays(28);
+    $version->save();
+
+    $user = User::factory()->create(['membership_level' => MembershipLevel::Stowaway]);
+    // Factory auto-agrees so user already has agreement
+
+    (new CheckRulesAgreementJob)->handle();
+
+    Notification::assertNotSentTo($user, RulesAgreementReminderNotification::class);
+    expect($user->fresh()->isInBrig())->toBeFalse();
+});
+
+it('does not act on Drifter-level users', function () {
+    Notification::fake();
+
+    $version = RuleVersion::currentPublished();
+    $version->published_at = now()->subDays(28);
+    $version->save();
+
+    $user = User::factory()->withoutRulesAgreed()->create(['membership_level' => MembershipLevel::Drifter]);
+
+    (new CheckRulesAgreementJob)->handle();
+
+    Notification::assertNotSentTo($user, RulesAgreementReminderNotification::class);
+    expect($user->fresh()->isInBrig())->toBeFalse();
+});

--- a/tests/Feature/Livewire/DisciplineReportsCardTest.php
+++ b/tests/Feature/Livewire/DisciplineReportsCardTest.php
@@ -8,6 +8,7 @@ use App\Enums\ReportStatus;
 use App\Enums\StaffDepartment;
 use App\Enums\StaffRank;
 use App\Models\DisciplineReport;
+use App\Models\ReportCategory;
 use App\Models\User;
 use Livewire\Volt\Volt;
 
@@ -53,16 +54,15 @@ it('shows only published reports to non-staff users', function () {
     $subject = User::factory()->create();
     loginAs($subject);
 
-    DisciplineReport::factory()->forSubject($subject)->create([
-        'description' => 'Draft report unique text',
-    ]);
+    $publishedCategory = ReportCategory::factory()->create(['name' => 'Published-Only-Category']);
+    DisciplineReport::factory()->forSubject($subject)->create(); // draft, no category
     DisciplineReport::factory()->forSubject($subject)->published()->create([
-        'description' => 'Published report unique text',
+        'report_category_id' => $publishedCategory->id,
     ]);
 
     Volt::test('users.discipline-reports-card', ['user' => $subject])
-        ->assertDontSee('Draft report unique text')
-        ->assertSee('Published report unique text');
+        ->assertDontSee('Draft')                // no Draft badge — draft report not shown
+        ->assertSee('Published-Only-Category'); // published report's category is visible
 });
 
 it('shows all reports including drafts to staff', function () {
@@ -70,16 +70,15 @@ it('shows all reports including drafts to staff', function () {
     loginAs($staff);
     $subject = User::factory()->create();
 
-    DisciplineReport::factory()->forSubject($subject)->create([
-        'description' => 'Draft visible to staff',
-    ]);
+    $publishedCategory = ReportCategory::factory()->create(['name' => 'Staff-Published-Category']);
+    DisciplineReport::factory()->forSubject($subject)->create(); // draft report
     DisciplineReport::factory()->forSubject($subject)->published()->create([
-        'description' => 'Published visible to staff',
+        'report_category_id' => $publishedCategory->id,
     ]);
 
     Volt::test('users.discipline-reports-card', ['user' => $subject])
-        ->assertSee('Draft visible to staff')
-        ->assertSee('Published visible to staff');
+        ->assertSee('Draft')                    // draft badge visible to staff
+        ->assertSee('Staff-Published-Category'); // published report also visible
 });
 
 it('allows staff to create a report via modal', function () {

--- a/tests/Feature/Rules/ComplianceAndHistoryTest.php
+++ b/tests/Feature/Rules/ComplianceAndHistoryTest.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Enums\MembershipLevel;
+use App\Models\RuleVersion;
+use App\Models\User;
+use App\Models\UserRuleAgreement;
+
+uses()->group('rules', 'compliance');
+
+it('compliance query returns users who have not agreed to the current version', function () {
+    $version = RuleVersion::currentPublished();
+
+    $agreedUser = User::factory()->create(['membership_level' => MembershipLevel::Stowaway]);
+    $unagreedUser = User::factory()->withoutRulesAgreed()->create(['membership_level' => MembershipLevel::Stowaway]);
+
+    $agreedUserIds = $version->agreements()->pluck('user_id');
+    $nonAgreed = User::whereNotIn('id', $agreedUserIds)
+        ->where('membership_level', '>=', MembershipLevel::Stowaway->value)
+        ->pluck('id');
+
+    expect($nonAgreed)->toContain($unagreedUser->id)
+        ->and($nonAgreed)->not->toContain($agreedUser->id);
+});
+
+it('compliance query excludes Drifter users', function () {
+    $version = RuleVersion::currentPublished();
+
+    $drifter = User::factory()->withoutRulesAgreed()->create(['membership_level' => MembershipLevel::Drifter]);
+
+    $agreedUserIds = $version->agreements()->pluck('user_id');
+    $nonAgreed = User::whereNotIn('id', $agreedUserIds)
+        ->where('membership_level', '>=', MembershipLevel::Stowaway->value)
+        ->pluck('id');
+
+    expect($nonAgreed)->not->toContain($drifter->id);
+});
+
+it('agreement history returns all user_rule_agreements records', function () {
+    $user = User::factory()->create(['membership_level' => MembershipLevel::Stowaway]);
+    // Factory auto-creates agreement for current version
+
+    $version = RuleVersion::currentPublished();
+    $agreements = UserRuleAgreement::with(['user', 'ruleVersion'])->get();
+
+    $userAgreement = $agreements->firstWhere('user_id', $user->id);
+    expect($userAgreement)->not->toBeNull()
+        ->and($userAgreement->rule_version_id)->toBe($version->id)
+        ->and($userAgreement->agreed_at)->not->toBeNull();
+});

--- a/tests/Feature/Rules/DashboardGateTest.php
+++ b/tests/Feature/Rules/DashboardGateTest.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Actions\AgreeToRulesVersion;
+use App\Enums\MembershipLevel;
+use App\Models\User;
+
+use function Pest\Laravel\actingAs;
+use function Pest\Laravel\get;
+
+uses()->group('rules', 'dashboard-gate');
+
+it('redirects a user who has not agreed to the rules to the rules page', function () {
+    $user = User::factory()->withoutRulesAgreed()->create(['membership_level' => MembershipLevel::Stowaway]);
+
+    actingAs($user);
+
+    get(route('dashboard'))->assertRedirect(route('rules.show'));
+});
+
+it('allows a user who has agreed to the current version to access the dashboard', function () {
+    $user = User::factory()->create(['membership_level' => MembershipLevel::Stowaway]);
+    AgreeToRulesVersion::run($user, $user);
+
+    actingAs($user);
+
+    get(route('dashboard'))->assertOk();
+});
+
+it('allows access to the rules page without having agreed', function () {
+    $user = User::factory()->create(['membership_level' => MembershipLevel::Stowaway]);
+
+    actingAs($user);
+
+    get(route('rules.show'))->assertOk();
+});

--- a/tests/Feature/Rules/ParentProxyAgreementTest.php
+++ b/tests/Feature/Rules/ParentProxyAgreementTest.php
@@ -1,0 +1,125 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Actions\AgreeToRulesVersion;
+use App\Enums\BrigType;
+use App\Enums\MembershipLevel;
+use App\Models\RuleVersion;
+use App\Models\User;
+use App\Models\UserRuleAgreement;
+use App\Services\MinecraftRconService;
+
+uses()->group('rules', 'proxy-agreement');
+
+it('records proxy_user_id when parent agrees on behalf of child', function () {
+    $parent = User::factory()->create(['membership_level' => MembershipLevel::Stowaway]);
+    $child = User::factory()->withoutRulesAgreed()->create(['membership_level' => MembershipLevel::Stowaway]);
+    $parent->children()->attach($child->id);
+
+    $version = RuleVersion::currentPublished();
+
+    AgreeToRulesVersion::run($child, $parent);
+
+    $agreement = UserRuleAgreement::where('user_id', $child->id)
+        ->where('rule_version_id', $version->id)
+        ->first();
+
+    expect($agreement)->not->toBeNull()
+        ->and($agreement->proxy_user_id)->toBe($parent->id)
+        ->and($agreement->isProxy())->toBeTrue();
+});
+
+it('does not set proxy_user_id when user agrees for themselves', function () {
+    $user = User::factory()->withoutRulesAgreed()->create(['membership_level' => MembershipLevel::Stowaway]);
+    $version = RuleVersion::currentPublished();
+
+    AgreeToRulesVersion::run($user, $user);
+
+    $agreement = UserRuleAgreement::where('user_id', $user->id)
+        ->where('rule_version_id', $version->id)
+        ->first();
+
+    expect($agreement->proxy_user_id)->toBeNull()
+        ->and($agreement->isProxy())->toBeFalse();
+});
+
+it('promotes Drifter child to Stowaway when parent agrees on their behalf', function () {
+    $parent = User::factory()->create(['membership_level' => MembershipLevel::Stowaway]);
+    $child = User::factory()->withoutRulesAgreed()->create(['membership_level' => MembershipLevel::Drifter]);
+    $parent->children()->attach($child->id);
+
+    AgreeToRulesVersion::run($child, $parent);
+
+    expect($child->fresh()->membership_level)->toBe(MembershipLevel::Stowaway);
+});
+
+it('lifts rules_non_compliance brig when parent agrees on behalf of child', function () {
+    $this->mock(MinecraftRconService::class)
+        ->shouldReceive('executeCommand')
+        ->andReturn(['success' => true, 'response' => null, 'error' => null]);
+
+    $parent = User::factory()->create(['membership_level' => MembershipLevel::Stowaway]);
+    $child = User::factory()->withoutRulesAgreed()->create(['membership_level' => MembershipLevel::Stowaway]);
+    $parent->children()->attach($child->id);
+
+    \App\Actions\PutUserInBrig::run(
+        $child,
+        $child,
+        'Rules non-compliance brig.',
+        brigType: BrigType::RulesNonCompliance,
+    );
+
+    expect($child->fresh()->isInBrig())->toBeTrue();
+
+    AgreeToRulesVersion::run($child, $parent);
+
+    expect($child->fresh()->isInBrig())->toBeFalse();
+});
+
+it('unagreedChildren returns only children who have not agreed', function () {
+    $parent = User::factory()->create(['membership_level' => MembershipLevel::Stowaway]);
+    $agreedChild = User::factory()->create(['membership_level' => MembershipLevel::Stowaway]);
+    $unagreedChild = User::factory()->withoutRulesAgreed()->create(['membership_level' => MembershipLevel::Stowaway]);
+
+    $parent->children()->attach($agreedChild->id);
+    $parent->children()->attach($unagreedChild->id);
+
+    $unagreed = $parent->unagreedChildren();
+
+    expect($unagreed->pluck('id'))->toContain($unagreedChild->id)
+        ->and($unagreed->pluck('id'))->not->toContain($agreedChild->id);
+});
+
+it('dashboard gate redirects parent with unagreed children to rules page', function () {
+    $parent = User::factory()->create(['membership_level' => MembershipLevel::Stowaway]);
+    $child = User::factory()->withoutRulesAgreed()->create(['membership_level' => MembershipLevel::Stowaway]);
+    $parent->children()->attach($child->id);
+
+    $this->actingAs($parent)
+        ->get(route('dashboard'))
+        ->assertRedirect(route('rules.show'));
+});
+
+it('dashboard gate allows parent through when all children have agreed', function () {
+    $parent = User::factory()->create(['membership_level' => MembershipLevel::Stowaway]);
+    $child = User::factory()->create(['membership_level' => MembershipLevel::Stowaway]);
+    $parent->children()->attach($child->id);
+
+    $this->actingAs($parent)
+        ->get(route('dashboard'))
+        ->assertOk();
+});
+
+it('proxy agreement does not cross-contaminate: agreeing for one child does not agree for another', function () {
+    $parent = User::factory()->create(['membership_level' => MembershipLevel::Stowaway]);
+    $child1 = User::factory()->withoutRulesAgreed()->create(['membership_level' => MembershipLevel::Stowaway]);
+    $child2 = User::factory()->withoutRulesAgreed()->create(['membership_level' => MembershipLevel::Stowaway]);
+    $parent->children()->attach($child1->id);
+    $parent->children()->attach($child2->id);
+
+    AgreeToRulesVersion::run($child1, $parent);
+
+    expect($child1->fresh()->hasAgreedToCurrentRules())->toBeTrue()
+        ->and($child2->fresh()->hasAgreedToCurrentRules())->toBeFalse();
+});

--- a/tests/Feature/Rules/RulesSchemaTest.php
+++ b/tests/Feature/Rules/RulesSchemaTest.php
@@ -138,7 +138,7 @@ it('users with rules_accepted_at get a user_rule_agreements record for version 1
 });
 
 it('users without rules_accepted_at do not get an agreement record from seeder logic', function () {
-    $user = User::factory()->create([
+    $user = User::factory()->withoutRulesAgreed()->create([
         'rules_accepted_at' => null,
     ]);
 

--- a/tests/Feature/Rules/RulesSchemaTest.php
+++ b/tests/Feature/Rules/RulesSchemaTest.php
@@ -1,0 +1,153 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Enums\BrigType;
+use App\Models\User;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+uses()->group('rules', 'schema');
+
+// == Table existence and structure ==
+
+it('rule_categories table has correct columns', function () {
+    expect(Schema::hasTable('rule_categories'))->toBeTrue();
+    expect(Schema::hasColumns('rule_categories', ['id', 'name', 'sort_order', 'created_at', 'updated_at']))->toBeTrue();
+});
+
+it('rules table has correct columns', function () {
+    expect(Schema::hasTable('rules'))->toBeTrue();
+    expect(Schema::hasColumns('rules', [
+        'id', 'rule_category_id', 'title', 'description', 'status',
+        'supersedes_rule_id', 'created_by_user_id', 'created_at', 'updated_at',
+    ]))->toBeTrue();
+});
+
+it('rule_versions table has correct columns', function () {
+    expect(Schema::hasTable('rule_versions'))->toBeTrue();
+    expect(Schema::hasColumns('rule_versions', [
+        'id', 'version_number', 'status', 'created_by_user_id', 'approved_by_user_id',
+        'rejection_note', 'published_at', 'created_at', 'updated_at',
+    ]))->toBeTrue();
+});
+
+it('rule_version_rules pivot table exists', function () {
+    expect(Schema::hasTable('rule_version_rules'))->toBeTrue();
+    expect(Schema::hasColumns('rule_version_rules', ['rule_version_id', 'rule_id']))->toBeTrue();
+});
+
+it('user_rule_agreements table has correct columns', function () {
+    expect(Schema::hasTable('user_rule_agreements'))->toBeTrue();
+    expect(Schema::hasColumns('user_rule_agreements', [
+        'id', 'user_id', 'rule_version_id', 'agreed_at', 'created_at', 'updated_at',
+    ]))->toBeTrue();
+});
+
+it('discipline_report_rules pivot table exists', function () {
+    expect(Schema::hasTable('discipline_report_rules'))->toBeTrue();
+    expect(Schema::hasColumns('discipline_report_rules', ['discipline_report_id', 'rule_id']))->toBeTrue();
+});
+
+it('users table has rules_reminder_sent_at column', function () {
+    expect(Schema::hasColumn('users', 'rules_reminder_sent_at'))->toBeTrue();
+});
+
+// == BrigType enum ==
+
+it('BrigType has rules_non_compliance value', function () {
+    expect(BrigType::RulesNonCompliance->value)->toBe('rules_non_compliance');
+});
+
+it('BrigType rules_non_compliance has correct label', function () {
+    expect(BrigType::RulesNonCompliance->label())->toBe('Rules Non-Compliance');
+});
+
+// == Seeded data ==
+
+it('seeder produces 10 rule categories', function () {
+    expect(DB::table('rule_categories')->count())->toBe(10);
+});
+
+it('seeder produces 26 rules', function () {
+    expect(DB::table('rules')->count())->toBe(26);
+});
+
+it('seeder produces version 1 as published', function () {
+    $version = DB::table('rule_versions')->where('version_number', 1)->first();
+
+    expect($version)->not->toBeNull()
+        ->and($version->status)->toBe('published')
+        ->and($version->published_at)->not->toBeNull();
+});
+
+it('version 1 contains all seeded rules', function () {
+    $version = DB::table('rule_versions')->where('version_number', 1)->first();
+    $ruleCount = DB::table('rules')->count();
+    $linkedCount = DB::table('rule_version_rules')->where('rule_version_id', $version->id)->count();
+
+    expect($linkedCount)->toBe($ruleCount);
+});
+
+it('seeder produces rules_header site config', function () {
+    $config = DB::table('site_configs')->where('key', 'rules_header')->first();
+
+    expect($config)->not->toBeNull()
+        ->and($config->value)->not->toBeEmpty();
+});
+
+it('seeder produces rules_footer site config', function () {
+    $config = DB::table('site_configs')->where('key', 'rules_footer')->first();
+
+    expect($config)->not->toBeNull()
+        ->and($config->value)->not->toBeEmpty();
+});
+
+it('all seeded rules have active status', function () {
+    $inactiveOrDraft = DB::table('rules')
+        ->whereIn('status', ['draft', 'inactive'])
+        ->count();
+
+    expect($inactiveOrDraft)->toBe(0);
+});
+
+// == Legacy agreement migration ==
+
+it('users with rules_accepted_at get a user_rule_agreements record for version 1', function () {
+    $user = User::factory()->create([
+        'rules_accepted_at' => now()->subDays(10),
+    ]);
+
+    // Simulate what the seeder does for a new user created before the migration
+    $version = DB::table('rule_versions')->where('version_number', 1)->first();
+
+    DB::table('user_rule_agreements')->insertOrIgnore([
+        'user_id' => $user->id,
+        'rule_version_id' => $version->id,
+        'agreed_at' => $user->rules_accepted_at,
+        'created_at' => now(),
+        'updated_at' => now(),
+    ]);
+
+    $agreement = DB::table('user_rule_agreements')
+        ->where('user_id', $user->id)
+        ->where('rule_version_id', $version->id)
+        ->first();
+
+    expect($agreement)->not->toBeNull();
+});
+
+it('users without rules_accepted_at do not get an agreement record from seeder logic', function () {
+    $user = User::factory()->create([
+        'rules_accepted_at' => null,
+    ]);
+
+    $version = DB::table('rule_versions')->where('version_number', 1)->first();
+
+    $agreement = DB::table('user_rule_agreements')
+        ->where('user_id', $user->id)
+        ->where('rule_version_id', $version->id)
+        ->first();
+
+    expect($agreement)->toBeNull();
+});


### PR DESCRIPTION
## What Changed

This PR adds a complete versioned Community Rules system to the site. The old static rules page is replaced with a database-backed system where rules are organized into categories, bundled into published versions, and tracked per-user.

Key features:
- Staff with "Rules - Manage" can create draft rule versions, add/edit/deactivate rules, manage categories, and edit header/footer content
- A two-person approval workflow ensures rule changes are reviewed before going live
- Members must agree to each new version individually, with NEW/UPDATED badges highlighting what changed
- A daily job sends reminder emails at 14 days and places non-compliant members in a temporary Rules Non-Compliance restriction at 28 days (auto-lifted on agreement)
- Parents can agree on behalf of linked child accounts via a proxy agreement flow
- Discipline reports can now optionally link to specific rules that were violated
- Staff admin page includes compliance monitoring (who hasn't agreed) and a full agreement audit history

## How to Test

### Agreeing to the Rules (as a member)
1. Log in as a Stowaway+ user who has not agreed to the current version
2. Try to visit `/dashboard` -- you should be redirected to `/rules`
3. On the rules page, check each rule checkbox one by one
4. The "I Have Read and Agree to All Rules" button should only become active once all boxes are checked
5. Click it and confirm you're redirected to the dashboard

### NEW / UPDATED badges
1. Publish a new rule version with at least one new rule and one edited rule
2. Log in as a user who agreed to the previous version
3. Visit `/rules` -- new rules should show a **NEW** badge; edited rules should show **UPDATED** with a collapsible previous version

### Parent Proxy Agreement
1. Log in as a parent user with a child account that has not agreed
2. Visit `/dashboard` -- you should be redirected to `/rules`
3. After the main rules list (assuming you've already agreed), you should see a "Proxy Agreement Required" section listing your unagreed children
4. Select one or more children and click "Submit Proxy Agreement"
5. Verify that the child's agreement is recorded and the dashboard becomes accessible

### Rules Admin (requires "Rules - Manage" role)
1. Go to the Admin Control Panel → Rules tab
2. Create a new draft version
3. Add a new rule, edit an existing one, and deactivate another
4. Submit for approval
5. As a different user with "Rules - Approve" role, approve the version
6. Verify all Stowaway+ users receive an email notification

### Compliance Monitoring
1. After publishing a version, go to the Rules Admin page
2. Scroll to the Compliance section -- it should list members who haven't agreed
3. Days overdue should show amber at 14+ days and red at 28+

### Discipline Report Rules Violated
1. Open a user's profile and create a new discipline report
2. In the form, expand the "Rules Violated" section and select one or more rules
3. Save and view the report -- the selected rules should appear as red badges
4. Edit the report and change the selected rules -- verify the list updates

## Things to Watch For

- The middleware gate (`ensure-rules-agreed`) is now on the dashboard route -- if something is broken in the rules agreement logic, all members could get stuck in a redirect loop
- The parent proxy section only appears after the parent has agreed themselves -- confirm a parent who hasn't agreed yet sees only the main rules form, not the proxy section
- The compliance list should exclude Drifter-level users (they're not yet required to agree)
- Agreeing auto-lifts a Rules Non-Compliance brig -- test this end-to-end if you have a test user in that state

## Parent PRD

#571

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Versioned Community Rules: read/agree UI, parent-proxy agreements, NEW/UPDATED badges, editable header/footer, admin rules workflow (draft → submit → approve → publish), automated reminders and 28‑day restriction flow.

* **Notifications & Jobs**
  * Reminder and published-version notifications; daily compliance checker to send reminders and enforce restrictions.

* **Data & Migrations**
  * Schema, models, factories and pivots to support categories, rules, versions and user agreements.

* **UI**
  * Rules page, dashboard redirect when required, admin Rules manager, compliance list, version history, and discipline‑report “Rules Violated” selection.

* **Documentation**
  * Full member and staff guides for rules workflows and admin procedures.

* **Tests**
  * Extensive feature, job and UI tests covering workflows, compliance and schema.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->