### PR TITLE
Tech Debt & Polish Sprint: Brig, Profile, Onboarding, PDF, Discord, Staff Activity

### DIFF
--- a/app/Actions/PutUserInBrig.php
+++ b/app/Actions/PutUserInBrig.php
@@ -69,8 +69,10 @@ class PutUserInBrig
             $account->save();
         }
 
-        // Strip Discord roles and mark accounts as brigged
+        // Strip Discord roles, mark accounts as brigged, and assign the "In Brig" role
         $discordApi = app(\App\Services\DiscordApiService::class);
+        $brigRoleId = (string) config('lighthouse.discord.roles.in_brig', '');
+
         foreach ($target->discordAccounts()->whereIn('status', [DiscordAccountStatus::Active, DiscordAccountStatus::ParentDisabled])->get() as $discordAccount) {
             try {
                 $discordApi->removeAllManagedRoles($discordAccount->discord_user_id);
@@ -80,6 +82,18 @@ class PutUserInBrig
                     'user_id' => $target->id,
                     'error' => $e->getMessage(),
                 ]);
+            }
+
+            if ($brigRoleId !== '') {
+                try {
+                    $discordApi->addRole($discordAccount->discord_user_id, $brigRoleId);
+                } catch (\Exception $e) {
+                    \Illuminate\Support\Facades\Log::warning('Failed to assign In Brig Discord role', [
+                        'discord_user_id' => $discordAccount->discord_user_id,
+                        'user_id' => $target->id,
+                        'error' => $e->getMessage(),
+                    ]);
+                }
             }
 
             $discordAccount->status = DiscordAccountStatus::Brigged;

--- a/app/Actions/ReleaseUserFromBrig.php
+++ b/app/Actions/ReleaseUserFromBrig.php
@@ -65,8 +65,23 @@ class ReleaseUserFromBrig
             ? DiscordAccountStatus::Active
             : DiscordAccountStatus::ParentDisabled;
 
-        // Restore Discord accounts from brigged
+        $discordApi = app(\App\Services\DiscordApiService::class);
+        $brigRoleId = (string) config('lighthouse.discord.roles.in_brig', '');
+
+        // Restore Discord accounts from brigged and remove the "In Brig" role
         foreach ($target->discordAccounts()->where('status', DiscordAccountStatus::Brigged)->get() as $discordAccount) {
+            if ($brigRoleId !== '') {
+                try {
+                    $discordApi->removeRole($discordAccount->discord_user_id, $brigRoleId);
+                } catch (\Exception $e) {
+                    Log::warning('Failed to remove In Brig Discord role on release', [
+                        'discord_user_id' => $discordAccount->discord_user_id,
+                        'user_id' => $target->id,
+                        'error' => $e->getMessage(),
+                    ]);
+                }
+            }
+
             try {
                 $discordAccount->status = $discordRestoreStatus;
                 $discordAccount->save();

--- a/app/Http/Controllers/DiscordAuthController.php
+++ b/app/Http/Controllers/DiscordAuthController.php
@@ -15,7 +15,9 @@ class DiscordAuthController extends Controller
         Gate::authorize('link-discord');
 
         if ($request->get('from') === 'onboarding') {
-            session(['discord_oauth_from' => 'onboarding']);
+            $request->session()->put('discord_oauth_from', 'onboarding');
+        } else {
+            $request->session()->forget('discord_oauth_from');
         }
 
         return Socialite::driver('discord')

--- a/app/Http/Controllers/DiscordAuthController.php
+++ b/app/Http/Controllers/DiscordAuthController.php
@@ -10,9 +10,13 @@ use Laravel\Socialite\Facades\Socialite;
 
 class DiscordAuthController extends Controller
 {
-    public function redirect()
+    public function redirect(Request $request)
     {
         Gate::authorize('link-discord');
+
+        if ($request->get('from') === 'onboarding') {
+            session(['discord_oauth_from' => 'onboarding']);
+        }
 
         return Socialite::driver('discord')
             ->scopes(['identify', 'guilds.join'])
@@ -23,12 +27,16 @@ class DiscordAuthController extends Controller
     {
         Gate::authorize('link-discord');
 
+        $from = session()->pull('discord_oauth_from');
+        $successRoute = $from === 'onboarding' ? 'dashboard' : 'settings.discord-account';
+        $errorRoute = $from === 'onboarding' ? 'dashboard' : 'settings.discord-account';
+
         try {
             $discordUser = Socialite::driver('discord')->user();
         } catch (\Exception $e) {
             Log::warning('Discord OAuth callback failed', ['error' => $e->getMessage()]);
 
-            return redirect()->route('settings.discord-account')
+            return redirect()->route($errorRoute)
                 ->with('error', 'Failed to authenticate with Discord. Please try again.');
         }
 
@@ -43,11 +51,11 @@ class DiscordAuthController extends Controller
         ]);
 
         if ($result['success']) {
-            return redirect()->route('settings.discord-account')
+            return redirect()->route($successRoute)
                 ->with('success', $result['message']);
         }
 
-        return redirect()->route('settings.discord-account')
+        return redirect()->route($errorRoute)
             ->with('error', $result['message']);
     }
 }

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -4,6 +4,7 @@ namespace App\Providers;
 
 use App\Enums\MembershipLevel;
 use App\Enums\StaffDepartment;
+use App\Enums\StaffRank;
 use Illuminate\Foundation\Support\Providers\AuthServiceProvider as ServiceProvider;
 use Illuminate\Support\Facades\Gate;
 
@@ -257,6 +258,16 @@ class AuthServiceProvider extends ServiceProvider
         // Community finance view — Resident+ members can see closed period summaries
         Gate::define('finance-community-view', function ($user) {
             return $user->isAdmin() || (! $user->in_brig && $user->isAtLeastLevel(MembershipLevel::Resident));
+        });
+
+        Gate::define('view-staff-activity', function ($user, $targetUser) {
+            // The staff member themselves
+            if ($user->id === $targetUser->id) {
+                return true;
+            }
+
+            // Command officers and department leads (Officer rank in any department)
+            return $user->isAtLeastRank(StaffRank::Officer);
         });
 
         // Rules gates

--- a/config/lighthouse.php
+++ b/config/lighthouse.php
@@ -123,6 +123,7 @@ return [
             'rank_officer' => env('DISCORD_ROLE_RANK_OFFICER'),
             // Special
             'verified' => env('DISCORD_ROLE_VERIFIED'),
+            'in_brig' => env('DISCORD_ROLE_IN_BRIG'),
         ],
     ],
 ];

--- a/docs/features/prd-599-tech-debt-polish-sprint.md
+++ b/docs/features/prd-599-tech-debt-polish-sprint.md
@@ -1,0 +1,628 @@
+# PRD #599: Tech Debt & Polish Sprint — Technical Reference
+
+## Overview
+
+PRD #599 encompasses six interconnected features focused on improving the robustness, consistency, and user experience of the Lighthouse Website. These features address long-standing technical debt, enhance authorization controls, streamline workflows, and tighten integrations between the core brig system, Discord account management, and staff tracking. Each feature is independently deployable but designed to work cohesively, with particular emphasis on the permanent brig option and Discord role synchronization during disciplinary actions. The work includes updates to modals, validation logic, configuration, and comprehensive test coverage across Livewire components, actions, and API integration points.
+
+## Feature 1: Permanent Brig Option
+
+### Overview
+Users with the `Brig Warden` role can now place a user in the brig with or without an automatic release timer. The modal includes a "Permanent (no expiry)" checkbox that, when checked, disables the optional days input and allows placing a user in the brig with no expiration date.
+
+### How It Works
+
+**Component:** `resources/views/livewire/users/display-basic-details.blade.php`
+
+**State Properties:**
+- `$brigActionPermanent` (bool): Tracks whether the permanent checkbox is checked
+- `$brigActionDays` (int|null): Number of days until auto-release (only used when permanent is false)
+- `$brigActionReason` (string): Required reason for the brig placement (minimum 5 characters)
+
+**Key Methods:**
+
+- **`openPutInBrigModal()`**: Prepares the modal by resetting form state and checking authorization via `'put-in-brig'` gate.
+  ```php
+  public function openPutInBrigModal(): void
+  {
+      if (! Auth::user()->can('put-in-brig')) {
+          return;
+      }
+      $this->brigActionReason = '';
+      $this->brigActionDays = null;
+      $this->brigActionPermanent = false;
+      Flux::modal('profile-put-in-brig-modal')->show();
+  }
+  ```
+
+- **`confirmPutInBrig()`**: Validates form input and executes the brig placement. Validation differs based on permanent status:
+  - When `$brigActionPermanent === true`: `brigActionDays` becomes `nullable` (no validation requirement)
+  - When `$brigActionPermanent === false`: `brigActionDays` is `nullable|integer|min:1|max:365` (only validated if a value is provided)
+  
+  Expiration logic:
+  ```php
+  $expiresAt = (! $this->brigActionPermanent && $this->brigActionDays)
+      ? now()->addDays((int) $this->brigActionDays)
+      : null;
+  ```
+  If permanent is checked or no days are provided, `$expiresAt` is `null`, creating a permanent brig entry.
+
+### Modal UI
+
+**Location:** `profile-put-in-brig-modal` (lines 1017–1044)
+
+- Shows a checkbox "Permanent (no expiry)" that toggles the days input visibility
+- Days input uses Alpine.js `x-show="!$wire.brigActionPermanent"` to conditionally display only when permanent is unchecked
+- Days input is disabled when permanent is checked (`:disabled="$brigActionPermanent"`)
+
+### Authorization
+Gate `'put-in-brig'` requires the user to have the `Brig Warden` role:
+```php
+Gate::define('put-in-brig', function ($user) {
+    return $user->hasRole('Brig Warden');
+});
+```
+
+### Data Flow
+1. Admin/Brig Warden opens the modal via `openPutInBrigModal()`
+2. Fills in reason and optionally checks permanent or sets days
+3. Calls `confirmPutInBrig()` which validates and calls `PutUserInBrig::run()`
+4. User record is updated with `in_brig=true`, `brig_expires_at` (null if permanent), and related fields
+5. Discord roles are synced (see Feature 6)
+6. Minecraft accounts are banned
+7. Activity log entry is recorded with expiration status
+
+### Related Action Classes
+- `PutUserInBrig::handle()` — Executes brig placement with Discord and Minecraft side effects (lines 32–119)
+
+## Feature 2: Profile Edit Restrictions
+
+### Overview
+When editing a user profile, the editable fields depend on the role of the person editing. Non-manager users can only edit the user's name; admins and User - Manager role users can edit all fields (name, email, date of birth, parent email).
+
+### Authorization
+The component checks authorization via:
+```php
+$this->authorize('update', $this->user);  // In openEditUserModal() and saveEditUser()
+```
+
+### canEditAllFields() Method
+
+**Location:** Line 412 in `display-basic-details.blade.php`
+
+```php
+public function canEditAllFields(): bool
+{
+    return Auth::user()->isAdmin() || Auth::user()->hasRole('User - Manager');
+}
+```
+
+Returns `true` only if the current user is an admin or has the `User - Manager` role. Everyone else can only edit the name field.
+
+### Restricted Fields
+
+When `canEditAllFields()` returns `false`, the following fields are read-only (displayed as plain text):
+- **Email** — Shows current email with message "Contact staff to update your email address."
+- **Date of Birth** — Displayed as read-only text if set
+- **Parent Email** — Displayed as read-only text if set
+
+When `canEditAllFields()` returns `true`, all fields are editable inputs.
+
+### Data Flow
+
+**Modal:** `profile-edit-user-modal`
+
+1. Admin/manager opens modal via `openEditUserModal()` (line 398)
+2. Modal initializes `editUserData` with current user values (lines 402–407)
+3. Template conditionally renders inputs or read-only text based on `$this->canEditAllFields()`
+4. On save, `saveEditUser()` validates based on role:
+   - Always validates `editUserData.name` as required, string, max 32 characters
+   - If `canEditAllFields()` is true, adds validation for email, date_of_birth, parent_email
+5. Updates only the permitted fields on the user record
+6. If parent email changed and `canEditAllFields()`, runs `LinkParentByEmail::run()`
+7. Records activity as `'update_profile'`
+
+### Validation Rules
+
+```php
+$rules = [
+    'editUserData.name' => ['required', 'string', 'max:32'],
+];
+
+if ($this->canEditAllFields()) {
+    $rules['editUserData.email'] = ['required', 'email', 'max:255', Rule::unique('users', 'email')->ignore($this->user->id)];
+    $rules['editUserData.date_of_birth'] = ['nullable', 'date', 'before:today'];
+    $rules['editUserData.parent_email'] = ['nullable', 'email'];
+}
+```
+
+### Related Methods
+- `openEditUserModal()` (line 398) — Prepares modal data and shows it
+- `saveEditUser()` (line 417) — Validates and persists changes
+- `LinkParentByEmail::run()` (line 451) — Action to link/relink parent when email is updated
+
+## Feature 3: Discord OAuth Return URL
+
+### Overview
+When a user initiates Discord account linking from the onboarding wizard, they are redirected back to the dashboard after successful linking instead of to the settings page. This is tracked via a `discord_oauth_from` session key set during the OAuth redirect.
+
+### Session Key: discord_oauth_from
+
+**Location:** `app/Http/Controllers/DiscordAuthController.php`
+
+**Redirect Method (lines 13–24):**
+```php
+public function redirect(Request $request)
+{
+    Gate::authorize('link-discord');
+
+    if ($request->get('from') === 'onboarding') {
+        session(['discord_oauth_from' => 'onboarding']);
+    }
+
+    return Socialite::driver('discord')
+        ->scopes(['identify', 'guilds.join'])
+        ->redirect();
+}
+```
+
+The session key is only set when the `from` query parameter is exactly `'onboarding'`. No other values are accepted.
+
+**Callback Method (lines 26–60):**
+```php
+$from = session()->pull('discord_oauth_from');  // Retrieves and clears the key
+$successRoute = $from === 'onboarding' ? 'dashboard' : 'settings.discord-account';
+$errorRoute = $from === 'onboarding' ? 'dashboard' : 'settings.discord-account';
+```
+
+The `session()->pull()` method retrieves the value and removes it from the session in one operation. If `$from` is `'onboarding'`, both success and error redirects go to `route('dashboard')`; otherwise they go to `route('settings.discord-account')`.
+
+### Onboarding Wizard Integration
+
+**Location:** `resources/views/livewire/onboarding/wizard.blade.php` (line 114)
+
+The Discord step button now links directly to the OAuth redirect with the `from` parameter:
+```blade
+<flux:button href="{{ route('auth.discord.redirect', ['from' => 'onboarding']) }}" variant="primary">
+    Connect Discord
+</flux:button>
+```
+
+Previously, it may have linked to a settings page; now it goes through the OAuth flow and returns to the dashboard to continue onboarding.
+
+### Authorization
+The `'link-discord'` gate is checked at the start of both methods:
+```php
+Gate::authorize('link-discord');
+```
+
+Gate definition (line 91–93 in AuthServiceProvider):
+```php
+Gate::define('link-discord', function ($user) {
+    return $user->isAtLeastLevel(MembershipLevel::Stowaway) && ! $user->in_brig && $user->parent_allows_discord;
+});
+```
+
+## Feature 4: Finance Report PDF Headers
+
+### Overview
+Finance reports now include a print-only header that appears when the page is printed or exported to PDF. The header displays the organization logo, report title (based on the active tab), and generation timestamp.
+
+### Print Header Location
+
+**File:** `resources/views/livewire/finance/reports.blade.php` (lines 547–571)
+
+```blade
+{{-- Print header (only visible when printing) --}}
+<div class="hidden print:block mb-6">
+    @php
+        $tabLabels = [
+            'activities'   => 'Statement of Activities',
+            'ledger'       => 'General Ledger',
+            'trial'        => 'Trial Balance',
+            'balance-sheet'=> 'Balance Sheet',
+            'cash-flow'    => 'Cash Flow Statement',
+            'variance'     => 'Budget vs. Actual',
+        ];
+        $reportTitle = $tabLabels[$activeTab] ?? 'Financial Report';
+    @endphp
+
+    <div style="display:flex; align-items:center; gap:12px; margin-bottom:8px;">
+        <img src="{{ asset('img/LighthouseMC_Logo.png') }}" alt="{{ config('app.name') }}" style="width:48px; height:48px; border-radius:6px;" />
+        <div>
+            <div style="font-size:18px; font-weight:700; line-height:1.2;">{{ config('app.name') }}</div>
+            <div style="font-size:14px; font-weight:600; color:#374151;">{{ $reportTitle }}</div>
+        </div>
+    </div>
+    <div style="border-top:1px solid #d1d5db; padding-top:6px;">
+        <span style="font-size:12px; color:#6b7280;">Generated {{ now()->format('F j, Y') }}</span>
+    </div>
+</div>
+```
+
+### Inline Styles Rationale
+
+All CSS is written inline (not as classes) to ensure styles are preserved when the report is printed or exported to PDF. PDF export engines often strip out Tailwind CSS classes, making inline styles essential for consistent appearance in PDF output. Key styled elements:
+
+| Element | Style | Rationale |
+|---------|-------|-----------|
+| Container | `display:flex; align-items:center; gap:12px; margin-bottom:8px;` | Horizontal layout with logo and text side-by-side |
+| Logo | `width:48px; height:48px; border-radius:6px;` | Consistent square logo with subtle rounding |
+| Organization Name | `font-size:18px; font-weight:700; line-height:1.2;` | Large, bold header text |
+| Report Title | `font-size:14px; font-weight:600; color:#374151;` | Smaller subtitle, gray text (#374151 = gray-700) |
+| Divider | `border-top:1px solid #d1d5db;` | Subtle gray line separator |
+| Timestamp | `font-size:12px; color:#6b7280;` | Small, gray (#6b7280 = gray-500) timestamp |
+
+### Tab-to-Title Mapping
+
+The header dynamically displays the report title based on the active tab:
+
+| Active Tab | Header Title |
+|-----------|--------------|
+| `activities` | Statement of Activities |
+| `ledger` | General Ledger |
+| `trial` | Trial Balance |
+| `balance-sheet` | Balance Sheet |
+| `cash-flow` | Cash Flow Statement |
+| `variance` | Budget vs. Actual |
+| (unknown/default) | Financial Report |
+
+### Visibility Control
+
+- **Screen display:** Hidden via `class="hidden"`; only the print UI is visible (tabs, filters, buttons)
+- **Print display:** Shown via `class="print:block"`; only the header and report tables are visible
+- **Print button:** Line 542–544 in the same file provides a "Print / PDF" button that triggers browser print dialog
+
+## Feature 5: Discord Brig Role Sync
+
+### Overview
+When a user is placed in or released from the brig, their Discord account(s) are assigned or removed from a special "In Brig" role. This is configured via the environment variable `DISCORD_ROLE_IN_BRIG` and is applied separately from the existing role-stripping logic.
+
+### Configuration
+
+**File:** `config/lighthouse.php` (line 126)
+
+```php
+'discord' => [
+    'roles' => [
+        // ... other roles ...
+        'in_brig' => env('DISCORD_ROLE_IN_BRIG'),
+    ],
+],
+```
+
+**Environment Variable:** `DISCORD_ROLE_IN_BRIG`
+
+This should be set to a Discord role ID (string). If not set, the role sync is skipped gracefully (no error is raised).
+
+### PutUserInBrig Action
+
+**File:** `app/Actions/PutUserInBrig.php` (lines 72–101)
+
+When a user is placed in the brig, Discord side effects occur in this order:
+
+1. **Retrieve the brig role ID:**
+   ```php
+   $brigRoleId = (string) config('lighthouse.discord.roles.in_brig', '');
+   ```
+
+2. **Iterate over active Discord accounts** (status = Active or ParentDisabled):
+   ```php
+   foreach ($target->discordAccounts()->whereIn('status', [DiscordAccountStatus::Active, DiscordAccountStatus::ParentDisabled])->get() as $discordAccount) {
+   ```
+
+3. **Strip all managed roles** (try/catch with warning log):
+   ```php
+   try {
+       $discordApi->removeAllManagedRoles($discordAccount->discord_user_id);
+   } catch (\Exception $e) {
+       \Illuminate\Support\Facades\Log::warning('Failed to strip Discord roles during brig', [...]);
+   }
+   ```
+
+4. **Assign the In Brig role** (only if `$brigRoleId !== ''`):
+   ```php
+   if ($brigRoleId !== '') {
+       try {
+           $discordApi->addRole($discordAccount->discord_user_id, $brigRoleId);
+       } catch (\Exception $e) {
+           \Illuminate\Support\Facades\Log::warning('Failed to assign In Brig Discord role', [...]);
+       }
+   }
+   ```
+
+5. **Mark account as brigged:**
+   ```php
+   $discordAccount->status = DiscordAccountStatus::Brigged;
+   $discordAccount->save();
+   ```
+
+### ReleaseUserFromBrig Action
+
+**File:** `app/Actions/ReleaseUserFromBrig.php` (lines 68–95)
+
+When a user is released from the brig, the In Brig role is removed:
+
+1. **Retrieve the brig role ID:**
+   ```php
+   $brigRoleId = (string) config('lighthouse.discord.roles.in_brig', '');
+   ```
+
+2. **Iterate over brigged Discord accounts:**
+   ```php
+   foreach ($target->discordAccounts()->where('status', DiscordAccountStatus::Brigged)->get() as $discordAccount) {
+   ```
+
+3. **Remove the In Brig role** (only if `$brigRoleId !== ''`):
+   ```php
+   if ($brigRoleId !== '') {
+       try {
+           $discordApi->removeRole($discordAccount->discord_user_id, $brigRoleId);
+       } catch (\Exception $e) {
+           Log::warning('Failed to remove In Brig Discord role on release', [...]);
+       }
+   }
+   ```
+
+4. **Restore account status** based on parent toggle:
+   ```php
+   $discordRestoreStatus = $target->parent_allows_discord
+       ? DiscordAccountStatus::Active
+       : DiscordAccountStatus::ParentDisabled;
+   $discordAccount->status = $discordRestoreStatus;
+   $discordAccount->save();
+   ```
+
+5. **Sync Discord roles** if restoring to Active:
+   ```php
+   if ($discordRestoreStatus === DiscordAccountStatus::Active) {
+       try {
+           SyncDiscordRoles::run($target);
+       } catch (\Exception $e) {
+           Log::error('Failed to sync Discord roles on brig release', [...]);
+       }
+       // Also sync staff roles if applicable
+   }
+   ```
+
+### Error Handling (Try/Catch Behavior)
+
+Both actions use a **try/catch with logging** pattern rather than throwing exceptions. This ensures that:
+
+- Transient Discord API failures do not fail the entire brig operation
+- All errors are logged with context (user ID, Discord user ID, error message)
+- The brig placement or release completes even if Discord role operations fail
+- Staff can see what happened in the logs for debugging
+
+**Log Levels:**
+- `Log::warning()` for role operation failures (expected to be recoverable)
+- `Log::error()` for account status/sync failures (more serious issues)
+
+## Feature 6: Staff Activity Card
+
+### Overview
+A new Livewire component displays a summary of a staff member's activity over the last 3 months: meeting attendance, staff reports filed/missed, and assigned tickets. The component is only shown on staff member profiles and is gated by authorization.
+
+### Component Location
+
+**File:** `resources/views/livewire/users/staff-activity-card.blade.php`
+
+**Component Class:** Lines 1–122 (PHP) define the Livewire Volt component.
+
+### Authorization Gate
+
+**Gate Name:** `'view-staff-activity'`
+
+**Location:** `app/Providers/AuthServiceProvider.php` (lines 263–271)
+
+```php
+Gate::define('view-staff-activity', function ($user, $targetUser) {
+    // The staff member themselves
+    if ($user->id === $targetUser->id) {
+        return true;
+    }
+
+    // Command officers and department leads (Officer rank in any department)
+    return $user->isAtLeastRank(StaffRank::Officer);
+});
+```
+
+Authorization allows viewing if:
+1. The user is viewing their own activity card, OR
+2. The user is at least an Officer rank (across any department)
+
+### Data Displayed
+
+The card displays four key metrics calculated from the last 3 months of data:
+
+#### 1. Meeting Attendance
+- **Query:** Completed staff meetings in the last 3 months
+- **Display:** `{{ $this->attendanceCount }} / {{ $this->totalMeetings3mo }}` meetings
+- **Interactive:** Clicking the count opens a modal with a table of all meetings and attendance status
+
+#### 2. Staff Reports
+- **Filed:** Count of submitted meeting reports for staff meetings in the last 3 months
+- **Missed:** Calculated as `totalMeetings3mo - reportsFiled`
+- **Display:** Shows "X filed" and optionally a "Y missed" badge (only if missed > 0)
+
+#### 3. Tickets
+- **Open:** Count of Open and Pending tickets assigned to the staff member
+- **Closed:** Count of Resolved and Closed tickets assigned to the staff member
+- **Display:** Two badges showing "X open" and "Y closed"
+
+### Component Properties & Methods
+
+**Locked Properties:**
+- `$userId` — The staff member's user ID (locked to prevent tampering)
+
+**Computed Properties:**
+- `$user` — Resolves the User model by `$userId`
+- `$meetingAttendance` — Collection of attendance records with meeting details
+- `$attendanceCount` — Number of meetings attended in last 3 months
+- `$totalMeetings3mo` — Total number of staff meetings in last 3 months
+- `$reportsFiled` — Count of submitted reports
+- `$reportsMissed` — Calculated as `totalMeetings3mo - reportsFiled` (min 0)
+- `$openTickets` — Count of Open/Pending tickets
+- `$closedTickets` — Count of Resolved/Closed tickets
+
+**Methods:**
+- `mount(User $user)` — Authorizes access and sets `$userId`
+- `openAttendanceModal()` — Shows the attendance detail modal
+
+### Modal Behavior
+
+**Modal Name:** `staff-attendance-modal-{{ $this->userId }}`
+
+The attendance modal displays:
+- Meeting title
+- Meeting date (M j, Y format)
+- Attendance status badge:
+  - "Not on Record" — User not in pivot table
+  - "Attended" — Pivot exists and `attended=true`
+  - "Absent" — Pivot exists and `attended=false`
+
+### Time Window
+
+All metrics are calculated from the last 3 months (hardcoded via `now()->subMonths(3)`). The badge on the card header reads "Last 3 months".
+
+### Display Integration
+
+**Location:** `resources/views/users/show.blade.php` (lines 16–22)
+
+The card is conditionally shown only if:
+1. The user has a staff position (`$user->staffPosition` is not null)
+2. Authorization passes (gate `'view-staff-activity'`)
+
+```blade
+@if($user->staffPosition)
+    @can('view-staff-activity', $user)
+        <div class="my-6">
+            <livewire:users.staff-activity-card :user="$user" />
+        </div>
+    @endcan
+@endif
+```
+
+## Authorization & Gates Summary
+
+| Gate Name | Definition | Purpose |
+|-----------|-----------|---------|
+| `put-in-brig` | User has `Brig Warden` role | Allow placing users in brig |
+| `release-from-brig` | User has `Brig Warden` role | Allow releasing users from brig |
+| `link-discord` | Stowaway+, not in brig, parent_allows_discord | Allow Discord account linking |
+| `view-staff-activity` | Self-view OR Officer+ rank | Allow viewing staff activity metrics |
+
+### Authorization in Components
+
+- **display-basic-details.blade.php:**
+  - `openPutInBrigModal()`: checks `'put-in-brig'`
+  - `confirmPutInBrig()`: checks `'put-in-brig'`
+  - `openReleaseFromBrigModal()`: checks `'release-from-brig'`
+  - `confirmReleaseFromBrig()`: checks `'release-from-brig'`
+  - `openEditUserModal()`: checks `'update'` policy (model policy)
+  - `saveEditUser()`: checks `'update'` policy
+
+- **staff-activity-card.blade.php:**
+  - `mount()`: checks `'view-staff-activity'` gate
+
+## Test Coverage
+
+### PermaBrigModalTest.php
+**File:** `tests/Feature/Livewire/PermaBrigModalTest.php`
+
+Tests the permanent brig checkbox behavior:
+
+1. **it('shows permanent checkbox in brig modal')** — Verifies the Permanent checkbox is visible in the component
+2. **it('places user in permanent brig when permanent checkbox is checked')** — Checks that with `brigActionPermanent=true`, `brig_expires_at` is null
+3. **it('places user in timed brig when permanent is unchecked and days are set')** — Verifies that with `brigActionPermanent=false` and `brigActionDays=7`, an expiration timestamp is set
+4. **it('places user in brig with no expiry when permanent is unchecked and no days set')** — Checks that with `brigActionPermanent=false` and `brigActionDays=null`, no expiration is set
+
+### ProfileEditRestrictionsTest.php
+**File:** `tests/Feature/Livewire/ProfileEditRestrictionsTest.php`
+
+Tests field edit restrictions based on user role:
+
+1. **it('regular user editing own profile can only update username')** — Non-managers can only change name; email, DOB, parent_email remain unchanged
+2. **it('user-manager can edit all fields')** — Users with `User - Manager` role can update all fields
+3. **it('admin can edit all fields on any profile')** — Admins can update all fields
+4. **it('regular user edit modal shows protected fields as read-only text')** — Verifies that non-managers see "Contact staff to update your email address." message
+5. **it('user-manager edit modal shows protected fields as inputs')** — Verifies that managers do NOT see the contact-staff message and can edit
+
+### OnboardingDiscordFlowTest.php
+**File:** `tests/Feature/Discord/OnboardingDiscordFlowTest.php`
+
+Tests Discord OAuth return flow from onboarding:
+
+1. **it('stores onboarding origin in session when from=onboarding param is passed')** — Verifies `session('discord_oauth_from')` is set to 'onboarding'
+2. **it('does not store onboarding origin when from param is absent')** — Verifies no session key is set without the param
+3. **it('does not store origin for unrecognised from values')** — Verifies only 'onboarding' is accepted; 'evil' or other values are ignored
+4. **it('callback redirects to dashboard on success when from=onboarding was stored')** — Verifies successful OAuth callback redirects to 'dashboard' route
+5. **it('callback redirects to settings on success without onboarding session')** — Verifies callback without session key redirects to 'settings.discord-account'
+6. **it('callback redirects to dashboard on OAuth error when from=onboarding')** — Verifies error during OAuth redirects to 'dashboard' when onboarding
+7. **it('wizard discord step links directly to OAuth redirect with onboarding param')** — Verifies the button in wizard uses the correct href with `from=onboarding`
+8. **it('wizard discord step does not link to settings page')** — Verifies the wizard button does NOT link to settings
+
+### ReportsTest.php
+**File:** `tests/Feature/Finance/ReportsTest.php` (last ~40 lines)
+
+Tests the print header functionality:
+
+1. **it('print header includes the org name')** — Verifies `config('app.name')` appears in the component output
+2. **it('print header includes the Lighthouse logo')** — Verifies the logo path 'LighthouseMC_Logo.png' is present
+3. **it('print header shows report title for active tab')** — Sets `activeTab='ledger'` and verifies 'General Ledger' appears
+4. **it('print header shows Statement of Activities for default tab')** — Verifies default tab title is 'Statement of Activities'
+
+### DiscordBrigIntegrationTest.php
+**File:** `tests/Feature/Discord/DiscordBrigIntegrationTest.php`
+
+Tests Discord role sync during brig operations:
+
+1. **it('sets discord accounts to brigged when user is put in brig')** — Verifies Discord account status changes to `Brigged`
+2. **it('calls removeAllManagedRoles when brigging')** — Verifies the API call to strip existing roles is made
+3. **it('restores discord accounts to active when released from brig')** — Verifies Discord account status changes back to `Active`
+4. **it('syncs discord permissions when released from brig')** — Verifies `SyncDiscordRoles::run()` is called on release
+5. **it('assigns the In Brig Discord role when user is put in brig')** — Verifies `addRole()` is called with the brig role ID from config
+6. **it('removes the In Brig Discord role when user is released from brig')** — Verifies `removeRole()` is called with the brig role ID
+7. **it('silently skips In Brig role sync when no Discord account is linked')** — Verifies no API calls occur if user has no Discord accounts
+8. **it('does not assign In Brig role when config key is not set')** — Verifies role assignment is skipped if `DISCORD_ROLE_IN_BRIG` is null or empty
+
+### StaffActivityCardTest.php
+**File:** `tests/Feature/Livewire/StaffActivityCardTest.php`
+
+Tests authorization and data display of the staff activity card:
+
+**Authorization Tests:**
+1. **it('shows card on staff profile page to the staff member themselves')** — Staff member can view their own card
+2. **it('shows card on staff profile page to an officer')** — Officer+ can view any staff member's card
+3. **it('does not show card on non-staff profile page')** — Card is hidden if user has no staff position
+4. **it('denies crew members from viewing another staff member activity card')** — Crew members (non-officers) are forbidden
+5. **it('denies regular members from viewing the staff activity card')** — Regular members are forbidden
+
+**Attendance Count Tests:**
+6. **it('shows correct attendance count from last 3 months')** — Displays "1 / 2" for 1 attended out of 2 meetings
+7. **it('does not count meetings older than 3 months in attendance')** — Excludes meetings before the 3-month window
+
+**Reports Filed/Missed Tests:**
+8. **it('shows correct reports filed and missed count')** — Displays "1 filed" and "1 missed" badge
+9. **it('does not show missed badge when all reports are filed')** — Badge only shows if missed > 0
+
+**Ticket Count Tests:**
+10. **it('shows correct open and closed ticket counts')** — Displays "2 open" and "2 closed" with Open/Pending and Resolved/Closed counts
+11. **it('shows zero ticket counts when no tickets assigned')** — Displays "0 open" and "0 closed"
+
+## Configuration
+
+### Environment Variables
+
+| Variable | Purpose | Example Value |
+|----------|---------|----------------|
+| `DISCORD_ROLE_IN_BRIG` | Discord role ID to assign when brigging | `1234567890123456789` |
+
+### Configuration Keys
+
+| Key Path | Purpose | Source |
+|----------|---------|--------|
+| `lighthouse.discord.roles.in_brig` | Discord In Brig role ID | `config/lighthouse.php` line 126, reads `env('DISCORD_ROLE_IN_BRIG')` |
+
+### No New Migration Requirements
+
+This sprint does not require new database migrations. All brig-related fields (`in_brig`, `brig_expires_at`, `brig_reason`, `next_appeal_available_at`, `brig_timer_notified`, `brig_type`) already exist on the `users` table. Discord account status is tracked on the `discord_accounts` table (existing `status` column).

--- a/resources/library/books/staff-handbook/02-user-management/03-the-brig/01-putting-users-in-the-brig.md
+++ b/resources/library/books/staff-handbook/02-user-management/03-the-brig/01-putting-users-in-the-brig.md
@@ -24,7 +24,7 @@ You cannot put another staff member in the Brig, and you cannot brig yourself.
 1. Open the **Stowaway Users** widget on your Dashboard
 2. Click the **Put in Brig** button next to the user
 3. In the modal, enter a **reason** (minimum 5 characters) explaining why
-4. Optionally set a **timer** (1-365 days) -- this doesn't auto-release them, but notifies them when the timer expires and they become eligible to appeal
+4. Optionally set a **timer** (1-365 days) or check **No expiry (permanent)** if no timer should be set
 5. Click **Confirm**
 
 ### From a User's Profile
@@ -32,7 +32,7 @@ You cannot put another staff member in the Brig, and you cannot brig yourself.
 1. Navigate to the user's **profile page**
 2. Click the **Actions** menu on their profile card
 3. Select **Put in Brig**
-4. Enter a **reason** and optional **timer** in the modal
+4. Enter a **reason** and optional **timer** (or check **No expiry** for an indefinite brig) in the modal
 5. Click **Confirm**
 
 ## What Happens Immediately
@@ -42,17 +42,19 @@ When you put a user in the Brig, the system automatically:
 - Sets their account as brigged with the reason you entered
 - **Bans all their Minecraft accounts** -- removes them from the server whitelist and sets their account status to Banned
 - **Strips all their Discord roles** -- removes managed roles from their Discord accounts
+- **Assigns the Discord "In Brig" role** (if configured) -- marks their account as brigged in the Discord server
 - Records the action in the **activity log**
 - Sends the user a **notification** about their brig placement
 - Sets their first appeal availability to **24 hours** from now unless you entered a longer timer
 
 ## The Brig Timer
 
-The timer is optional but recommended. It sets a date when the user will be notified that they're eligible to submit an appeal. Important things to know:
+The timer is optional. It sets a date when the user will be notified that they're eligible to submit an appeal. Important things to know:
 
 - The timer does **not** automatically release the user -- staff must manually release them
 - A scheduled task checks daily for expired timers and sends the user a notification
 - If you don't set a timer, the user can still appeal after the initial 24-hour cooldown
+- Check **No expiry (permanent)** to skip the timer entirely -- the days field is hidden when this is checked. Users without a timer can still appeal after 24 hours
 
 ## What the User Sees
 

--- a/resources/library/books/staff-handbook/02-user-management/03-the-brig/02-appeals-and-releasing.md
+++ b/resources/library/books/staff-handbook/02-user-management/03-the-brig/02-appeals-and-releasing.md
@@ -43,7 +43,7 @@ When you release a user, the system automatically:
 
 - Clears their brig status and reason
 - **Restores their Minecraft accounts** -- previously active accounts are re-whitelisted on the server and permissions re-synced
-- **Restores their Discord roles** -- membership level and department roles are re-synced
+- **Removes the Discord "In Brig" role** (if configured) and restores their normal Discord roles
 - Records the release in the **activity log**
 - Sends the user a **notification** that they've been released
 

--- a/resources/library/books/staff-handbook/02-user-management/04-staff-profiles/01-staff-activity-card.md
+++ b/resources/library/books/staff-handbook/02-user-management/04-staff-profiles/01-staff-activity-card.md
@@ -20,7 +20,7 @@ Crew Members and Jr Crew cannot see this card on other staff profiles.
 
 ## What the Card Shows
 
-The card has three sections, all covering a **rolling 3-month window**:
+The card has three sections. **Meeting Attendance** and **Staff Reports** use a rolling 3-month window. **Tickets** are all-time counts:
 
 ### Meeting Attendance
 

--- a/resources/library/books/staff-handbook/02-user-management/04-staff-profiles/01-staff-activity-card.md
+++ b/resources/library/books/staff-handbook/02-user-management/04-staff-profiles/01-staff-activity-card.md
@@ -1,0 +1,46 @@
+---
+title: "Staff Activity Card"
+visibility: officer
+order: 1
+summary: "How to read the staff activity summary on a staff member's profile page."
+---
+
+## Overview
+
+When you visit a staff member's profile page, you'll see a **Staff Activity** card showing a quick summary of their recent engagement. It's meant to give department leads and command officers a fast read on how a staff member has been participating.
+
+The card only appears on profiles of users who hold a staff position, and it's only visible to officers and the staff member themselves.
+
+## Who Can See It
+
+- Officers in any department (including Command)
+- The staff member viewing their own profile
+
+Crew Members and Jr Crew cannot see this card on other staff profiles.
+
+## What the Card Shows
+
+The card has three sections, all covering a **rolling 3-month window**:
+
+### Meeting Attendance
+
+Shows how many completed staff meetings the member attended out of the total in the last 3 months -- for example, **3 / 5 meetings**.
+
+Click that number to open a breakdown modal listing each meeting in the window with its date and whether the member attended or was absent. Members who weren't yet on the staff roster for a particular meeting will show as **Not on Record**.
+
+### Staff Reports
+
+Shows how many staff update reports the member has submitted, and how many were missed -- for example, **4 filed** with an amber **1 missed** badge if any were missed.
+
+If all reports for the period were filed, the missed badge doesn't appear.
+
+### Tickets
+
+Shows the member's current ticket counts -- an open count (Open or Pending status) and a closed count (Resolved or Closed status). These are tickets **assigned to** that staff member.
+
+## Important Notes
+
+- All counts are live -- the card always reflects the current state of the data
+- The 3-month window is rolling from today, not a fixed quarter
+- Ticket counts reflect all time, not just the 3-month window
+- This card reads existing records -- it doesn't create any new data or take any actions

--- a/resources/library/books/staff-handbook/02-user-management/04-staff-profiles/_index.md
+++ b/resources/library/books/staff-handbook/02-user-management/04-staff-profiles/_index.md
@@ -1,0 +1,8 @@
+---
+title: "Staff Profiles"
+visibility: officer
+order: 4
+summary: "Viewing staff member activity and profile information as an officer."
+---
+
+How to review staff member profiles and interpret the activity summary card.

--- a/resources/library/books/staff-handbook/10-finance/03-budgets-and-reports/02-financial-reports.md
+++ b/resources/library/books/staff-handbook/10-finance/03-budgets-and-reports/02-financial-reports.md
@@ -73,3 +73,5 @@ Color coding follows the same rules: green = favorable, red = unfavorable.
 ## Printing and PDF Export
 
 All report tabs are print-friendly. Use your browser's **Print** function (Ctrl+P / Cmd+P) to print or save as PDF. The print layout hides navigation and filters so only the report content shows.
+
+Printed reports include a header with the **{{config:app.name}} logo**, organization name, the report title (e.g., "General Ledger" or "Balance Sheet"), and the date the report was generated. This makes printed or PDF copies clearly identifiable.

--- a/resources/library/books/staff-handbook/10-finance/03-budgets-and-reports/02-financial-reports.md
+++ b/resources/library/books/staff-handbook/10-finance/03-budgets-and-reports/02-financial-reports.md
@@ -74,4 +74,4 @@ Color coding follows the same rules: green = favorable, red = unfavorable.
 
 All report tabs are print-friendly. Use your browser's **Print** function (Ctrl+P / Cmd+P) to print or save as PDF. The print layout hides navigation and filters so only the report content shows.
 
-Printed reports include a header with the **{{config:app.name}} logo**, organization name, the report title (e.g., "General Ledger" or "Balance Sheet"), and the date the report was generated. This makes printed or PDF copies clearly identifiable.
+Printed reports include a header with the **Lighthouse logo image**, organization name ({{config:app.name}}), the report title (e.g., "General Ledger" or "Balance Sheet"), and the date the report was generated. This makes printed or PDF copies clearly identifiable.

--- a/resources/library/books/user-handbook/01-getting-started/02-account-setup/02-connecting-discord.md
+++ b/resources/library/books/user-handbook/01-getting-started/02-account-setup/02-connecting-discord.md
@@ -9,7 +9,7 @@ summary: "What to do on the Discord setup step and how to complete it."
 
 When you're a **Stowaway**, the first thing the wizard asks you to do is connect your Discord account. Linking Discord lets Lighthouse assign you the right roles on the server automatically and enables Discord DM notifications for things like ticket replies and announcements.
 
-Click **Connect Discord** and you'll be taken to your account settings where you can complete the link. Once your account is connected, come back to your Dashboard -- the wizard will detect it and move you to the next step.
+Click **Connect Discord** and you'll be taken to Discord's authorization page. Once you authorize the connection, you'll be brought straight back to your Dashboard -- the wizard will detect your linked account and move you to the next step automatically. There's nothing else you need to do.
 
 For a detailed walkthrough of the linking process itself, see [[books/user-handbook/discord/accounts/linking-your-account|Linking Your Discord Account]].
 

--- a/resources/views/livewire/finance/reports.blade.php
+++ b/resources/views/livewire/finance/reports.blade.php
@@ -545,9 +545,29 @@ new class extends Component
     </div>
 
     {{-- Print header (only visible when printing) --}}
-    <div class="hidden print:block mb-4">
-        <h1 class="text-xl font-bold">Financial Report</h1>
-        <p class="text-sm text-zinc-500">Generated {{ now()->format('M j, Y') }}</p>
+    <div class="hidden print:block mb-6">
+        @php
+            $tabLabels = [
+                'activities'   => 'Statement of Activities',
+                'ledger'       => 'General Ledger',
+                'trial'        => 'Trial Balance',
+                'balance-sheet'=> 'Balance Sheet',
+                'cash-flow'    => 'Cash Flow Statement',
+                'variance'     => 'Budget vs. Actual',
+            ];
+            $reportTitle = $tabLabels[$activeTab] ?? 'Financial Report';
+        @endphp
+
+        <div style="display:flex; align-items:center; gap:12px; margin-bottom:8px;">
+            <img src="{{ asset('img/LighthouseMC_Logo.png') }}" alt="{{ config('app.name') }}" style="width:48px; height:48px; border-radius:6px;" />
+            <div>
+                <div style="font-size:18px; font-weight:700; line-height:1.2;">{{ config('app.name') }}</div>
+                <div style="font-size:14px; font-weight:600; color:#374151;">{{ $reportTitle }}</div>
+            </div>
+        </div>
+        <div style="border-top:1px solid #d1d5db; padding-top:6px;">
+            <span style="font-size:12px; color:#6b7280;">Generated {{ now()->format('F j, Y') }}</span>
+        </div>
     </div>
 
     {{-- Tabs --}}

--- a/resources/views/livewire/onboarding/wizard.blade.php
+++ b/resources/views/livewire/onboarding/wizard.blade.php
@@ -103,15 +103,15 @@ new class extends Component
                         and send you direct message notifications about meetings, tickets, and community updates.
                     </flux:text>
                     <flux:text variant="subtle" class="text-sm mb-4">
-                        You'll be redirected to your account settings to complete the link.
-                        Once connected, <strong>return to the dashboard</strong> to continue your setup.
+                        You'll be taken to Discord to authorize the connection.
+                        Once connected, you'll return here automatically to continue your setup.
                     </flux:text>
 
                     <div class="flex items-center justify-between">
                         <flux:button wire:click="skipDiscord" variant="ghost" size="sm">
                             Skip for now
                         </flux:button>
-                        <flux:button href="{{ route('settings.discord-account') }}" variant="primary">
+                        <flux:button href="{{ route('auth.discord.redirect', ['from' => 'onboarding']) }}" variant="primary">
                             Connect Discord
                         </flux:button>
                     </div>

--- a/resources/views/livewire/users/display-basic-details.blade.php
+++ b/resources/views/livewire/users/display-basic-details.blade.php
@@ -1024,8 +1024,8 @@ new class extends Component {
 
             <flux:field x-show="!$wire.brigActionPermanent">
                 <flux:label>Days Until Auto-Release</flux:label>
-                <flux:description>Optional. Leave blank for no auto-release timer.</flux:description>
-                <flux:input wire:model.live="brigActionDays" type="number" min="1" max="365" placeholder="e.g. 7 (leave blank for no timer)" :disabled="$brigActionPermanent" />
+                <flux:description>Optional. Leave blank to skip auto-release (equivalent to permanent).</flux:description>
+                <flux:input wire:model.live="brigActionDays" type="number" min="1" max="365" placeholder="e.g. 7" :disabled="$brigActionPermanent" />
                 <flux:error name="brigActionDays" />
             </flux:field>
 

--- a/resources/views/livewire/users/display-basic-details.blade.php
+++ b/resources/views/livewire/users/display-basic-details.blade.php
@@ -15,6 +15,7 @@ new class extends Component {
     public ?MinecraftAccount $selectedAccount = null;
     public string $brigActionReason = '';
     public ?int $brigActionDays = null;
+    public bool $brigActionPermanent = false;
     public ?int $accountToRevoke = null;
     public ?int $accountToForceDelete = null;
 
@@ -268,6 +269,7 @@ new class extends Component {
         }
         $this->brigActionReason = '';
         $this->brigActionDays = null;
+        $this->brigActionPermanent = false;
         Flux::modal('profile-put-in-brig-modal')->show();
     }
 
@@ -288,10 +290,12 @@ new class extends Component {
 
         $this->validate([
             'brigActionReason' => 'required|string|min:5',
-            'brigActionDays' => 'nullable|integer|min:1|max:365',
+            'brigActionDays' => $this->brigActionPermanent ? 'nullable' : 'nullable|integer|min:1|max:365',
         ]);
 
-        $expiresAt = $this->brigActionDays ? now()->addDays((int) $this->brigActionDays) : null;
+        $expiresAt = (! $this->brigActionPermanent && $this->brigActionDays)
+            ? now()->addDays((int) $this->brigActionDays)
+            : null;
 
         \App\Actions\PutUserInBrig::run($this->user, Auth::user(), $this->brigActionReason, $expiresAt);
 
@@ -980,9 +984,13 @@ new class extends Component {
             </flux:field>
 
             <flux:field>
+                <flux:checkbox wire:model.live="brigActionPermanent" label="Permanent (no expiry)" />
+            </flux:field>
+
+            <flux:field x-show="!$wire.brigActionPermanent">
                 <flux:label>Days Until Auto-Release</flux:label>
                 <flux:description>Optional. Leave blank for no auto-release timer.</flux:description>
-                <flux:input wire:model.live="brigActionDays" type="number" min="1" max="365" placeholder="e.g. 7 (leave blank for no timer)" />
+                <flux:input wire:model.live="brigActionDays" type="number" min="1" max="365" placeholder="e.g. 7 (leave blank for no timer)" :disabled="$brigActionPermanent" />
                 <flux:error name="brigActionDays" />
             </flux:field>
 

--- a/resources/views/livewire/users/display-basic-details.blade.php
+++ b/resources/views/livewire/users/display-basic-details.blade.php
@@ -444,10 +444,7 @@ new class extends Component {
         $this->user->update($updateData);
 
         if ($this->canEditAllFields()) {
-            $newParentEmail = $this->editUserData['parent_email'] ?: null;
-            $oldParentEmail = $this->user->fresh()->parent_email;
-
-            if ($newParentEmail && strtolower($newParentEmail ?? '') !== strtolower($oldParentEmail ?? '')) {
+            if ($newParentEmail && strcasecmp($newParentEmail, (string) ($oldParentEmail ?? '')) !== 0) {
                 \App\Actions\LinkParentByEmail::run($this->user);
             }
         }
@@ -989,21 +986,17 @@ new class extends Component {
                         <flux:description>Contact staff to update your email address.</flux:description>
                     </flux:field>
 
-                    @if($editUserData['date_of_birth'])
-                        <flux:field>
-                            <flux:label>Date of Birth</flux:label>
-                            <flux:text>{{ $editUserData['date_of_birth'] }}</flux:text>
-                            <flux:description>Contact staff to update your date of birth.</flux:description>
-                        </flux:field>
-                    @endif
+                    <flux:field>
+                        <flux:label>Date of Birth</flux:label>
+                        <flux:text>{{ $editUserData['date_of_birth'] ?: '—' }}</flux:text>
+                        <flux:description>Contact staff to update your date of birth.</flux:description>
+                    </flux:field>
 
-                    @if($editUserData['parent_email'])
-                        <flux:field>
-                            <flux:label>Parent Email</flux:label>
-                            <flux:text>{{ $editUserData['parent_email'] }}</flux:text>
-                            <flux:description>Contact staff to update your parent email.</flux:description>
-                        </flux:field>
-                    @endif
+                    <flux:field>
+                        <flux:label>Parent Email</flux:label>
+                        <flux:text>{{ $editUserData['parent_email'] ?: '—' }}</flux:text>
+                        <flux:description>Contact staff to update your parent email.</flux:description>
+                    </flux:field>
                 @endif
 
                 <div class="flex justify-end">

--- a/resources/views/livewire/users/display-basic-details.blade.php
+++ b/resources/views/livewire/users/display-basic-details.blade.php
@@ -409,29 +409,47 @@ new class extends Component {
         Flux::modal('profile-edit-user-modal')->show();
     }
 
+    public function canEditAllFields(): bool
+    {
+        return Auth::user()->isAdmin() || Auth::user()->hasRole('User - Manager');
+    }
+
     public function saveEditUser(): void
     {
         $this->authorize('update', $this->user);
 
-        $this->validate([
+        $rules = [
             'editUserData.name' => ['required', 'string', 'max:32'],
-            'editUserData.email' => ['required', 'email', 'max:255', Rule::unique('users', 'email')->ignore($this->user->id)],
-            'editUserData.date_of_birth' => ['nullable', 'date', 'before:today'],
-            'editUserData.parent_email' => ['nullable', 'email'],
-        ]);
+        ];
 
-        $oldParentEmail = $this->user->parent_email;
-        $newParentEmail = $this->editUserData['parent_email'] ?: null;
+        if ($this->canEditAllFields()) {
+            $rules['editUserData.email'] = ['required', 'email', 'max:255', Rule::unique('users', 'email')->ignore($this->user->id)];
+            $rules['editUserData.date_of_birth'] = ['nullable', 'date', 'before:today'];
+            $rules['editUserData.parent_email'] = ['nullable', 'email'];
+        }
 
-        $this->user->update([
-            'name' => $this->editUserData['name'],
-            'email' => $this->editUserData['email'],
-            'date_of_birth' => $this->editUserData['date_of_birth'] ?: null,
-            'parent_email' => $newParentEmail,
-        ]);
+        $this->validate($rules);
 
-        if ($newParentEmail && strtolower($newParentEmail ?? '') !== strtolower($oldParentEmail ?? '')) {
-            \App\Actions\LinkParentByEmail::run($this->user);
+        $updateData = ['name' => $this->editUserData['name']];
+
+        if ($this->canEditAllFields()) {
+            $oldParentEmail = $this->user->parent_email;
+            $newParentEmail = $this->editUserData['parent_email'] ?: null;
+
+            $updateData['email'] = $this->editUserData['email'];
+            $updateData['date_of_birth'] = $this->editUserData['date_of_birth'] ?: null;
+            $updateData['parent_email'] = $newParentEmail;
+        }
+
+        $this->user->update($updateData);
+
+        if ($this->canEditAllFields()) {
+            $newParentEmail = $this->editUserData['parent_email'] ?: null;
+            $oldParentEmail = $this->user->fresh()->parent_email;
+
+            if ($newParentEmail && strtolower($newParentEmail ?? '') !== strtolower($oldParentEmail ?? '')) {
+                \App\Actions\LinkParentByEmail::run($this->user);
+            }
         }
 
         \App\Actions\RecordActivity::run($this->user, 'update_profile', 'User profile updated.');
@@ -946,23 +964,47 @@ new class extends Component {
                     <flux:error name="editUserData.name" />
                 </flux:field>
 
-                <flux:field>
-                    <flux:label>Email</flux:label>
-                    <flux:input wire:model="editUserData.email" type="email" required />
-                    <flux:error name="editUserData.email" />
-                </flux:field>
+                @if($this->canEditAllFields())
+                    <flux:field>
+                        <flux:label>Email</flux:label>
+                        <flux:input wire:model="editUserData.email" type="email" required />
+                        <flux:error name="editUserData.email" />
+                    </flux:field>
 
-                <flux:field>
-                    <flux:label>Date of Birth</flux:label>
-                    <flux:input wire:model="editUserData.date_of_birth" type="date" />
-                    <flux:error name="editUserData.date_of_birth" />
-                </flux:field>
+                    <flux:field>
+                        <flux:label>Date of Birth</flux:label>
+                        <flux:input wire:model="editUserData.date_of_birth" type="date" />
+                        <flux:error name="editUserData.date_of_birth" />
+                    </flux:field>
 
-                <flux:field>
-                    <flux:label>Parent Email</flux:label>
-                    <flux:input wire:model="editUserData.parent_email" type="email" placeholder="Optional" />
-                    <flux:error name="editUserData.parent_email" />
-                </flux:field>
+                    <flux:field>
+                        <flux:label>Parent Email</flux:label>
+                        <flux:input wire:model="editUserData.parent_email" type="email" placeholder="Optional" />
+                        <flux:error name="editUserData.parent_email" />
+                    </flux:field>
+                @else
+                    <flux:field>
+                        <flux:label>Email</flux:label>
+                        <flux:text>{{ $editUserData['email'] }}</flux:text>
+                        <flux:description>Contact staff to update your email address.</flux:description>
+                    </flux:field>
+
+                    @if($editUserData['date_of_birth'])
+                        <flux:field>
+                            <flux:label>Date of Birth</flux:label>
+                            <flux:text>{{ $editUserData['date_of_birth'] }}</flux:text>
+                            <flux:description>Contact staff to update your date of birth.</flux:description>
+                        </flux:field>
+                    @endif
+
+                    @if($editUserData['parent_email'])
+                        <flux:field>
+                            <flux:label>Parent Email</flux:label>
+                            <flux:text>{{ $editUserData['parent_email'] }}</flux:text>
+                            <flux:description>Contact staff to update your parent email.</flux:description>
+                        </flux:field>
+                    @endif
+                @endif
 
                 <div class="flex justify-end">
                     <flux:button type="submit" variant="primary">Save</flux:button>

--- a/resources/views/livewire/users/staff-activity-card.blade.php
+++ b/resources/views/livewire/users/staff-activity-card.blade.php
@@ -168,7 +168,7 @@ new class extends Component {
 
                     @if($viewReport)
                         @foreach($viewReport->answers->sortBy(fn ($a) => $a->question->sort_order) as $answer)
-                            <div>
+                            <div wire:key="report-answer-{{ $answer->id }}">
                                 <flux:text class="font-semibold text-sm">{{ $answer->question->question_text }}</flux:text>
                                 @if($answer->answer)
                                     <div class="prose prose-sm dark:prose-invert max-w-none mt-1">

--- a/resources/views/livewire/users/staff-activity-card.blade.php
+++ b/resources/views/livewire/users/staff-activity-card.blade.php
@@ -1,0 +1,205 @@
+<?php
+
+use App\Enums\MeetingStatus;
+use App\Enums\MeetingType;
+use App\Enums\StaffRank;
+use App\Enums\ThreadStatus;
+use App\Enums\ThreadType;
+use App\Models\Meeting;
+use App\Models\MeetingReport;
+use App\Models\Thread;
+use App\Models\User;
+use Flux\Flux;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\DB;
+use Livewire\Attributes\Locked;
+use Livewire\Volt\Component;
+
+new class extends Component {
+    #[Locked]
+    public int $userId;
+
+    public function mount(User $user): void
+    {
+        $this->authorize('view-staff-activity', $user);
+        $this->userId = $user->id;
+    }
+
+    public function getUserProperty(): User
+    {
+        return User::findOrFail($this->userId);
+    }
+
+    private function getThreeMonthsAgo(): \Illuminate\Support\Carbon
+    {
+        return now()->subMonths(3);
+    }
+
+    private function getStaffMeetings3mo()
+    {
+        return Meeting::where('type', MeetingType::StaffMeeting)
+            ->where('status', MeetingStatus::Completed)
+            ->where('end_time', '>=', $this->getThreeMonthsAgo())
+            ->get();
+    }
+
+    public function getMeetingAttendanceProperty(): \Illuminate\Support\Collection
+    {
+        return $this->getStaffMeetings3mo()
+            ->map(function (Meeting $meeting) {
+                $pivot = DB::table('meeting_user')
+                    ->where('meeting_id', $meeting->id)
+                    ->where('user_id', $this->userId)
+                    ->first();
+
+                return [
+                    'meeting' => $meeting,
+                    'attended' => $pivot ? (bool) $pivot->attended : false,
+                    'on_record' => $pivot !== null,
+                ];
+            })
+            ->sortByDesc(fn ($row) => $row['meeting']->scheduled_time);
+    }
+
+    public function getAttendanceCountProperty(): int
+    {
+        return DB::table('meeting_user')
+            ->join('meetings', 'meetings.id', '=', 'meeting_user.meeting_id')
+            ->where('meeting_user.user_id', $this->userId)
+            ->where('meeting_user.attended', true)
+            ->where('meetings.type', MeetingType::StaffMeeting->value)
+            ->where('meetings.status', MeetingStatus::Completed->value)
+            ->where('meetings.end_time', '>=', $this->getThreeMonthsAgo())
+            ->count();
+    }
+
+    public function getTotalMeetings3moProperty(): int
+    {
+        return Meeting::where('type', MeetingType::StaffMeeting)
+            ->where('status', MeetingStatus::Completed)
+            ->where('end_time', '>=', $this->getThreeMonthsAgo())
+            ->count();
+    }
+
+    public function getReportsFiledProperty(): int
+    {
+        $meetingIds = Meeting::where('type', MeetingType::StaffMeeting)
+            ->where('status', MeetingStatus::Completed)
+            ->where('end_time', '>=', $this->getThreeMonthsAgo())
+            ->pluck('id');
+
+        return MeetingReport::whereIn('meeting_id', $meetingIds)
+            ->where('user_id', $this->userId)
+            ->whereNotNull('submitted_at')
+            ->count();
+    }
+
+    public function getReportsMissedProperty(): int
+    {
+        return max(0, $this->totalMeetings3mo - $this->reportsFiled);
+    }
+
+    public function getOpenTicketsProperty(): int
+    {
+        return Thread::where('type', ThreadType::Ticket)
+            ->where('assigned_to_user_id', $this->userId)
+            ->whereIn('status', [ThreadStatus::Open, ThreadStatus::Pending])
+            ->count();
+    }
+
+    public function getClosedTicketsProperty(): int
+    {
+        return Thread::where('type', ThreadType::Ticket)
+            ->where('assigned_to_user_id', $this->userId)
+            ->whereIn('status', [ThreadStatus::Resolved, ThreadStatus::Closed])
+            ->count();
+    }
+
+    public function openAttendanceModal(): void
+    {
+        Flux::modal('staff-attendance-modal-' . $this->userId)->show();
+    }
+}; ?>
+
+<div>
+    <flux:card class="w-full">
+        <div class="flex items-center gap-3">
+            <flux:heading size="md">Staff Activity</flux:heading>
+            <flux:badge color="zinc" size="sm">Last 3 months</flux:badge>
+        </div>
+
+        <flux:separator variant="subtle" class="my-2" />
+
+        <div class="grid grid-cols-1 sm:grid-cols-3 gap-4">
+            {{-- Meeting Attendance --}}
+            <div class="flex flex-col gap-1">
+                <flux:text class="text-xs font-semibold text-zinc-500 uppercase tracking-wide">Meeting Attendance</flux:text>
+                <div class="flex items-center gap-2">
+                    <button wire:click="openAttendanceModal" class="text-lg font-bold text-blue-600 dark:text-blue-400 hover:underline focus:outline-none">
+                        {{ $this->attendanceCount }} / {{ $this->totalMeetings3mo }}
+                    </button>
+                    <flux:text variant="subtle" class="text-sm">meetings</flux:text>
+                </div>
+            </div>
+
+            {{-- Staff Reports --}}
+            <div class="flex flex-col gap-1">
+                <flux:text class="text-xs font-semibold text-zinc-500 uppercase tracking-wide">Staff Reports</flux:text>
+                <div class="flex items-center gap-2">
+                    <span class="text-lg font-bold text-zinc-800 dark:text-zinc-200">
+                        {{ $this->reportsFiled }} filed
+                    </span>
+                    @if($this->reportsMissed > 0)
+                        <flux:badge color="amber" size="sm">{{ $this->reportsMissed }} missed</flux:badge>
+                    @endif
+                </div>
+            </div>
+
+            {{-- Tickets --}}
+            <div class="flex flex-col gap-1">
+                <flux:text class="text-xs font-semibold text-zinc-500 uppercase tracking-wide">Tickets</flux:text>
+                <div class="flex items-center gap-2">
+                    <flux:badge color="green" size="sm">{{ $this->openTickets }} open</flux:badge>
+                    <flux:badge color="zinc" size="sm">{{ $this->closedTickets }} closed</flux:badge>
+                </div>
+            </div>
+        </div>
+    </flux:card>
+
+    {{-- Attendance Modal --}}
+    <flux:modal name="staff-attendance-modal-{{ $this->userId }}" class="w-full md:w-1/2">
+        <div class="space-y-4">
+            <flux:heading size="lg">Meeting Attendance</flux:heading>
+            <flux:text variant="subtle">Staff meetings in the last 3 months</flux:text>
+
+            @if($this->meetingAttendance->isEmpty())
+                <flux:text variant="subtle" class="text-center py-4">No completed staff meetings in the last 3 months.</flux:text>
+            @else
+                <flux:table>
+                    <flux:table.columns>
+                        <flux:table.column>Meeting</flux:table.column>
+                        <flux:table.column>Date</flux:table.column>
+                        <flux:table.column>Status</flux:table.column>
+                    </flux:table.columns>
+                    <flux:table.rows>
+                        @foreach($this->meetingAttendance as $row)
+                            <flux:table.row wire:key="attendance-{{ $row['meeting']->id }}">
+                                <flux:table.cell>{{ $row['meeting']->title }}</flux:table.cell>
+                                <flux:table.cell>{{ $row['meeting']->scheduled_time->format('M j, Y') }}</flux:table.cell>
+                                <flux:table.cell>
+                                    @if(! $row['on_record'])
+                                        <flux:badge color="zinc" size="sm">Not on Record</flux:badge>
+                                    @elseif($row['attended'])
+                                        <flux:badge color="green" size="sm">Attended</flux:badge>
+                                    @else
+                                        <flux:badge color="red" size="sm">Absent</flux:badge>
+                                    @endif
+                                </flux:table.cell>
+                            </flux:table.row>
+                        @endforeach
+                    </flux:table.rows>
+                </flux:table>
+            @endif
+        </div>
+    </flux:modal>
+</div>

--- a/resources/views/livewire/users/staff-activity-card.blade.php
+++ b/resources/views/livewire/users/staff-activity-card.blade.php
@@ -40,6 +40,7 @@ new class extends Component {
         return Meeting::where('type', MeetingType::StaffMeeting)
             ->where('status', MeetingStatus::Completed)
             ->where('end_time', '>=', $this->getThreeMonthsAgo())
+            ->with(['attendees' => fn ($q) => $q->where('users.id', $this->userId)])
             ->get();
     }
 
@@ -47,15 +48,12 @@ new class extends Component {
     {
         return $this->getStaffMeetings3mo()
             ->map(function (Meeting $meeting) {
-                $pivot = DB::table('meeting_user')
-                    ->where('meeting_id', $meeting->id)
-                    ->where('user_id', $this->userId)
-                    ->first();
+                $attendee = $meeting->attendees->first();
 
                 return [
                     'meeting' => $meeting,
-                    'attended' => $pivot ? (bool) $pivot->attended : false,
-                    'on_record' => $pivot !== null,
+                    'attended' => $attendee ? (bool) $attendee->pivot->attended : false,
+                    'on_record' => $attendee !== null,
                 ];
             })
             ->sortByDesc(fn ($row) => $row['meeting']->scheduled_time);
@@ -135,7 +133,7 @@ new class extends Component {
             <div class="flex flex-col gap-1">
                 <flux:text class="text-xs font-semibold text-zinc-500 uppercase tracking-wide">Meeting Attendance</flux:text>
                 <div class="flex items-center gap-2">
-                    <button wire:click="openAttendanceModal" class="text-lg font-bold text-blue-600 dark:text-blue-400 hover:underline focus:outline-none">
+                    <button wire:click="openAttendanceModal" class="text-lg font-bold text-blue-600 dark:text-blue-400 hover:underline focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 rounded-sm">
                         {{ $this->attendanceCount }} / {{ $this->totalMeetings3mo }}
                     </button>
                     <flux:text variant="subtle" class="text-sm">meetings</flux:text>

--- a/resources/views/livewire/users/staff-activity-card.blade.php
+++ b/resources/views/livewire/users/staff-activity-card.blade.php
@@ -2,7 +2,6 @@
 
 use App\Enums\MeetingStatus;
 use App\Enums\MeetingType;
-use App\Enums\StaffRank;
 use App\Enums\ThreadStatus;
 use App\Enums\ThreadType;
 use App\Models\Meeting;
@@ -11,13 +10,14 @@ use App\Models\Thread;
 use App\Models\User;
 use Flux\Flux;
 use Illuminate\Support\Facades\Auth;
-use Illuminate\Support\Facades\DB;
 use Livewire\Attributes\Locked;
 use Livewire\Volt\Component;
 
 new class extends Component {
     #[Locked]
     public int $userId;
+
+    public ?int $viewingReportMeetingId = null;
 
     public function mount(User $user): void
     {
@@ -30,71 +30,42 @@ new class extends Component {
         return User::findOrFail($this->userId);
     }
 
-    private function getThreeMonthsAgo(): \Illuminate\Support\Carbon
-    {
-        return now()->subMonths(3);
-    }
-
-    private function getStaffMeetings3mo()
+    private function getRecentStaffMeetings()
     {
         return Meeting::where('type', MeetingType::StaffMeeting)
             ->where('status', MeetingStatus::Completed)
-            ->where('end_time', '>=', $this->getThreeMonthsAgo())
-            ->with(['attendees' => fn ($q) => $q->where('users.id', $this->userId)])
+            ->orderByDesc('scheduled_time')
+            ->limit(7)
+            ->with([
+                'attendees' => fn ($q) => $q->where('users.id', $this->userId),
+            ])
             ->get();
     }
 
-    public function getMeetingAttendanceProperty(): \Illuminate\Support\Collection
+    public function getMeetingRowsProperty(): \Illuminate\Support\Collection
     {
-        return $this->getStaffMeetings3mo()
-            ->map(function (Meeting $meeting) {
-                $attendee = $meeting->attendees->first();
+        $meetings = $this->getRecentStaffMeetings();
 
-                return [
-                    'meeting' => $meeting,
-                    'attended' => $attendee ? (bool) $attendee->pivot->attended : false,
-                    'on_record' => $attendee !== null,
-                ];
-            })
-            ->sortByDesc(fn ($row) => $row['meeting']->scheduled_time);
-    }
+        $meetingIds = $meetings->pluck('id');
 
-    public function getAttendanceCountProperty(): int
-    {
-        return DB::table('meeting_user')
-            ->join('meetings', 'meetings.id', '=', 'meeting_user.meeting_id')
-            ->where('meeting_user.user_id', $this->userId)
-            ->where('meeting_user.attended', true)
-            ->where('meetings.type', MeetingType::StaffMeeting->value)
-            ->where('meetings.status', MeetingStatus::Completed->value)
-            ->where('meetings.end_time', '>=', $this->getThreeMonthsAgo())
-            ->count();
-    }
-
-    public function getTotalMeetings3moProperty(): int
-    {
-        return Meeting::where('type', MeetingType::StaffMeeting)
-            ->where('status', MeetingStatus::Completed)
-            ->where('end_time', '>=', $this->getThreeMonthsAgo())
-            ->count();
-    }
-
-    public function getReportsFiledProperty(): int
-    {
-        $meetingIds = Meeting::where('type', MeetingType::StaffMeeting)
-            ->where('status', MeetingStatus::Completed)
-            ->where('end_time', '>=', $this->getThreeMonthsAgo())
-            ->pluck('id');
-
-        return MeetingReport::whereIn('meeting_id', $meetingIds)
+        $reports = MeetingReport::whereIn('meeting_id', $meetingIds)
             ->where('user_id', $this->userId)
             ->whereNotNull('submitted_at')
-            ->count();
-    }
+            ->with('answers.question')
+            ->get()
+            ->keyBy('meeting_id');
 
-    public function getReportsMissedProperty(): int
-    {
-        return max(0, $this->totalMeetings3mo - $this->reportsFiled);
+        return $meetings->map(function (Meeting $meeting) use ($reports) {
+            $attendee = $meeting->attendees->first();
+            $report = $reports->get($meeting->id);
+
+            return [
+                'meeting'   => $meeting,
+                'attended'  => $attendee ? (bool) $attendee->pivot->attended : false,
+                'on_record' => $attendee !== null,
+                'report'    => $report,
+            ];
+        });
     }
 
     public function getOpenTicketsProperty(): int
@@ -113,91 +84,114 @@ new class extends Component {
             ->count();
     }
 
-    public function openAttendanceModal(): void
+    public function viewReport(int $meetingId): void
     {
-        Flux::modal('staff-attendance-modal-' . $this->userId)->show();
+        $this->viewingReportMeetingId = $meetingId;
+        Flux::modal('staff-report-modal-' . $this->userId)->show();
     }
 }; ?>
 
 <div>
     <flux:card class="w-full">
-        <div class="flex items-center gap-3">
-            <flux:heading size="md">Staff Activity</flux:heading>
-            <flux:badge color="zinc" size="sm">Last 3 months</flux:badge>
+        <div class="flex items-center justify-between gap-3">
+            <div class="flex items-center gap-3">
+                <flux:heading size="md">Staff Activity</flux:heading>
+                <flux:badge color="zinc" size="sm">Last 7 meetings</flux:badge>
+            </div>
+
+            {{-- Tickets --}}
+            <div class="flex items-center gap-2">
+                <flux:text class="text-xs font-semibold text-zinc-500 uppercase tracking-wide">Tickets</flux:text>
+                <flux:badge color="green" size="sm">{{ $this->openTickets }} open</flux:badge>
+                <flux:badge color="zinc" size="sm">{{ $this->closedTickets }} closed</flux:badge>
+            </div>
         </div>
 
         <flux:separator variant="subtle" class="my-2" />
 
-        <div class="grid grid-cols-1 sm:grid-cols-3 gap-4">
-            {{-- Meeting Attendance --}}
-            <div class="flex flex-col gap-1">
-                <flux:text class="text-xs font-semibold text-zinc-500 uppercase tracking-wide">Meeting Attendance</flux:text>
-                <div class="flex items-center gap-2">
-                    <button wire:click="openAttendanceModal" class="text-lg font-bold text-blue-600 dark:text-blue-400 hover:underline focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 rounded-sm">
-                        {{ $this->attendanceCount }} / {{ $this->totalMeetings3mo }}
-                    </button>
-                    <flux:text variant="subtle" class="text-sm">meetings</flux:text>
-                </div>
-            </div>
-
-            {{-- Staff Reports --}}
-            <div class="flex flex-col gap-1">
-                <flux:text class="text-xs font-semibold text-zinc-500 uppercase tracking-wide">Staff Reports</flux:text>
-                <div class="flex items-center gap-2">
-                    <span class="text-lg font-bold text-zinc-800 dark:text-zinc-200">
-                        {{ $this->reportsFiled }} filed
-                    </span>
-                    @if($this->reportsMissed > 0)
-                        <flux:badge color="amber" size="sm">{{ $this->reportsMissed }} missed</flux:badge>
-                    @endif
-                </div>
-            </div>
-
-            {{-- Tickets --}}
-            <div class="flex flex-col gap-1">
-                <flux:text class="text-xs font-semibold text-zinc-500 uppercase tracking-wide">Tickets</flux:text>
-                <div class="flex items-center gap-2">
-                    <flux:badge color="green" size="sm">{{ $this->openTickets }} open</flux:badge>
-                    <flux:badge color="zinc" size="sm">{{ $this->closedTickets }} closed</flux:badge>
-                </div>
-            </div>
-        </div>
+        @if($this->meetingRows->isEmpty())
+            <flux:text variant="subtle" class="text-center py-4">No completed staff meetings on record.</flux:text>
+        @else
+            <flux:table>
+                <flux:table.columns>
+                    <flux:table.column>Meeting</flux:table.column>
+                    <flux:table.column>Attendance</flux:table.column>
+                    <flux:table.column>Staff Report</flux:table.column>
+                </flux:table.columns>
+                <flux:table.rows>
+                    @foreach($this->meetingRows as $row)
+                        <flux:table.row wire:key="meeting-row-{{ $row['meeting']->id }}">
+                            <flux:table.cell>
+                                <div>
+                                    <flux:text class="font-medium text-sm">{{ $row['meeting']->title }}</flux:text>
+                                    <flux:text variant="subtle" class="text-xs">{{ $row['meeting']->scheduled_time->format('M j, Y') }}</flux:text>
+                                </div>
+                            </flux:table.cell>
+                            <flux:table.cell>
+                                @if(! $row['on_record'])
+                                    <flux:badge color="zinc" size="sm">Not on Record</flux:badge>
+                                @elseif($row['attended'])
+                                    <flux:badge color="green" size="sm">Attended</flux:badge>
+                                @else
+                                    <flux:badge color="red" size="sm">Absent</flux:badge>
+                                @endif
+                            </flux:table.cell>
+                            <flux:table.cell>
+                                @if($row['report'])
+                                    <flux:button size="sm" variant="ghost" wire:click="viewReport({{ $row['meeting']->id }})">View Report</flux:button>
+                                @else
+                                    <flux:text variant="subtle" class="text-sm">—</flux:text>
+                                @endif
+                            </flux:table.cell>
+                        </flux:table.row>
+                    @endforeach
+                </flux:table.rows>
+            </flux:table>
+        @endif
     </flux:card>
 
-    {{-- Attendance Modal --}}
-    <flux:modal name="staff-attendance-modal-{{ $this->userId }}" class="w-full md:w-1/2">
-        <div class="space-y-4">
-            <flux:heading size="lg">Meeting Attendance</flux:heading>
-            <flux:text variant="subtle">Staff meetings in the last 3 months</flux:text>
+    {{-- Staff Report Modal --}}
+    <flux:modal name="staff-report-modal-{{ $this->userId }}" class="min-w-[32rem] !text-left">
+        @if($viewingReportMeetingId)
+            @php
+                $viewRow = $this->meetingRows->firstWhere('meeting.id', $viewingReportMeetingId);
+                $viewReport = $viewRow['report'] ?? null;
+                $viewMeeting = $viewRow['meeting'] ?? null;
+            @endphp
 
-            @if($this->meetingAttendance->isEmpty())
-                <flux:text variant="subtle" class="text-center py-4">No completed staff meetings in the last 3 months.</flux:text>
-            @else
-                <flux:table>
-                    <flux:table.columns>
-                        <flux:table.column>Meeting</flux:table.column>
-                        <flux:table.column>Date</flux:table.column>
-                        <flux:table.column>Status</flux:table.column>
-                    </flux:table.columns>
-                    <flux:table.rows>
-                        @foreach($this->meetingAttendance as $row)
-                            <flux:table.row wire:key="attendance-{{ $row['meeting']->id }}">
-                                <flux:table.cell>{{ $row['meeting']->title }}</flux:table.cell>
-                                <flux:table.cell>{{ $row['meeting']->scheduled_time->format('M j, Y') }}</flux:table.cell>
-                                <flux:table.cell>
-                                    @if(! $row['on_record'])
-                                        <flux:badge color="zinc" size="sm">Not on Record</flux:badge>
-                                    @elseif($row['attended'])
-                                        <flux:badge color="green" size="sm">Attended</flux:badge>
-                                    @else
-                                        <flux:badge color="red" size="sm">Absent</flux:badge>
-                                    @endif
-                                </flux:table.cell>
-                            </flux:table.row>
+            @if($viewMeeting)
+                <div class="space-y-4">
+                    <div>
+                        <flux:heading size="lg">{{ $viewMeeting->title }}</flux:heading>
+                        <flux:text variant="subtle" class="text-sm">{{ $viewMeeting->scheduled_time->format('F j, Y') }}</flux:text>
+                    </div>
+
+                    @if($viewReport)
+                        @foreach($viewReport->answers->sortBy(fn ($a) => $a->question->sort_order) as $answer)
+                            <div>
+                                <flux:text class="font-semibold text-sm">{{ $answer->question->question_text }}</flux:text>
+                                @if($answer->answer)
+                                    <div class="prose prose-sm dark:prose-invert max-w-none mt-1">
+                                        {!! Str::markdown($answer->answer, ['html_input' => 'strip', 'allow_unsafe_links' => false]) !!}
+                                    </div>
+                                @else
+                                    <flux:text class="mt-1" variant="subtle">No response</flux:text>
+                                @endif
+                            </div>
                         @endforeach
-                    </flux:table.rows>
-                </flux:table>
+                    @else
+                        <flux:callout color="zinc">
+                            <flux:callout.text>No staff update report submitted for this meeting.</flux:callout.text>
+                        </flux:callout>
+                    @endif
+
+                    <div class="text-right">
+                        <flux:modal.close>
+                            <flux:button variant="ghost">Close</flux:button>
+                        </flux:modal.close>
+                    </div>
+                </div>
             @endif
-        </div>
+        @endif
     </flux:modal>
 </div>

--- a/resources/views/users/show.blade.php
+++ b/resources/views/users/show.blade.php
@@ -13,6 +13,14 @@
         </div>
     @endcan
 
+    @if($user->staffPosition)
+        @can('view-staff-activity', $user)
+            <div class="my-6">
+                <livewire:users.staff-activity-card :user="$user" />
+            </div>
+        @endcan
+    @endif
+
     @can('viewActivityLog', $user)
         <div class="w-full my-6 flex justify-end">
             <flux:modal.trigger name="activity-log-modal">

--- a/tests/Feature/Actions/Rules/UpdateRuleInDraftTest.php
+++ b/tests/Feature/Actions/Rules/UpdateRuleInDraftTest.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 use App\Actions\CreateRuleVersion;
 use App\Actions\UpdateRuleInDraft;
 use App\Models\Rule;
-use App\Models\RuleVersion;
 use App\Models\User;
 
 uses()->group('rules', 'actions');
@@ -62,7 +61,8 @@ it('does not immediately deactivate the old rule', function () {
 
 it('throws if the version is not a draft', function () {
     $user = User::factory()->create();
-    $version = RuleVersion::factory()->create(['status' => 'submitted']);
+    $version = CreateRuleVersion::run($user);
+    $version->update(['status' => 'submitted']);
     $oldRule = Rule::factory()->create(['status' => 'active']);
 
     UpdateRuleInDraft::run($version, $oldRule, 'Title', 'Desc.', $user);

--- a/tests/Feature/Discord/DiscordBrigIntegrationTest.php
+++ b/tests/Feature/Discord/DiscordBrigIntegrationTest.php
@@ -82,3 +82,71 @@ it('syncs discord permissions when released from brig', function () {
     $addCalls = collect($fakeApi->calls)->where('method', 'addRole');
     expect($addCalls->count())->toBeGreaterThanOrEqual(1);
 });
+
+it('assigns the In Brig Discord role when user is put in brig', function () {
+    config(['lighthouse.discord.roles.in_brig' => 'BRIG_ROLE_ID']);
+
+    $admin = User::factory()->create();
+    $target = User::factory()->create(['membership_level' => MembershipLevel::Traveler]);
+    $account = DiscordAccount::factory()->active()->create(['user_id' => $target->id]);
+
+    $fakeApi = new FakeDiscordApiService;
+    app()->instance(DiscordApiService::class, $fakeApi);
+
+    PutUserInBrig::run($target, $admin, 'Test reason');
+
+    $addCalls = collect($fakeApi->calls)->where('method', 'addRole')->where('role_id', 'BRIG_ROLE_ID');
+    expect($addCalls)->toHaveCount(1);
+});
+
+it('removes the In Brig Discord role when user is released from brig', function () {
+    config(['lighthouse.discord.roles.in_brig' => 'BRIG_ROLE_ID']);
+
+    $admin = User::factory()->create();
+    $target = User::factory()->create([
+        'membership_level' => MembershipLevel::Traveler,
+        'in_brig' => true,
+        'brig_reason' => 'Test',
+    ]);
+    $account = DiscordAccount::factory()->brigged()->create(['user_id' => $target->id]);
+
+    $fakeApi = new FakeDiscordApiService;
+    app()->instance(DiscordApiService::class, $fakeApi);
+
+    ReleaseUserFromBrig::run($target, $admin, 'Appeal approved');
+
+    $removeCalls = collect($fakeApi->calls)->where('method', 'removeRole')->where('role_id', 'BRIG_ROLE_ID');
+    expect($removeCalls)->toHaveCount(1);
+});
+
+it('silently skips In Brig role sync when no Discord account is linked', function () {
+    config(['lighthouse.discord.roles.in_brig' => 'BRIG_ROLE_ID']);
+
+    $admin = User::factory()->create();
+    $target = User::factory()->create(['membership_level' => MembershipLevel::Traveler]);
+    // No Discord account linked
+
+    $fakeApi = new FakeDiscordApiService;
+    app()->instance(DiscordApiService::class, $fakeApi);
+
+    PutUserInBrig::run($target, $admin, 'No Discord linked');
+
+    $addCalls = collect($fakeApi->calls)->where('method', 'addRole')->where('role_id', 'BRIG_ROLE_ID');
+    expect($addCalls)->toHaveCount(0);
+});
+
+it('does not assign In Brig role when config key is not set', function () {
+    config(['lighthouse.discord.roles.in_brig' => null]);
+
+    $admin = User::factory()->create();
+    $target = User::factory()->create(['membership_level' => MembershipLevel::Traveler]);
+    $account = DiscordAccount::factory()->active()->create(['user_id' => $target->id]);
+
+    $fakeApi = new FakeDiscordApiService;
+    app()->instance(DiscordApiService::class, $fakeApi);
+
+    PutUserInBrig::run($target, $admin, 'No role configured');
+
+    $addCalls = collect($fakeApi->calls)->where('method', 'addRole');
+    expect($addCalls)->toHaveCount(0);
+});

--- a/tests/Feature/Discord/OnboardingDiscordFlowTest.php
+++ b/tests/Feature/Discord/OnboardingDiscordFlowTest.php
@@ -8,8 +8,17 @@ use Laravel\Socialite\Facades\Socialite;
 
 uses()->group('discord', 'onboarding');
 
+function stowawayWithDiscord(): User
+{
+    return User::factory()->create([
+        'membership_level' => MembershipLevel::Stowaway,
+        'parent_allows_discord' => true,
+        'in_brig' => false,
+    ]);
+}
+
 it('stores onboarding origin in session when from=onboarding param is passed', function () {
-    $user = User::factory()->create(['membership_level' => MembershipLevel::Stowaway]);
+    $user = stowawayWithDiscord();
 
     $this->actingAs($user)
         ->get(route('auth.discord.redirect', ['from' => 'onboarding']));
@@ -18,7 +27,7 @@ it('stores onboarding origin in session when from=onboarding param is passed', f
 });
 
 it('does not store onboarding origin when from param is absent', function () {
-    $user = User::factory()->create(['membership_level' => MembershipLevel::Stowaway]);
+    $user = stowawayWithDiscord();
 
     $this->actingAs($user)
         ->get(route('auth.discord.redirect'));
@@ -27,7 +36,7 @@ it('does not store onboarding origin when from param is absent', function () {
 });
 
 it('does not store origin for unrecognised from values', function () {
-    $user = User::factory()->create(['membership_level' => MembershipLevel::Stowaway]);
+    $user = stowawayWithDiscord();
 
     $this->actingAs($user)
         ->get(route('auth.discord.redirect', ['from' => 'evil']));
@@ -35,8 +44,18 @@ it('does not store origin for unrecognised from values', function () {
     expect(session('discord_oauth_from'))->toBeNull();
 });
 
+it('clears stale onboarding session when redirect is not from onboarding', function () {
+    $user = stowawayWithDiscord();
+
+    $this->actingAs($user)
+        ->withSession(['discord_oauth_from' => 'onboarding'])
+        ->get(route('auth.discord.redirect'));
+
+    expect(session('discord_oauth_from'))->toBeNull();
+});
+
 it('callback redirects to dashboard on success when from=onboarding was stored', function () {
-    $user = User::factory()->create(['membership_level' => MembershipLevel::Stowaway]);
+    $user = stowawayWithDiscord();
 
     $mockSocialUser = Mockery::mock(\Laravel\Socialite\Two\User::class);
     $mockSocialUser->shouldReceive('getId')->andReturn('999888777');
@@ -61,7 +80,7 @@ it('callback redirects to dashboard on success when from=onboarding was stored',
 });
 
 it('callback redirects to settings on success without onboarding session', function () {
-    $user = User::factory()->create(['membership_level' => MembershipLevel::Stowaway]);
+    $user = stowawayWithDiscord();
 
     $mockSocialUser = Mockery::mock(\Laravel\Socialite\Two\User::class);
     $mockSocialUser->shouldReceive('getId')->andReturn('111222333');
@@ -85,7 +104,7 @@ it('callback redirects to settings on success without onboarding session', funct
 });
 
 it('callback redirects to dashboard on OAuth error when from=onboarding', function () {
-    $user = User::factory()->create(['membership_level' => MembershipLevel::Stowaway]);
+    $user = stowawayWithDiscord();
 
     $mockProvider = Mockery::mock(\Laravel\Socialite\Contracts\Provider::class);
     $mockProvider->shouldReceive('scopes')->andReturnSelf();
@@ -101,7 +120,7 @@ it('callback redirects to dashboard on OAuth error when from=onboarding', functi
 });
 
 it('wizard discord step links directly to OAuth redirect with onboarding param', function () {
-    $user = User::factory()->create(['membership_level' => MembershipLevel::Stowaway]);
+    $user = stowawayWithDiscord();
     $this->actingAs($user);
 
     \Livewire\Volt\Volt::test('onboarding.wizard')
@@ -109,7 +128,7 @@ it('wizard discord step links directly to OAuth redirect with onboarding param',
 });
 
 it('wizard discord step does not link to settings page', function () {
-    $user = User::factory()->create(['membership_level' => MembershipLevel::Stowaway]);
+    $user = stowawayWithDiscord();
     $this->actingAs($user);
 
     \Livewire\Volt\Volt::test('onboarding.wizard')

--- a/tests/Feature/Discord/OnboardingDiscordFlowTest.php
+++ b/tests/Feature/Discord/OnboardingDiscordFlowTest.php
@@ -1,0 +1,117 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Enums\MembershipLevel;
+use App\Models\User;
+use Laravel\Socialite\Facades\Socialite;
+
+uses()->group('discord', 'onboarding');
+
+it('stores onboarding origin in session when from=onboarding param is passed', function () {
+    $user = User::factory()->create(['membership_level' => MembershipLevel::Stowaway]);
+
+    $this->actingAs($user)
+        ->get(route('auth.discord.redirect', ['from' => 'onboarding']));
+
+    expect(session('discord_oauth_from'))->toBe('onboarding');
+});
+
+it('does not store onboarding origin when from param is absent', function () {
+    $user = User::factory()->create(['membership_level' => MembershipLevel::Stowaway]);
+
+    $this->actingAs($user)
+        ->get(route('auth.discord.redirect'));
+
+    expect(session('discord_oauth_from'))->toBeNull();
+});
+
+it('does not store origin for unrecognised from values', function () {
+    $user = User::factory()->create(['membership_level' => MembershipLevel::Stowaway]);
+
+    $this->actingAs($user)
+        ->get(route('auth.discord.redirect', ['from' => 'evil']));
+
+    expect(session('discord_oauth_from'))->toBeNull();
+});
+
+it('callback redirects to dashboard on success when from=onboarding was stored', function () {
+    $user = User::factory()->create(['membership_level' => MembershipLevel::Stowaway]);
+
+    $mockSocialUser = Mockery::mock(\Laravel\Socialite\Two\User::class);
+    $mockSocialUser->shouldReceive('getId')->andReturn('999888777');
+    $mockSocialUser->shouldReceive('getNickname')->andReturn('TestUser');
+    $mockSocialUser->shouldReceive('getName')->andReturn('TestUser');
+    $mockSocialUser->token = 'access-token';
+    $mockSocialUser->refreshToken = 'refresh-token';
+    $mockSocialUser->expiresIn = 604800;
+    $mockSocialUser->user = ['global_name' => 'Test User', 'avatar' => null];
+
+    $mockProvider = Mockery::mock(\Laravel\Socialite\Contracts\Provider::class);
+    $mockProvider->shouldReceive('scopes')->andReturnSelf();
+    $mockProvider->shouldReceive('redirect')->andReturn(redirect('https://discord.com'));
+    $mockProvider->shouldReceive('user')->andReturn($mockSocialUser);
+
+    Socialite::shouldReceive('driver')->with('discord')->andReturn($mockProvider);
+
+    $this->actingAs($user)
+        ->withSession(['discord_oauth_from' => 'onboarding'])
+        ->get(route('auth.discord.callback'))
+        ->assertRedirect(route('dashboard'));
+});
+
+it('callback redirects to settings on success without onboarding session', function () {
+    $user = User::factory()->create(['membership_level' => MembershipLevel::Stowaway]);
+
+    $mockSocialUser = Mockery::mock(\Laravel\Socialite\Two\User::class);
+    $mockSocialUser->shouldReceive('getId')->andReturn('111222333');
+    $mockSocialUser->shouldReceive('getNickname')->andReturn('AnotherUser');
+    $mockSocialUser->shouldReceive('getName')->andReturn('AnotherUser');
+    $mockSocialUser->token = 'access-token';
+    $mockSocialUser->refreshToken = 'refresh-token';
+    $mockSocialUser->expiresIn = 604800;
+    $mockSocialUser->user = ['global_name' => 'Another User', 'avatar' => null];
+
+    $mockProvider = Mockery::mock(\Laravel\Socialite\Contracts\Provider::class);
+    $mockProvider->shouldReceive('scopes')->andReturnSelf();
+    $mockProvider->shouldReceive('redirect')->andReturn(redirect('https://discord.com'));
+    $mockProvider->shouldReceive('user')->andReturn($mockSocialUser);
+
+    Socialite::shouldReceive('driver')->with('discord')->andReturn($mockProvider);
+
+    $this->actingAs($user)
+        ->get(route('auth.discord.callback'))
+        ->assertRedirect(route('settings.discord-account'));
+});
+
+it('callback redirects to dashboard on OAuth error when from=onboarding', function () {
+    $user = User::factory()->create(['membership_level' => MembershipLevel::Stowaway]);
+
+    $mockProvider = Mockery::mock(\Laravel\Socialite\Contracts\Provider::class);
+    $mockProvider->shouldReceive('scopes')->andReturnSelf();
+    $mockProvider->shouldReceive('redirect')->andReturn(redirect('https://discord.com'));
+    $mockProvider->shouldReceive('user')->andThrow(new \Exception('OAuth failed'));
+
+    Socialite::shouldReceive('driver')->with('discord')->andReturn($mockProvider);
+
+    $this->actingAs($user)
+        ->withSession(['discord_oauth_from' => 'onboarding'])
+        ->get(route('auth.discord.callback'))
+        ->assertRedirect(route('dashboard'));
+});
+
+it('wizard discord step links directly to OAuth redirect with onboarding param', function () {
+    $user = User::factory()->create(['membership_level' => MembershipLevel::Stowaway]);
+    $this->actingAs($user);
+
+    \Livewire\Volt\Volt::test('onboarding.wizard')
+        ->assertSee(route('auth.discord.redirect', ['from' => 'onboarding']));
+});
+
+it('wizard discord step does not link to settings page', function () {
+    $user = User::factory()->create(['membership_level' => MembershipLevel::Stowaway]);
+    $this->actingAs($user);
+
+    \Livewire\Volt\Volt::test('onboarding.wizard')
+        ->assertDontSee(route('settings.discord-account'));
+});

--- a/tests/Feature/Finance/ReportsTest.php
+++ b/tests/Feature/Finance/ReportsTest.php
@@ -359,3 +359,38 @@ it('trial balance excludes draft entries', function () {
     expect($component->get('trialBalanceTotalDebit'))->toBe(0);
     expect($component->get('trialBalanceTotalCredit'))->toBe(0);
 });
+
+// == Print header ==
+
+it('print header includes the org name', function () {
+    $user = User::factory()->withRole('Finance - View')->create();
+    $this->actingAs($user);
+
+    Volt::test('finance.reports')
+        ->assertSee(config('app.name'));
+});
+
+it('print header includes the Lighthouse logo', function () {
+    $user = User::factory()->withRole('Finance - View')->create();
+    $this->actingAs($user);
+
+    Volt::test('finance.reports')
+        ->assertSee('LighthouseMC_Logo.png', false);
+});
+
+it('print header shows report title for active tab', function () {
+    $user = User::factory()->withRole('Finance - View')->create();
+    $this->actingAs($user);
+
+    Volt::test('finance.reports')
+        ->set('activeTab', 'ledger')
+        ->assertSee('General Ledger');
+});
+
+it('print header shows Statement of Activities for default tab', function () {
+    $user = User::factory()->withRole('Finance - View')->create();
+    $this->actingAs($user);
+
+    Volt::test('finance.reports')
+        ->assertSee('Statement of Activities');
+});

--- a/tests/Feature/Livewire/PermaBrigModalTest.php
+++ b/tests/Feature/Livewire/PermaBrigModalTest.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\User;
+
+use function Pest\Laravel\actingAs;
+
+uses()->group('brig', 'livewire');
+
+it('shows permanent checkbox in brig modal', function () {
+    $warden = User::factory()->withRole('Brig Warden')->create();
+    $target = User::factory()->create();
+    actingAs($warden);
+
+    Livewire\Volt\Volt::test('users.display-basic-details', ['user' => $target])
+        ->assertSee('Permanent');
+});
+
+it('places user in permanent brig when permanent checkbox is checked', function () {
+    $warden = User::factory()->withRole('Brig Warden')->create();
+    $target = User::factory()->create();
+    actingAs($warden);
+
+    Livewire\Volt\Volt::test('users.display-basic-details', ['user' => $target])
+        ->set('brigActionReason', 'Permanent ban for serious violation')
+        ->set('brigActionPermanent', true)
+        ->call('confirmPutInBrig');
+
+    expect($target->fresh()->in_brig)->toBeTrue()
+        ->and($target->fresh()->brig_expires_at)->toBeNull();
+});
+
+it('places user in timed brig when permanent is unchecked and days are set', function () {
+    $warden = User::factory()->withRole('Brig Warden')->create();
+    $target = User::factory()->create();
+    actingAs($warden);
+
+    Livewire\Volt\Volt::test('users.display-basic-details', ['user' => $target])
+        ->set('brigActionReason', 'Short sentence for minor infraction')
+        ->set('brigActionPermanent', false)
+        ->set('brigActionDays', 7)
+        ->call('confirmPutInBrig');
+
+    expect($target->fresh()->in_brig)->toBeTrue()
+        ->and($target->fresh()->brig_expires_at)->not->toBeNull();
+});
+
+it('places user in brig with no expiry when permanent is unchecked and no days set', function () {
+    $warden = User::factory()->withRole('Brig Warden')->create();
+    $target = User::factory()->create();
+    actingAs($warden);
+
+    Livewire\Volt\Volt::test('users.display-basic-details', ['user' => $target])
+        ->set('brigActionReason', 'No timer set for this sentence')
+        ->set('brigActionPermanent', false)
+        ->set('brigActionDays', null)
+        ->call('confirmPutInBrig');
+
+    expect($target->fresh()->in_brig)->toBeTrue()
+        ->and($target->fresh()->brig_expires_at)->toBeNull();
+});

--- a/tests/Feature/Livewire/ProfileEditRestrictionsTest.php
+++ b/tests/Feature/Livewire/ProfileEditRestrictionsTest.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\User;
+
+use function Pest\Livewire\livewire;
+
+uses()->group('profile', 'livewire');
+
+it('regular user editing own profile can only update username', function () {
+    $user = User::factory()->create([
+        'email' => 'original@example.com',
+        'date_of_birth' => '1990-01-01',
+        'parent_email' => 'parent@example.com',
+    ]);
+    loginAs($user);
+
+    livewire('users.display-basic-details', ['user' => $user])
+        ->set('editUserData.name', 'NewUsername')
+        ->set('editUserData.email', 'hacker@example.com')
+        ->set('editUserData.date_of_birth', '2000-12-31')
+        ->set('editUserData.parent_email', 'evil@example.com')
+        ->call('saveEditUser');
+
+    expect($user->fresh()->name)->toBe('NewUsername')
+        ->and($user->fresh()->email)->toBe('original@example.com')
+        ->and($user->fresh()->date_of_birth->format('Y-m-d'))->toBe('1990-01-01')
+        ->and($user->fresh()->parent_email)->toBe('parent@example.com');
+});
+
+it('user-manager can edit all fields', function () {
+    $manager = User::factory()->withRole('User - Manager')->create();
+    $target = User::factory()->create([
+        'email' => 'original@example.com',
+        'date_of_birth' => '1990-01-01',
+        'parent_email' => null,
+    ]);
+    loginAs($manager);
+
+    livewire('users.display-basic-details', ['user' => $target])
+        ->set('editUserData.name', 'UpdatedName')
+        ->set('editUserData.email', 'updated@example.com')
+        ->set('editUserData.date_of_birth', '1995-06-15')
+        ->call('saveEditUser');
+
+    expect($target->fresh()->name)->toBe('UpdatedName')
+        ->and($target->fresh()->email)->toBe('updated@example.com')
+        ->and($target->fresh()->date_of_birth->format('Y-m-d'))->toBe('1995-06-15');
+});
+
+it('admin can edit all fields on any profile', function () {
+    $admin = loginAsAdmin();
+    $target = User::factory()->create([
+        'email' => 'original@example.com',
+        'date_of_birth' => '1990-01-01',
+    ]);
+
+    livewire('users.display-basic-details', ['user' => $target])
+        ->set('editUserData.name', 'AdminEdited')
+        ->set('editUserData.email', 'admin-updated@example.com')
+        ->call('saveEditUser');
+
+    expect($target->fresh()->name)->toBe('AdminEdited')
+        ->and($target->fresh()->email)->toBe('admin-updated@example.com');
+});
+
+it('regular user edit modal shows protected fields as read-only text', function () {
+    $user = User::factory()->create([
+        'email' => 'test@example.com',
+        'date_of_birth' => '1990-01-01',
+        'parent_email' => 'parent@example.com',
+    ]);
+    loginAs($user);
+
+    livewire('users.display-basic-details', ['user' => $user])
+        ->assertSee('Contact staff to update your email address.');
+});
+
+it('user-manager edit modal shows protected fields as inputs', function () {
+    $manager = User::factory()->withRole('User - Manager')->create();
+    $target = User::factory()->create();
+    loginAs($manager);
+
+    livewire('users.display-basic-details', ['user' => $target])
+        ->assertDontSee('Contact staff to update your email address.');
+});

--- a/tests/Feature/Livewire/StaffActivityCardTest.php
+++ b/tests/Feature/Livewire/StaffActivityCardTest.php
@@ -82,54 +82,44 @@ it('denies regular members from viewing the staff activity card', function () {
         ->assertForbidden();
 });
 
-// Attendance count tests
+// Meeting table row tests
 
-it('shows correct attendance count from last 3 months', function () {
+it('shows attended badge for a meeting the staff member attended', function () {
     $staff = staffMemberWithPosition();
     loginAs($staff);
 
-    $attended = completedStaffMeeting();
-    $missed = completedStaffMeeting();
-    $attended->attendees()->attach($staff->id, ['added_at' => now(), 'attended' => true]);
-    $missed->attendees()->attach($staff->id, ['added_at' => now(), 'attended' => false]);
+    $meeting = completedStaffMeeting(['title' => 'Weekly Standup']);
+    $meeting->attendees()->attach($staff->id, ['added_at' => now(), 'attended' => true]);
 
     Volt::test('users.staff-activity-card', ['user' => $staff])
-        ->assertSee('1 / 2');
+        ->assertSee('Weekly Standup')
+        ->assertSee('Attended');
 });
 
-it('does not count meetings older than 3 months in attendance', function () {
+it('shows absent badge for a meeting the staff member missed', function () {
     $staff = staffMemberWithPosition();
     loginAs($staff);
 
-    $old = completedStaffMeeting(['end_time' => now()->subMonths(4), 'scheduled_time' => now()->subMonths(4)]);
-    $old->attendees()->attach($staff->id, ['added_at' => now(), 'attended' => true]);
+    $meeting = completedStaffMeeting(['title' => 'Weekly Standup']);
+    $meeting->attendees()->attach($staff->id, ['added_at' => now(), 'attended' => false]);
 
     Volt::test('users.staff-activity-card', ['user' => $staff])
-        ->assertSee('0 / 0');
+        ->assertSee('Weekly Standup')
+        ->assertSee('Absent');
 });
 
-// Reports filed/missed tests
-
-it('shows correct reports filed and missed count', function () {
+it('shows not on record badge when staff member has no attendance entry', function () {
     $staff = staffMemberWithPosition();
     loginAs($staff);
 
-    $meeting1 = completedStaffMeeting();
-    $meeting2 = completedStaffMeeting();
-
-    MeetingReport::create([
-        'meeting_id' => $meeting1->id,
-        'user_id' => $staff->id,
-        'submitted_at' => now(),
-    ]);
-    // No report for meeting2
+    completedStaffMeeting(['title' => 'Weekly Standup']);
 
     Volt::test('users.staff-activity-card', ['user' => $staff])
-        ->assertSee('1 filed')
-        ->assertSee('1 missed');
+        ->assertSee('Weekly Standup')
+        ->assertSee('Not on Record');
 });
 
-it('does not show missed badge when all reports are filed', function () {
+it('shows view report button when a submitted report exists for the meeting', function () {
     $staff = staffMemberWithPosition();
     loginAs($staff);
 
@@ -141,8 +131,17 @@ it('does not show missed badge when all reports are filed', function () {
     ]);
 
     Volt::test('users.staff-activity-card', ['user' => $staff])
-        ->assertSee('1 filed')
-        ->assertDontSee('missed');
+        ->assertSee('View Report');
+});
+
+it('does not show view report button when no report was submitted', function () {
+    $staff = staffMemberWithPosition();
+    loginAs($staff);
+
+    completedStaffMeeting();
+
+    Volt::test('users.staff-activity-card', ['user' => $staff])
+        ->assertDontSee('View Report');
 });
 
 // Ticket count tests

--- a/tests/Feature/Livewire/StaffActivityCardTest.php
+++ b/tests/Feature/Livewire/StaffActivityCardTest.php
@@ -1,0 +1,171 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Enums\MeetingStatus;
+use App\Enums\MeetingType;
+use App\Enums\MembershipLevel;
+use App\Enums\StaffDepartment;
+use App\Enums\StaffRank;
+use App\Enums\ThreadStatus;
+use App\Models\Meeting;
+use App\Models\MeetingReport;
+use App\Models\Thread;
+use App\Models\User;
+use Livewire\Volt\Volt;
+
+uses()->group('staff-activity', 'livewire');
+
+// Helpers
+function staffMemberWithPosition(): User
+{
+    return User::factory()
+        ->withMembershipLevel(MembershipLevel::Resident)
+        ->withStaffPosition(StaffDepartment::Engineer, StaffRank::CrewMember, 'Test Engineer')
+        ->withRole('Staff Access')
+        ->create();
+}
+
+function completedStaffMeeting(array $attributes = []): Meeting
+{
+    return Meeting::factory()->create(array_merge([
+        'type' => MeetingType::StaffMeeting,
+        'status' => MeetingStatus::Completed,
+        'end_time' => now()->subWeek(),
+        'scheduled_time' => now()->subWeek(),
+    ], $attributes));
+}
+
+// Authorization tests
+
+it('shows card on staff profile page to the staff member themselves', function () {
+    $staff = staffMemberWithPosition();
+    loginAs($staff);
+
+    $this->get(route('profile.show', $staff))
+        ->assertSeeLivewire('users.staff-activity-card');
+});
+
+it('shows card on staff profile page to an officer', function () {
+    $officer = officerCommand();
+    loginAs($officer);
+    $staff = staffMemberWithPosition();
+
+    $this->get(route('profile.show', $staff))
+        ->assertSeeLivewire('users.staff-activity-card');
+});
+
+it('does not show card on non-staff profile page', function () {
+    $officer = officerCommand();
+    loginAs($officer);
+    $regular = membershipTraveler();
+
+    $this->get(route('profile.show', $regular))
+        ->assertDontSeeLivewire('users.staff-activity-card');
+});
+
+it('denies crew members from viewing another staff member activity card', function () {
+    $crew = crewEngineer();
+    loginAs($crew);
+    $staff = staffMemberWithPosition();
+
+    Volt::test('users.staff-activity-card', ['user' => $staff])
+        ->assertForbidden();
+});
+
+it('denies regular members from viewing the staff activity card', function () {
+    $regular = membershipTraveler();
+    loginAs($regular);
+    $staff = staffMemberWithPosition();
+
+    Volt::test('users.staff-activity-card', ['user' => $staff])
+        ->assertForbidden();
+});
+
+// Attendance count tests
+
+it('shows correct attendance count from last 3 months', function () {
+    $staff = staffMemberWithPosition();
+    loginAs($staff);
+
+    $attended = completedStaffMeeting();
+    $missed = completedStaffMeeting();
+    $attended->attendees()->attach($staff->id, ['added_at' => now(), 'attended' => true]);
+    $missed->attendees()->attach($staff->id, ['added_at' => now(), 'attended' => false]);
+
+    Volt::test('users.staff-activity-card', ['user' => $staff])
+        ->assertSee('1 / 2');
+});
+
+it('does not count meetings older than 3 months in attendance', function () {
+    $staff = staffMemberWithPosition();
+    loginAs($staff);
+
+    $old = completedStaffMeeting(['end_time' => now()->subMonths(4), 'scheduled_time' => now()->subMonths(4)]);
+    $old->attendees()->attach($staff->id, ['added_at' => now(), 'attended' => true]);
+
+    Volt::test('users.staff-activity-card', ['user' => $staff])
+        ->assertSee('0 / 0');
+});
+
+// Reports filed/missed tests
+
+it('shows correct reports filed and missed count', function () {
+    $staff = staffMemberWithPosition();
+    loginAs($staff);
+
+    $meeting1 = completedStaffMeeting();
+    $meeting2 = completedStaffMeeting();
+
+    MeetingReport::create([
+        'meeting_id' => $meeting1->id,
+        'user_id' => $staff->id,
+        'submitted_at' => now(),
+    ]);
+    // No report for meeting2
+
+    Volt::test('users.staff-activity-card', ['user' => $staff])
+        ->assertSee('1 filed')
+        ->assertSee('1 missed');
+});
+
+it('does not show missed badge when all reports are filed', function () {
+    $staff = staffMemberWithPosition();
+    loginAs($staff);
+
+    $meeting = completedStaffMeeting();
+    MeetingReport::create([
+        'meeting_id' => $meeting->id,
+        'user_id' => $staff->id,
+        'submitted_at' => now(),
+    ]);
+
+    Volt::test('users.staff-activity-card', ['user' => $staff])
+        ->assertSee('1 filed')
+        ->assertDontSee('missed');
+});
+
+// Ticket count tests
+
+it('shows correct open and closed ticket counts', function () {
+    $staff = staffMemberWithPosition();
+    loginAs($staff);
+
+    Thread::factory()->assigned($staff)->create(['status' => ThreadStatus::Open]);
+    Thread::factory()->assigned($staff)->create(['status' => ThreadStatus::Pending]);
+    Thread::factory()->assigned($staff)->create(['status' => ThreadStatus::Closed]);
+    Thread::factory()->assigned($staff)->create(['status' => ThreadStatus::Resolved]);
+
+    Volt::test('users.staff-activity-card', ['user' => $staff])
+        ->assertSee('2 open')
+        ->assertSee('2 closed');
+});
+
+it('shows zero ticket counts when no tickets assigned', function () {
+    $staff = staffMemberWithPosition();
+    loginAs($staff);
+
+    Volt::test('users.staff-activity-card', ['user' => $staff])
+        ->assertSee('0 open')
+        ->assertSee('0 closed');
+});

--- a/tests/Feature/Onboarding/WizardDashboardTakeoverTest.php
+++ b/tests/Feature/Onboarding/WizardDashboardTakeoverTest.php
@@ -60,10 +60,10 @@ test('Discord step shows Connect Discord button and Skip for now option', functi
     Volt::test('onboarding.wizard')
         ->assertSee('Connect Discord')
         ->assertSee('Skip for now')
-        ->assertSee(route('settings.discord-account'));
+        ->assertSee(route('auth.discord.redirect', ['from' => 'onboarding']));
 });
 
-test('Connect Discord button points to the discord account settings route', function () {
+test('Connect Discord button points directly to the OAuth redirect with onboarding param', function () {
     $user = User::factory()->create([
         'membership_level' => MembershipLevel::Stowaway,
         'rules_accepted_at' => now(),
@@ -71,7 +71,8 @@ test('Connect Discord button points to the discord account settings route', func
     loginAs($user);
 
     Volt::test('onboarding.wizard')
-        ->assertSee(route('settings.discord-account'));
+        ->assertSee(route('auth.discord.redirect', ['from' => 'onboarding']))
+        ->assertDontSee(route('settings.discord-account'));
 });
 
 test('Skip for now records onboarding_discord_skipped in activity log', function () {


### PR DESCRIPTION
## What Changed

This sprint addresses six polish and tech debt items across brig management, user profiles, onboarding, finance reporting, Discord integration, and staff oversight.

**Permanent Brig Option** — Staff can now check "No expiry (permanent)" when placing a user in the Brig. The days field is hidden when this is selected. Previously, leaving days blank would cause a validation error. No expiry brigs still allow appeals after the 24-hour cooldown.

**Profile Edit Restrictions** — When a non-manager views their own profile and opens the Edit modal, they can only change their name. Email, date of birth, and parent email are shown as read-only with a "contact staff" prompt. Staff with the User - Manager role retain full edit access.

**Discord OAuth Return URL** — The "Connect Discord" button in the onboarding wizard now flows directly through Discord OAuth and returns to the Dashboard on completion, instead of routing to account settings. Users who come from onboarding land back on their Dashboard automatically.

**Finance Report PDF Headers** — Printed finance reports now include a branded header with the organization logo, name, report title (matching the active tab), and generation date. The header uses inline styles to ensure reliable rendering at print time.

**Discord Brig Role Sync** — When a user is placed in the Brig, the system assigns the configured "In Brig" Discord role (`DISCORD_ROLE_IN_BRIG` env var). When released, the role is removed before their normal roles are restored. Both operations are wrapped in try/catch so a Discord API failure never blocks the brig action itself.

**Staff Activity Card** — A new card on staff profile pages shows Officers (and the staff member themselves) a 3-month rolling summary: meeting attendance count (clickable for a per-meeting breakdown modal), staff reports filed vs. missed, and open/closed ticket counts.

## How to Test

### Permanent Brig

1. Log in as a Brig Warden (Quartermaster or Command staff)
2. Open a non-staff user's profile → Actions → Put in Brig
3. Enter a reason and check **No expiry (permanent)** — the days field should hide
4. Confirm — brig should be placed with no expiry date shown

### Profile Edit Restrictions

1. Log in as a regular (non-manager) user
2. Visit your own profile page → click Edit
3. Verify name is editable, but email/DOB/parent email show read-only text with a "contact staff" note
4. Try saving — only name should update
5. Log in as a User - Manager and verify all fields remain editable

### Discord OAuth Return URL

1. Log in as a Stowaway user (accepted rules, no Discord linked)
2. On the Dashboard wizard, click **Connect Discord**
3. Authorize on Discord's page
4. Verify you land back on the Dashboard (not the Discord settings page)
5. Verify the wizard advances to the next step automatically

### Finance PDF Header

1. Log in as Finance - View (or higher)
2. Go to Finance → Reports
3. Switch to different tabs (General Ledger, Balance Sheet, etc.)
4. Press Ctrl+P (or Cmd+P) to open print preview
5. Verify the header shows the logo, org name, report title matching the active tab, and today's date

### Discord Brig Role Sync

1. Requires `DISCORD_ROLE_IN_BRIG` to be set in the environment to a real Discord role ID
2. Put a user with a linked Discord account in the Brig
3. Verify they receive the "In Brig" Discord role and their other roles are removed
4. Release them from the Brig
5. Verify the "In Brig" role is removed and their normal roles are restored

### Staff Activity Card

1. Log in as an Officer
2. Visit a staff member's profile page
3. Verify the "Staff Activity" card appears with three sections (attendance, reports, tickets)
4. Click the attendance count — verify a modal opens listing each meeting with attended/absent status
5. Visit a non-staff user's profile — verify the card does not appear
6. Log in as a Crew Member and visit a staff profile — verify the card is not visible

## Things to Watch For

- The permanent brig checkbox should properly hide the days field via Alpine.js — verify the days input is not submitted or validated when permanent is checked
- Discord role sync failures are non-blocking (logged as warnings, not errors) — check logs if Discord role assignment seems off
- The staff activity card ticket counts reflect all-time assigned tickets, while attendance and reports are rolling 3 months — verify the label says "Last 3 months"
- If `DISCORD_ROLE_IN_BRIG` is not configured, the role sync step is silently skipped — no error shown to staff

## Parent PRD

#599

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Discord “In Brig” role sync (assign/remove when configured) with safe per-user error logging
  * Permanent (no-expiry) brig option and updated brig UI/validation
  * Staff Activity card on staff profiles showing attendance, reports, and ticket metrics
  * Onboarding Discord flow preserves origin and redirects to dashboard when started from onboarding
  * Printed/PDF finance reports include org header, logo, and generation date

* **Permissions**
  * New gate controlling view access to staff activity

* **Documentation**
  * Updated brig, Discord onboarding/linking, finance, and staff profile docs

* **Tests**
  * Added integration and Livewire tests for brig, Discord onboarding, staff activity, profile edit restrictions, and finance headers
<!-- end of auto-generated comment: release notes by coderabbit.ai -->