### PR TITLE
Password Vault (#621)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -121,3 +121,12 @@ DISCORD_ROLE_VERIFIED=
 OPENAI_API_KEY=
 AI_MEETING_NOTES_PROVIDER=openai
 AI_MEETING_NOTES_MODEL=gpt-4.1-mini
+
+# Staff Credential Vault
+# A dedicated encryption key separate from APP_KEY. Generate with:
+#   php -r "echo base64_encode(random_bytes(32)).PHP_EOL;"
+# Add this to your .env and server environment BEFORE running vault migrations.
+# If not set, the vault feature will throw a configuration exception.
+VAULT_KEY=
+# Optional: how long (minutes) a vault re-auth session stays valid (default: 30)
+# VAULT_SESSION_TTL_MINUTES=30

--- a/README.md
+++ b/README.md
@@ -155,3 +155,5 @@ If you encounter permission issues while accessing certain features or resources
     }
     dd($msg);
     ``` 
+## Generate Vault Key
+`php -r "echo base64_encode(random_bytes(32)).PHP_EOL;"`

--- a/ai/CONVENTIONS.md
+++ b/ai/CONVENTIONS.md
@@ -90,6 +90,32 @@ new class extends Component {
 - Computed properties: `public function getXxxProperty()` returns data, accessed as `$this->xxx`.
 - `wire:key` on every repeated element: `wire:key="prefix-{{ $item->id }}"`.
 
+**Full-page components and the single-root rule**:
+
+Livewire requires **exactly one root HTML element** per component. For full-page Volt components, Livewire **automatically** applies `resources/views/components/layouts/app.blade.php` as the page layout — **do NOT add `<x-layouts.app>` manually**. The component template must start with a single root `<div>`.
+
+Using `<x-layouts.app>` explicitly causes `MultipleRootElementsDetectedException` because Livewire's `SupportPageComponents` feature extracts the slot content and checks it for root elements. Even with a wrapper `<div>` inside `<x-layouts.app>`, Livewire still sees multiple roots in some render paths (e.g. wire:navigate).
+
+**Correct** (bare single `<div>` root — layout auto-applied):
+```blade
+<div class="space-y-6">
+    <div class="flex items-center justify-between">...</div>
+    <flux:table>...</flux:table>
+    <flux:modal name="...">...</flux:modal>
+</div>
+```
+
+**Wrong** (explicit `<x-layouts.app>` — causes MultipleRootElementsDetectedException):
+```blade
+<x-layouts.app>
+    <div class="flex items-center justify-between">...</div>
+    <flux:table>...</flux:table>
+    <flux:modal name="...">...</flux:modal>
+</x-layouts.app>
+```
+
+All modals belong inside the single root `<div>`, even though they render as overlays — they still count as DOM children of the component.
+
 ---
 
 ## Flux UI Component Cheatsheet

--- a/app/Actions/AssignCredentialPositions.php
+++ b/app/Actions/AssignCredentialPositions.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Actions;
+
+use App\Models\Credential;
+use App\Models\User;
+use Illuminate\Support\Facades\DB;
+use Lorisleiva\Actions\Concerns\AsAction;
+
+class AssignCredentialPositions
+{
+    use AsAction;
+
+    /**
+     * @param  array<int>  $positionIds
+     */
+    public function handle(Credential $credential, User $assignedBy, array $positionIds): void
+    {
+        DB::transaction(function () use ($credential, $assignedBy, $positionIds) {
+            $credential->staffPositions()->sync($positionIds);
+
+            RecordActivity::run(
+                $credential,
+                'credential_positions_assigned',
+                "Credential \"{$credential->name}\" position access updated by {$assignedBy->name}.",
+                $assignedBy
+            );
+            RecordCredentialAccess::run($credential, $assignedBy, 'positions_assigned');
+        });
+    }
+}

--- a/app/Actions/CreateCredential.php
+++ b/app/Actions/CreateCredential.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Actions;
+
+use App\Models\Credential;
+use App\Models\User;
+use Lorisleiva\Actions\Concerns\AsAction;
+
+class CreateCredential
+{
+    use AsAction;
+
+    public function handle(User $creator, array $data): Credential
+    {
+        $credential = Credential::create([
+            'name' => $data['name'],
+            'website_url' => $data['website_url'] ?? null,
+            'username' => $data['username'],
+            'email' => $data['email'] ?? null,
+            'password' => $data['password'],
+            'totp_secret' => $data['totp_secret'] ?? null,
+            'notes' => $data['notes'] ?? null,
+            'recovery_codes' => $data['recovery_codes'] ?? null,
+            'needs_password_change' => false,
+            'password_changed_at' => now(),
+            'created_by' => $creator->id,
+            'updated_by' => null,
+        ]);
+
+        RecordActivity::run($credential, 'credential_created', "Credential \"{$credential->name}\" created by {$creator->name}.", $creator);
+        RecordCredentialAccess::run($credential, $creator, 'created');
+
+        return $credential;
+    }
+}

--- a/app/Actions/DeleteCredential.php
+++ b/app/Actions/DeleteCredential.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Actions;
+
+use App\Models\Credential;
+use App\Models\User;
+use Illuminate\Support\Facades\DB;
+use Lorisleiva\Actions\Concerns\AsAction;
+
+class DeleteCredential
+{
+    use AsAction;
+
+    public function handle(Credential $credential, User $deletedBy): void
+    {
+        $name = $credential->name;
+
+        // All operations are atomic: if delete fails, no orphaned audit entry is left
+        DB::transaction(function () use ($credential, $deletedBy, $name) {
+            // Audit entry is preserved with credential_id = null (nullOnDelete FK)
+            RecordCredentialAccess::run($credential, $deletedBy, 'deleted');
+            $credential->staffPositions()->detach();
+            $credential->delete();
+            RecordActivity::run($deletedBy, 'credential_deleted', "Credential \"{$name}\" deleted by {$deletedBy->name}.", $deletedBy);
+        });
+    }
+}

--- a/app/Actions/FlagCredentialsAfterPositionRemoval.php
+++ b/app/Actions/FlagCredentialsAfterPositionRemoval.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Actions;
+
+use App\Models\StaffPosition;
+use App\Models\User;
+use Lorisleiva\Actions\Concerns\AsAction;
+
+class FlagCredentialsAfterPositionRemoval
+{
+    use AsAction;
+
+    public function handle(User $user, StaffPosition $position): void
+    {
+        // Flag credentials on this position that the departing user actually accessed
+        $position->credentials()
+            ->whereHas('accessLogs', fn ($accessLogQuery) => $accessLogQuery->where('user_id', $user->id))
+            ->update(['needs_password_change' => true]);
+    }
+}

--- a/app/Actions/GenerateTotpCode.php
+++ b/app/Actions/GenerateTotpCode.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Actions;
+
+use App\Models\Credential;
+use Lorisleiva\Actions\Concerns\AsAction;
+use OTPHP\InternalClock;
+use OTPHP\TOTP;
+
+class GenerateTotpCode
+{
+    use AsAction;
+
+    /**
+     * Generate the current TOTP code for a credential.
+     *
+     * @return array{code: string, seconds_remaining: int}
+     */
+    public function handle(Credential $credential): array
+    {
+        $rawSecret = $credential->totp_secret;
+
+        if (blank($rawSecret)) {
+            throw new \RuntimeException('TOTP secret is missing for this credential.');
+        }
+
+        $totp = TOTP::createFromSecret($rawSecret, new InternalClock);
+
+        return [
+            'code' => $totp->now(),
+            'seconds_remaining' => $totp->expiresIn(),
+        ];
+    }
+}

--- a/app/Actions/ReauthenticateVaultSession.php
+++ b/app/Actions/ReauthenticateVaultSession.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Actions;
+
+use App\Models\User;
+use App\Services\VaultSession;
+use Illuminate\Support\Facades\Hash;
+use Lorisleiva\Actions\Concerns\AsAction;
+
+class ReauthenticateVaultSession
+{
+    use AsAction;
+
+    public function handle(User $user, string $password): bool
+    {
+        if (! Hash::check($password, $user->password)) {
+            return false;
+        }
+
+        app(VaultSession::class)->unlock();
+
+        return true;
+    }
+}

--- a/app/Actions/RecordCredentialAccess.php
+++ b/app/Actions/RecordCredentialAccess.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Actions;
+
+use App\Models\Credential;
+use App\Models\CredentialAccessLog;
+use App\Models\User;
+use Lorisleiva\Actions\Concerns\AsAction;
+
+class RecordCredentialAccess
+{
+    use AsAction;
+
+    public function handle(Credential $credential, User $user, string $action): void
+    {
+        CredentialAccessLog::create([
+            'credential_id' => $credential->id,
+            'user_id' => $user->id,
+            'action' => $action,
+            'created_at' => now(),
+        ]);
+    }
+}

--- a/app/Actions/UnassignStaffPosition.php
+++ b/app/Actions/UnassignStaffPosition.php
@@ -21,6 +21,9 @@ class UnassignStaffPosition
         $positionTitle = $position->title;
 
         DB::transaction(function () use ($position, $user, $positionTitle) {
+            // Flag credentials accessed by the departing user before clearing the position
+            FlagCredentialsAfterPositionRemoval::run($user, $position);
+
             // Clear the position assignment
             $position->update(['user_id' => null]);
 

--- a/app/Actions/UpdateCredential.php
+++ b/app/Actions/UpdateCredential.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace App\Actions;
+
+use App\Models\Credential;
+use App\Models\User;
+use Lorisleiva\Actions\Concerns\AsAction;
+
+class UpdateCredential
+{
+    use AsAction;
+
+    public function handle(Credential $credential, User $updater, array $data): Credential
+    {
+        $updates = ['updated_by' => $updater->id];
+
+        if (isset($data['name'])) {
+            $updates['name'] = $data['name'];
+        }
+
+        if (array_key_exists('website_url', $data)) {
+            $updates['website_url'] = $data['website_url'];
+        }
+
+        if (isset($data['username'])) {
+            $updates['username'] = $data['username'];
+        }
+
+        if (array_key_exists('email', $data)) {
+            $updates['email'] = $data['email'];
+        }
+
+        if (array_key_exists('totp_secret', $data)) {
+            $updates['totp_secret'] = $data['totp_secret'];
+        }
+
+        if (array_key_exists('notes', $data)) {
+            $updates['notes'] = $data['notes'];
+        }
+
+        if (array_key_exists('recovery_codes', $data)) {
+            $updates['recovery_codes'] = $data['recovery_codes'];
+        }
+
+        if (isset($data['password']) && $data['password'] !== '') {
+            $updates['password'] = $data['password'];
+            $updates['needs_password_change'] = false;
+            $updates['password_changed_at'] = now();
+        }
+
+        $credential->update($updates);
+
+        RecordActivity::run($credential, 'credential_updated', "Credential \"{$credential->name}\" updated by {$updater->name}.", $updater);
+        RecordCredentialAccess::run($credential, $updater, 'updated');
+
+        return $credential->fresh();
+    }
+}

--- a/app/Models/Credential.php
+++ b/app/Models/Credential.php
@@ -1,0 +1,163 @@
+<?php
+
+namespace App\Models;
+
+use App\Services\VaultEncrypter;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\Relations\HasOne;
+
+class Credential extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'name',
+        'website_url',
+        'username',
+        'email',
+        'password',
+        'totp_secret',
+        'notes',
+        'recovery_codes',
+        'needs_password_change',
+        'password_changed_at',
+        'created_by',
+        'updated_by',
+    ];
+
+    protected function casts(): array
+    {
+        return [
+            'needs_password_change' => 'boolean',
+            'password_changed_at' => 'datetime',
+        ];
+    }
+
+    // === Encrypted field accessors/mutators ===
+
+    public function getUsernameAttribute(?string $value): ?string
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        return app(VaultEncrypter::class)->decrypt($value);
+    }
+
+    public function setUsernameAttribute(string $value): void
+    {
+        $this->attributes['username'] = app(VaultEncrypter::class)->encrypt($value);
+    }
+
+    public function getEmailAttribute(?string $value): ?string
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        return app(VaultEncrypter::class)->decrypt($value);
+    }
+
+    public function setEmailAttribute(?string $value): void
+    {
+        $this->attributes['email'] = $value !== null
+            ? app(VaultEncrypter::class)->encrypt($value)
+            : null;
+    }
+
+    public function getPasswordAttribute(?string $value): ?string
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        return app(VaultEncrypter::class)->decrypt($value);
+    }
+
+    public function setPasswordAttribute(string $value): void
+    {
+        $this->attributes['password'] = app(VaultEncrypter::class)->encrypt($value);
+    }
+
+    public function getTotpSecretAttribute(?string $value): ?string
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        return app(VaultEncrypter::class)->decrypt($value);
+    }
+
+    public function setTotpSecretAttribute(?string $value): void
+    {
+        $this->attributes['totp_secret'] = $value !== null
+            ? app(VaultEncrypter::class)->encrypt($value)
+            : null;
+    }
+
+    public function getNotesAttribute(?string $value): ?string
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        return app(VaultEncrypter::class)->decrypt($value);
+    }
+
+    public function setNotesAttribute(?string $value): void
+    {
+        $this->attributes['notes'] = $value !== null
+            ? app(VaultEncrypter::class)->encrypt($value)
+            : null;
+    }
+
+    public function getRecoveryCodesAttribute(?string $value): ?string
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        return app(VaultEncrypter::class)->decrypt($value);
+    }
+
+    public function setRecoveryCodesAttribute(?string $value): void
+    {
+        $this->attributes['recovery_codes'] = $value !== null
+            ? app(VaultEncrypter::class)->encrypt($value)
+            : null;
+    }
+
+    // === Relationships ===
+
+    public function createdBy(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'created_by');
+    }
+
+    public function updatedBy(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'updated_by');
+    }
+
+    public function staffPositions(): BelongsToMany
+    {
+        return $this->belongsToMany(StaffPosition::class, 'credential_staff_position')
+            ->withTimestamps();
+    }
+
+    public function accessLogs(): HasMany
+    {
+        return $this->hasMany(CredentialAccessLog::class);
+    }
+
+    public function latestAccessLog(): HasOne
+    {
+        return $this->hasOne(CredentialAccessLog::class)
+            ->whereIn('action', ['viewed_password', 'viewed_totp'])
+            ->latestOfMany('created_at');
+    }
+}

--- a/app/Models/CredentialAccessLog.php
+++ b/app/Models/CredentialAccessLog.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class CredentialAccessLog extends Model
+{
+    public $timestamps = false;
+
+    protected $fillable = [
+        'credential_id',
+        'user_id',
+        'action',
+        'created_at',
+    ];
+
+    protected function casts(): array
+    {
+        return [
+            'created_at' => 'datetime',
+        ];
+    }
+
+    public function credential(): BelongsTo
+    {
+        return $this->belongsTo(Credential::class);
+    }
+
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+}

--- a/app/Models/StaffPosition.php
+++ b/app/Models/StaffPosition.php
@@ -91,6 +91,11 @@ class StaffPosition extends Model
         return $query->where('accepting_applications', true);
     }
 
+    public function credentials(): BelongsToMany
+    {
+        return $this->belongsToMany(Credential::class, 'credential_staff_position');
+    }
+
     public function roles(): BelongsToMany
     {
         return $this->belongsToMany(Role::class);

--- a/app/Policies/CredentialPolicy.php
+++ b/app/Policies/CredentialPolicy.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace App\Policies;
+
+use App\Models\Credential;
+use App\Models\User;
+
+class CredentialPolicy
+{
+    public function before(User $user, string $ability): ?bool
+    {
+        if ($user->isAdmin()) {
+            return true;
+        }
+
+        return null;
+    }
+
+    public function viewAny(User $user): bool
+    {
+        return $user->hasRole('Vault Manager') || $user->isAtLeastRank(\App\Enums\StaffRank::JrCrew);
+    }
+
+    public function view(User $user, Credential $credential): bool
+    {
+        if ($user->hasRole('Vault Manager')) {
+            return true;
+        }
+
+        $positionId = $user->staffPosition?->id;
+        if ($positionId === null) {
+            return false;
+        }
+
+        return $credential->staffPositions()->where('staff_positions.id', $positionId)->exists();
+    }
+
+    public function update(User $user, Credential $credential): bool
+    {
+        return $this->view($user, $credential);
+    }
+
+    public function delete(User $user, Credential $credential): bool
+    {
+        return $user->hasRole('Vault Manager');
+    }
+
+    public function managePositions(User $user, Credential $credential): bool
+    {
+        return $user->hasRole('Vault Manager');
+    }
+}

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -32,6 +32,10 @@ class AppServiceProvider extends ServiceProvider
         $this->app->singleton(\App\Services\DocumentationService::class, function () {
             return new \App\Services\DocumentationService(resource_path('library'));
         });
+
+        $this->app->singleton(\App\Services\VaultEncrypter::class, function () {
+            return new \App\Services\VaultEncrypter;
+        });
     }
 
     /**

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -28,6 +28,7 @@ class AuthServiceProvider extends ServiceProvider
         \App\Models\CommunityResponse::class => \App\Policies\CommunityResponsePolicy::class,
         \App\Models\StaffApplication::class => \App\Policies\StaffApplicationPolicy::class,
         \App\Models\BlogPost::class => \App\Policies\BlogPostPolicy::class,
+        \App\Models\Credential::class => \App\Policies\CredentialPolicy::class,
     ];
 
     /**
@@ -111,6 +112,7 @@ class AuthServiceProvider extends ServiceProvider
         Gate::define('view-mc-command-log', $canViewLogs);
         Gate::define('view-discord-api-log', $canViewLogs);
         Gate::define('view-activity-log', $canViewLogs);
+        Gate::define('view-credential-access-log', $canViewLogs);
         Gate::define('view-discipline-report-log', function ($user) use ($canViewLogs) {
             return $canViewLogs($user) || $user->hasRole('Discipline Report - Manager');
         });
@@ -268,6 +270,15 @@ class AuthServiceProvider extends ServiceProvider
 
             // Command officers and department leads (Officer rank in any department)
             return $user->isAtLeastRank(StaffRank::Officer);
+        });
+
+        // Vault gates
+        Gate::define('manage-vault', function ($user) {
+            return $user->isAdmin() || $user->hasRole('Vault Manager');
+        });
+
+        Gate::define('view-vault', function ($user) {
+            return $user->isAdmin() || $user->isAtLeastRank(StaffRank::JrCrew);
         });
 
         // Rules gates

--- a/app/Services/VaultEncrypter.php
+++ b/app/Services/VaultEncrypter.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Services;
+
+use Illuminate\Encryption\Encrypter;
+
+class VaultEncrypter
+{
+    private Encrypter $encrypter;
+
+    public function __construct()
+    {
+        $key = config('vault.key');
+
+        if (empty($key)) {
+            throw new \RuntimeException(
+                'VAULT_KEY is not set. Add VAULT_KEY to your .env file. '.
+                'Generate a value with: php -r "echo base64_encode(random_bytes(32)).PHP_EOL;"'
+            );
+        }
+
+        $this->encrypter = new Encrypter(base64_decode($key), 'AES-256-CBC');
+    }
+
+    public function encrypt(string $value): string
+    {
+        return $this->encrypter->encrypt($value);
+    }
+
+    public function decrypt(string $payload): string
+    {
+        return $this->encrypter->decrypt($payload);
+    }
+}

--- a/app/Services/VaultSession.php
+++ b/app/Services/VaultSession.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Services;
+
+class VaultSession
+{
+    private const SESSION_KEY = 'vault_unlocked_at';
+
+    public function unlock(): void
+    {
+        session([self::SESSION_KEY => now()->timestamp]);
+    }
+
+    public function isUnlocked(): bool
+    {
+        $unlockedAt = session(self::SESSION_KEY);
+
+        if ($unlockedAt === null) {
+            return false;
+        }
+
+        $ttl = (int) config('vault.session_ttl_minutes', 30);
+
+        return now()->timestamp - $unlockedAt < $ttl * 60;
+    }
+
+    public function lock(): void
+    {
+        session()->forget(self::SESSION_KEY);
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,7 @@
         "lorisleiva/laravel-actions": "^2.9",
         "prism-php/prism": "^0.99.21",
         "socialiteproviders/discord": "^4.2",
+        "spomky-labs/otphp": "^11.4",
         "symfony/yaml": "^7.4",
         "thedudeguy/rcon": "^1.0"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "038b4f1ee640fce93737ce7198541011",
+    "content-hash": "74421e447e55f74432006625fe43a950",
     "packages": [
         {
             "name": "aws/aws-crt-php",
@@ -4731,6 +4731,76 @@
                 "source": "https://github.com/socialiteproviders/manager"
             },
             "time": "2025-02-24T19:33:30+00:00"
+        },
+        {
+            "name": "spomky-labs/otphp",
+            "version": "11.4.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Spomky-Labs/otphp.git",
+                "reference": "2a1b503fd1c1a5c751ab3c5cd37f2d2d26ab74ad"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Spomky-Labs/otphp/zipball/2a1b503fd1c1a5c751ab3c5cd37f2d2d26ab74ad",
+                "reference": "2a1b503fd1c1a5c751ab3c5cd37f2d2d26ab74ad",
+                "shasum": ""
+            },
+            "require": {
+                "paragonie/constant_time_encoding": "^2.0 || ^3.0",
+                "php": ">=8.1",
+                "psr/clock": "^1.0",
+                "symfony/deprecation-contracts": "^3.2"
+            },
+            "require-dev": {
+                "symfony/error-handler": "^6.4|^7.0|^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "OTPHP\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Florent Morselli",
+                    "homepage": "https://github.com/Spomky"
+                },
+                {
+                    "name": "All contributors",
+                    "homepage": "https://github.com/Spomky-Labs/otphp/contributors"
+                }
+            ],
+            "description": "A PHP library for generating one time passwords according to RFC 4226 (HOTP Algorithm) and the RFC 6238 (TOTP Algorithm) and compatible with Google Authenticator",
+            "homepage": "https://github.com/Spomky-Labs/otphp",
+            "keywords": [
+                "FreeOTP",
+                "RFC 4226",
+                "RFC 6238",
+                "google authenticator",
+                "hotp",
+                "otp",
+                "totp"
+            ],
+            "support": {
+                "issues": "https://github.com/Spomky-Labs/otphp/issues",
+                "source": "https://github.com/Spomky-Labs/otphp/tree/11.4.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/Spomky",
+                    "type": "github"
+                },
+                {
+                    "url": "https://www.patreon.com/FlorentMorselli",
+                    "type": "patreon"
+                }
+            ],
+            "time": "2026-01-23T10:53:01+00:00"
         },
         {
             "name": "symfony/clock",

--- a/config/vault.php
+++ b/config/vault.php
@@ -1,0 +1,30 @@
+<?php
+
+return [
+    /*
+    |--------------------------------------------------------------------------
+    | Vault Encryption Key
+    |--------------------------------------------------------------------------
+    |
+    | A dedicated encryption key for the staff credential vault, separate from
+    | APP_KEY. This means a database dump alone is not sufficient to read stored
+    | credentials — the VAULT_KEY is also required.
+    |
+    | Generate a value with:
+    |   php -r "echo base64_encode(random_bytes(32)).PHP_EOL;"
+    |
+    */
+    'key' => env('VAULT_KEY'),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Vault Session TTL
+    |--------------------------------------------------------------------------
+    |
+    | How long (in minutes) a re-authentication session remains valid after
+    | the user verifies their password. After this window expires, the user
+    | must re-authenticate to view encrypted credential fields.
+    |
+    */
+    'session_ttl_minutes' => (int) env('VAULT_SESSION_TTL_MINUTES', 30),
+];

--- a/database/factories/CredentialFactory.php
+++ b/database/factories/CredentialFactory.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\Credential>
+ */
+class CredentialFactory extends Factory
+{
+    public function definition(): array
+    {
+        return [
+            'name' => $this->faker->company().' Admin',
+            'website_url' => $this->faker->optional()->url(),
+            'username' => $this->faker->userName(),
+            'email' => $this->faker->optional()->safeEmail(),
+            'password' => $this->faker->password(12),
+            'totp_secret' => null,
+            'notes' => $this->faker->optional()->sentence(),
+            'recovery_codes' => null,
+            'needs_password_change' => false,
+            'created_by' => User::factory(),
+            'updated_by' => null,
+        ];
+    }
+
+    public function withTotp(): static
+    {
+        return $this->state(fn () => [
+            'totp_secret' => strtoupper($this->faker->lexify('????????????????????????????????')),
+        ]);
+    }
+
+    public function needsPasswordChange(): static
+    {
+        return $this->state(fn () => [
+            'needs_password_change' => true,
+        ]);
+    }
+}

--- a/database/migrations/2026_04_12_000001_create_credentials_table.php
+++ b/database/migrations/2026_04_12_000001_create_credentials_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('credentials', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->string('website_url')->nullable();
+            $table->text('username');
+            $table->text('email')->nullable();
+            $table->text('password');
+            $table->text('totp_secret')->nullable();
+            $table->text('notes')->nullable();
+            $table->text('recovery_codes')->nullable();
+            $table->boolean('needs_password_change')->default(false);
+            $table->foreignId('created_by')->constrained('users');
+            $table->foreignId('updated_by')->nullable()->constrained('users');
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('credentials');
+    }
+};

--- a/database/migrations/2026_04_12_000002_create_credential_staff_position_table.php
+++ b/database/migrations/2026_04_12_000002_create_credential_staff_position_table.php
@@ -1,0 +1,23 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('credential_staff_position', function (Blueprint $table) {
+            $table->foreignId('credential_id')->constrained('credentials')->cascadeOnDelete();
+            $table->foreignId('staff_position_id')->constrained('staff_positions')->cascadeOnDelete();
+            $table->timestamps();
+            $table->primary(['credential_id', 'staff_position_id']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('credential_staff_position');
+    }
+};

--- a/database/migrations/2026_04_12_000003_create_credential_access_logs_table.php
+++ b/database/migrations/2026_04_12_000003_create_credential_access_logs_table.php
@@ -1,0 +1,24 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('credential_access_logs', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('credential_id')->constrained('credentials')->cascadeOnDelete();
+            $table->foreignId('user_id')->constrained('users');
+            $table->string('action');
+            $table->timestamp('created_at')->useCurrent();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('credential_access_logs');
+    }
+};

--- a/database/migrations/2026_04_12_000004_seed_vault_manager_role.php
+++ b/database/migrations/2026_04_12_000004_seed_vault_manager_role.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        $exists = DB::table('roles')->where('name', 'Vault Manager')->exists();
+        if (! $exists) {
+            DB::table('roles')->insert([
+                'name' => 'Vault Manager',
+                'description' => 'Full control over the staff credential vault: create, edit, delete credentials and manage position access.',
+                'color' => 'violet',
+                'icon' => 'key',
+                'created_at' => now(),
+                'updated_at' => now(),
+            ]);
+        }
+    }
+
+    public function down(): void
+    {
+        DB::table('roles')->where('name', 'Vault Manager')->delete();
+    }
+};

--- a/database/migrations/2026_04_12_174500_make_credential_access_log_credential_id_nullable.php
+++ b/database/migrations/2026_04_12_174500_make_credential_access_log_credential_id_nullable.php
@@ -1,0 +1,26 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('credential_access_logs', function (Blueprint $table) {
+            $table->dropForeign(['credential_id']);
+            $table->unsignedBigInteger('credential_id')->nullable()->change();
+            $table->foreign('credential_id')->references('id')->on('credentials')->nullOnDelete();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('credential_access_logs', function (Blueprint $table) {
+            $table->dropForeign(['credential_id']);
+            $table->unsignedBigInteger('credential_id')->nullable(false)->change();
+            $table->foreign('credential_id')->references('id')->on('credentials')->cascadeOnDelete();
+        });
+    }
+};

--- a/database/migrations/2026_04_12_233924_add_password_changed_at_to_credentials_table.php
+++ b/database/migrations/2026_04_12_233924_add_password_changed_at_to_credentials_table.php
@@ -1,0 +1,25 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('credentials', function (Blueprint $table) {
+            $table->timestamp('password_changed_at')->nullable()->after('needs_password_change');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('credentials', function (Blueprint $table) {
+            $table->dropColumn('password_changed_at');
+        });
+    }
+};

--- a/docs/features/Staff Credential Vault with Role-Based Access & TOTP.md
+++ b/docs/features/Staff Credential Vault with Role-Based Access & TOTP.md
@@ -1,0 +1,700 @@
+# Staff Credential Vault with Role-Based Access & TOTP — Technical Documentation
+
+> **Audience:** Project owner, developers, AI agents
+> **Generated:** 2026-04-12
+> **Generator:** `/document-feature` skill
+
+---
+
+## Table of Contents
+
+1. [Overview](#1-overview)
+2. [Database Schema](#2-database-schema)
+3. [Models & Relationships](#3-models--relationships)
+4. [Enums Reference](#4-enums-reference)
+5. [Authorization & Permissions](#5-authorization--permissions)
+6. [Routes](#6-routes)
+7. [User Interface Components](#7-user-interface-components)
+8. [Actions (Business Logic)](#8-actions-business-logic)
+9. [Notifications](#9-notifications)
+10. [Background Jobs](#10-background-jobs)
+11. [Console Commands & Scheduled Tasks](#11-console-commands--scheduled-tasks)
+12. [Services](#12-services)
+13. [Activity Log Entries](#13-activity-log-entries)
+14. [Data Flow Diagrams](#14-data-flow-diagrams)
+15. [Configuration](#15-configuration)
+16. [Test Coverage](#16-test-coverage)
+17. [File Map](#17-file-map)
+18. [Known Issues & Improvement Opportunities](#18-known-issues--improvement-opportunities)
+
+---
+
+## 1. Overview
+
+The Staff Credential Vault is a secure password manager built into the Lighthouse Website for storing and sharing service credentials among authorized staff. Sensitive fields are encrypted at rest using a dedicated vault key that is separate from the application key, so a database dump alone is insufficient to read stored credentials.
+
+**Who uses it:**
+
+- **Vault Manager** (role): Full control over the vault — can create, edit, delete credentials and manage which staff positions have access to each credential.
+- **Position holders** (JrCrew rank and above): Can view and update credentials that are assigned to their staff position. Cannot delete credentials or change position access.
+- **Non-position staff / members below JrCrew rank**: Cannot access the vault at all.
+- **Admins**: Bypass all policy checks and have full access.
+- **Logs - Viewer** (role): Can read the Credential Access Log in the Admin Control Panel (ACP).
+
+**Key concepts:**
+
+- **Credential**: A named record containing a username, optional email, password, optional TOTP secret, notes, and recovery codes. All sensitive fields are encrypted via Eloquent accessors/mutators using AES-256-CBC and the `VAULT_KEY` environment variable.
+- **Vault Session**: Re-authentication (entering the user's Lighthouse password) is required before sensitive data can be revealed. The session remains unlocked for a configurable TTL (default 30 minutes). Password reveal requires the session to be unlocked; TOTP reveal always requires re-authentication regardless of session state.
+- **Position Access Control**: A Vault Manager assigns one or more `StaffPosition` records to each credential. Only the holder of an assigned position can view that credential. Credentials with no assigned positions are visible only to Vault Managers.
+- **Rotation Flags**: When a staff member is removed from a position via `UnassignStaffPosition`, `FlagCredentialsAfterPositionRemoval` automatically sets `needs_password_change = true` on every credential assigned to that position that the departing user previously accessed. This surfaces a "Needs Rotation" badge in the vault index and detail views.
+- **Access Log**: Every meaningful interaction with a credential (creation, update, deletion, password reveal, TOTP reveal, position assignment) is recorded in `credential_access_logs`. These logs are viewable in the ACP by staff with the `Logs - Viewer` role.
+
+---
+
+## 2. Database Schema
+
+### `credentials` table
+
+| Column | Type | Nullable | Default | Notes |
+|--------|------|----------|---------|-------|
+| id | bigint unsigned | No | auto | Primary key |
+| name | varchar(255) | No | | Human-readable label (e.g. "Apex Hosting Admin") |
+| website_url | varchar(255) | Yes | null | Login URL for the service |
+| username | text | No | | Encrypted via VaultEncrypter |
+| email | text | Yes | null | Encrypted via VaultEncrypter |
+| password | text | No | | Encrypted via VaultEncrypter |
+| totp_secret | text | Yes | null | Encrypted via VaultEncrypter |
+| notes | text | Yes | null | Encrypted via VaultEncrypter |
+| recovery_codes | text | Yes | null | Encrypted via VaultEncrypter |
+| needs_password_change | tinyint(1) | No | 0 | Set to 1 when a departing staff member accessed the credential |
+| created_by | bigint unsigned | No | | FK → users.id |
+| updated_by | bigint unsigned | Yes | null | FK → users.id |
+| created_at | timestamp | Yes | null | |
+| updated_at | timestamp | Yes | null | |
+
+**Migration:** `database/migrations/2026_04_12_000001_create_credentials_table.php`
+
+---
+
+### `credential_staff_position` table (pivot)
+
+| Column | Type | Nullable | Default | Notes |
+|--------|------|----------|---------|-------|
+| credential_id | bigint unsigned | No | | FK → credentials.id (cascade delete) |
+| staff_position_id | bigint unsigned | No | | FK → staff_positions.id (cascade delete) |
+| created_at | timestamp | Yes | null | |
+| updated_at | timestamp | Yes | null | |
+
+**Primary key:** Composite `(credential_id, staff_position_id)`
+
+**Migration:** `database/migrations/2026_04_12_000002_create_credential_staff_position_table.php`
+
+---
+
+### `credential_access_logs` table
+
+| Column | Type | Nullable | Default | Notes |
+|--------|------|----------|---------|-------|
+| id | bigint unsigned | No | auto | Primary key |
+| credential_id | bigint unsigned | No | | FK → credentials.id (cascade delete) |
+| user_id | bigint unsigned | No | | FK → users.id |
+| action | varchar(255) | No | | Action string (see below) |
+| created_at | timestamp | No | CURRENT_TIMESTAMP | No `updated_at` column |
+
+**Note:** This table has no `updated_at` column. The model sets `$timestamps = false` and manually fills `created_at`.
+
+**Known action values:**
+
+| Action | Triggered by |
+|--------|-------------|
+| `created` | `CreateCredential` |
+| `updated` | `UpdateCredential` |
+| `deleted` | `DeleteCredential` (recorded before logs are cleared) |
+| `viewed_password` | Vault detail component on password reveal |
+| `viewed_totp` | Vault detail component on TOTP reveal |
+| `positions_assigned` | `AssignCredentialPositions` |
+
+**Migration:** `database/migrations/2026_04_12_000003_create_credential_access_logs_table.php`
+
+---
+
+### `roles` table — seeded entry
+
+The migration `database/migrations/2026_04_12_000004_seed_vault_manager_role.php` inserts a `Vault Manager` role (color: `violet`, icon: `key`) if it does not already exist. The `down()` method deletes this role.
+
+---
+
+## 3. Models & Relationships
+
+### `App\Models\Credential`
+
+All six sensitive fields (`username`, `email`, `password`, `totp_secret`, `notes`, `recovery_codes`) are encrypted on write and decrypted on read via custom Eloquent accessors and mutators that call `VaultEncrypter`. The plaintext value is **never** stored in the database.
+
+The `needs_password_change` field is cast to `boolean`.
+
+**Important UI note:** The index and detail Blade views use `$credential->getRawOriginal('totp_secret')` to check whether a TOTP secret exists without decrypting the value. This avoids an unnecessary decrypt operation just to determine presence.
+
+| Relationship | Type | Description |
+|---|---|---|
+| `createdBy()` | BelongsTo User | Staff member who created the credential |
+| `updatedBy()` | BelongsTo User | Staff member who last updated the credential |
+| `staffPositions()` | BelongsToMany StaffPosition | Positions that can view this credential (via `credential_staff_position`) |
+| `accessLogs()` | HasMany CredentialAccessLog | All access log entries for this credential |
+| `latestAccessLog()` | HasOne CredentialAccessLog | Most recent `viewed_password` or `viewed_totp` entry, used for the "Last Accessed" column on the index |
+
+---
+
+### `App\Models\CredentialAccessLog`
+
+Append-only log record. `$timestamps = false`; only `created_at` is stored.
+
+| Relationship | Type | Description |
+|---|---|---|
+| `credential()` | BelongsTo Credential | |
+| `user()` | BelongsTo User | |
+
+---
+
+### `App\Models\StaffPosition` (updated)
+
+A `credentials()` BelongsToMany relationship was added to `StaffPosition` pointing to the `credential_staff_position` pivot table. This is used by `FlagCredentialsAfterPositionRemoval` to query credentials scoped to a given position.
+
+---
+
+## 4. Enums Reference
+
+No feature-specific enums. The `StaffRank` enum (pre-existing) is used by the `view-vault` gate (`isAtLeastRank(StaffRank::JrCrew)`).
+
+---
+
+## 5. Authorization & Permissions
+
+### Gates (in `AuthServiceProvider`)
+
+| Gate | Logic | Used by |
+|---|---|---|
+| `view-vault` | User is at least `StaffRank::JrCrew` | Vault route middleware; index component `mount()` |
+| `manage-vault` | User has `Vault Manager` role | Index `openCreate()`/`create()`; detail `openManagePositions()`, `addPosition()`, `removePosition()` |
+| `view-credential-access-log` | Shared `$canViewLogs` closure (requires `Logs - Viewer` role) | ACP credential access log tab |
+
+### `CredentialPolicy`
+
+| Method | Who can? |
+|---|---|
+| `before()` | Admins bypass all checks (returns `true`) |
+| `viewAny()` | Vault Manager OR at least JrCrew rank |
+| `view()` | Vault Manager, OR current user's `staffPosition` is in `credential->staffPositions` |
+| `update()` | Same as `view()` — position holders can update credentials they can see |
+| `delete()` | Vault Manager only |
+| `managePositions()` | Vault Manager only |
+
+**Position-holder edit restriction:** The `vault.detail` component further restricts what non-Vault-Manager editors can change. Position holders cannot edit `name` or `website_url`; only Vault Managers see those fields in the edit modal.
+
+---
+
+## 6. Routes
+
+All vault routes are grouped under the `vault.` name prefix, `/vault` URL prefix, and the `['auth', 'can:view-vault']` middleware stack.
+
+```
+GET  /vault            vault.index    resources/views/livewire/vault/index.blade.php
+GET  /vault/{credential}  vault.detail   resources/views/livewire/vault/detail.blade.php
+```
+
+The `{credential}` segment uses implicit route–model binding on the `Credential` model.
+
+**ACP route:** The credential access log page is embedded inside the ACP via the `admin-control-panel-tabs` component. It does not have its own route; access is gated by `view-credential-access-log` within the ACP.
+
+---
+
+## 7. User Interface Components
+
+### `resources/views/livewire/vault/index.blade.php`
+
+**Volt component.** Mounts with `authorize('view-vault')`.
+
+**Properties:** `name`, `website_url`, `username`, `email`, `password`, `totp_secret`, `notes`, `recovery_codes` (all strings, used for the create modal form).
+
+**Computed property `credentials()`:** Returns the list of credentials visible to the current user.
+- Vault Manager / Admin: all credentials, ordered by name, with `latestAccessLog.user` eager-loaded.
+- Position holder: only credentials where `staffPositions` contains the user's current position.
+- No position: returns an empty collection.
+
+**Methods:**
+
+| Method | Gate/Policy | Description |
+|---|---|---|
+| `openCreate()` | `manage-vault` | Resets form fields and shows `create-credential-modal` |
+| `create()` | `manage-vault` | Validates input, calls `CreateCredential::run()`, shows toast, resets form |
+
+**Table columns:** Name (with "Needs Rotation" badge), Website, Password (always masked), TOTP (badge or dash), Last Accessed (user + diffForHumans).
+
+**Create modal:** Available only to users who pass `@can('manage-vault')`. Fields: Name*, Website URL, Username*, Email, Password*, TOTP Secret, Notes, Recovery Codes.
+
+---
+
+### `resources/views/livewire/vault/detail.blade.php`
+
+**Volt component.** Mounts with `authorize('view', $credential)`.
+
+**Properties:**
+
+| Property | Type | Description |
+|---|---|---|
+| `credential` | Credential | The bound model |
+| `editName`, `editWebsiteUrl`, `editUsername`, `editEmail`, `editPassword`, `editTotpSecret`, `editNotes`, `editRecoveryCodes` | string | Edit form fields |
+| `addPositionId` | ?int | Selected position ID in the manage-positions modal |
+| `revealedPassword` | ?string | Plaintext password once revealed; null while hidden |
+| `totpCode` | ?string | Current TOTP code once revealed |
+| `totpSecondsRemaining` | int | Seconds until the current TOTP window expires |
+| `reauthPassword` | string | Password input in the re-auth modal |
+| `reauthError` | string | Error message shown in the re-auth modal |
+| `reauthPurpose` | string | `'password'` or `'totp'` — action to take after successful re-auth |
+
+**Computed properties:**
+
+| Computed | Description |
+|---|---|
+| `isSessionUnlocked` | Delegates to `VaultSession::isUnlocked()` |
+| `isVaultManager` | True if user has `Vault Manager` role or is admin |
+| `assignedPositions` | StaffPositions currently assigned to this credential (with user eager-loaded) |
+| `availablePositions` | All StaffPositions not yet assigned to this credential |
+
+**Methods:**
+
+| Method | Gate/Policy | Description |
+|---|---|---|
+| `revealPassword()` | `view` | Reveals password if session unlocked; otherwise opens re-auth modal with `reauthPurpose = 'password'` |
+| `showTotp()` | `view` | Always opens re-auth modal with `reauthPurpose = 'totp'` (TOTP reveal never skips re-auth) |
+| `refreshTotp()` | `view` | Refreshes `totpCode` and `totpSecondsRemaining` without re-auth; no-op if `totpCode` is null. Called by `wire:poll.1000ms` in the TOTP modal |
+| `reauth()` | `view` | Calls `ReauthenticateVaultSession::run()`; on success unlocks vault, then either reveals password or reveals TOTP and opens the TOTP modal |
+| `openEdit()` | `update` | Loads current values into edit fields; Vault Managers see name/website fields, position holders do not |
+| `saveEdit()` | `update` | Validates and calls `UpdateCredential::run()`; blank password is ignored |
+| `confirmDelete()` | `delete` | Shows delete confirmation modal |
+| `delete()` | `delete` | Calls `DeleteCredential::run()`, redirects to vault index |
+| `openManagePositions()` | `managePositions` | Opens the position management modal |
+| `addPosition()` | `managePositions` | Appends a position to the current list and calls `AssignCredentialPositions::run()` |
+| `removePosition(int $positionId)` | `managePositions` | Removes a position from the current list and calls `AssignCredentialPositions::run()` |
+
+**Modals rendered in this component:**
+
+| Modal name | Who sees it | Description |
+|---|---|---|
+| `edit-credential-modal` | `can('update', $credential)` | Edit form (fields vary by role) |
+| `delete-confirm-modal` | `can('delete', $credential)` | Deletion confirmation |
+| `reauth-modal` | All (rendered unconditionally) | Password entry for session unlock |
+| `totp-modal` | All (rendered only when `$totpCode !== null`) | Displays live TOTP code with countdown |
+| `manage-positions-modal` | `can('managePositions', $credential)` | Add/remove position access |
+
+---
+
+### `resources/views/livewire/admin-manage-credential-access-log-page.blade.php`
+
+**Volt component.** Mounts with `authorize('view-credential-access-log')`.
+
+Displays a paginated (25 per page) table of all `credential_access_logs` records, ordered newest-first. An action filter dropdown (populated from distinct values in the table) can be used to narrow the view.
+
+Columns: Date/Time, User, Credential, Action (human-readable badge).
+
+Handles deleted users (`(deleted user)`) and deleted credentials (`(deleted credential)`) gracefully via nullable relationship checks.
+
+---
+
+### `resources/views/livewire/admin-control-panel-tabs.blade.php` (integration)
+
+The ACP tabs component includes a "Credential Access Log" tab under the Logs tab group, guarded by `@can('view-credential-access-log')`. The tab renders `<livewire:admin-manage-credential-access-log-page />` inside the tab panel. The `hasLogTabs()` and default tab resolution logic were updated to include this gate.
+
+---
+
+## 8. Actions (Business Logic)
+
+All actions use `AsAction` and are invoked via `ClassName::run(...)`.
+
+---
+
+### `App\Actions\CreateCredential`
+
+**Signature:** `handle(User $creator, array $data): Credential`
+
+**Required `$data` keys:** `name`, `username`, `password`
+
+**Optional `$data` keys:** `website_url`, `email`, `totp_secret`, `notes`, `recovery_codes`
+
+Creates the credential with `needs_password_change = false` and `created_by = $creator->id`. Encrypted fields are stored encrypted automatically by model mutators. Records `credential_created` activity and a `created` access log entry.
+
+---
+
+### `App\Actions\UpdateCredential`
+
+**Signature:** `handle(Credential $credential, User $updater, array $data): Credential`
+
+Accepts a partial `$data` array — only keys present in `$data` are updated. Password update only occurs when `$data['password']` is present and non-empty; when a password is changed, `needs_password_change` is reset to `false`. Records `credential_updated` activity and an `updated` access log entry. Returns `$credential->fresh()`.
+
+---
+
+### `App\Actions\DeleteCredential`
+
+**Signature:** `handle(Credential $credential, User $deletedBy): void`
+
+Records a `deleted` access log entry **before** clearing data. Then detaches all `staffPositions()` pivot rows, deletes all `accessLogs()` entries, and hard-deletes the credential. Records `credential_deleted` activity on the **user** model (not the credential, since it no longer exists).
+
+---
+
+### `App\Actions\AssignCredentialPositions`
+
+**Signature:** `handle(Credential $credential, User $assignedBy, array $positionIds): void`
+
+Uses `sync()` to replace the full set of assigned positions with `$positionIds`. Passing an empty array removes all positions. Records `credential_positions_assigned` activity and a `positions_assigned` access log entry.
+
+---
+
+### `App\Actions\FlagCredentialsAfterPositionRemoval`
+
+**Signature:** `handle(User $user, StaffPosition $position): void`
+
+Called from `UnassignStaffPosition` within a database transaction. Queries credentials assigned to `$position` that have at least one access log entry from `$user`, then sets `needs_password_change = true` on each. Credentials the departing user never accessed are not flagged.
+
+**Wired into:** `App\Actions\UnassignStaffPosition` — called at the start of the transaction, before the position's `user_id` is cleared.
+
+---
+
+### `App\Actions\GenerateTotpCode`
+
+**Signature:** `handle(Credential $credential): array{code: string, seconds_remaining: int}`
+
+Uses the `spomky-labs/otphp` library (`OTPHP\TOTP::createFromSecret()`) with an internal clock. Reads the decrypted `totp_secret` from the credential and returns the current 6-digit code and seconds until the window expires. The raw secret is never included in the return value.
+
+---
+
+### `App\Actions\ReauthenticateVaultSession`
+
+**Signature:** `handle(User $user, string $password): bool`
+
+Verifies `$password` against the user's Lighthouse account password using `Hash::check()`. On success, calls `VaultSession::unlock()` and returns `true`. On failure, returns `false` without touching the session.
+
+---
+
+### `App\Actions\RecordCredentialAccess`
+
+**Signature:** `handle(Credential $credential, User $user, string $action): void`
+
+Creates a `CredentialAccessLog` record directly. This is a thin wrapper to ensure consistent logging. Not intended to be called from outside the vault action layer.
+
+---
+
+## 9. Notifications
+
+No notifications are sent by the vault feature.
+
+---
+
+## 10. Background Jobs
+
+No queued jobs are used by the vault feature. TOTP code generation happens synchronously in the request cycle via `wire:poll`.
+
+---
+
+## 11. Console Commands & Scheduled Tasks
+
+No console commands or scheduled tasks are introduced by this feature.
+
+---
+
+## 12. Services
+
+### `App\Services\VaultEncrypter`
+
+A thin wrapper around Laravel's `Illuminate\Encryption\Encrypter` using a **separate key** from `APP_KEY`.
+
+**Constructor:** Reads `config('vault.key')` (base64-encoded 32-byte key). Throws `RuntimeException` if the key is not set, with a message instructing how to generate one.
+
+**Methods:**
+
+| Method | Description |
+|---|---|
+| `encrypt(string $value): string` | Encrypts a string using AES-256-CBC. Produces a different ciphertext for the same plaintext on each call (IV randomization). |
+| `decrypt(string $payload): string` | Decrypts a previously encrypted payload. |
+
+**Binding:** Resolved via `app(VaultEncrypter::class)` from the service container (singleton by default). Called directly from Eloquent model accessors/mutators in `Credential`.
+
+**Key generation command (reference):**
+```
+php -r "echo base64_encode(random_bytes(32)).PHP_EOL;"
+```
+
+---
+
+### `App\Services\VaultSession`
+
+Manages the re-authentication session window.
+
+**Session key:** `vault_unlocked_at` (stores a Unix timestamp integer).
+
+**Methods:**
+
+| Method | Description |
+|---|---|
+| `unlock(): void` | Writes `now()->timestamp` to the session under `vault_unlocked_at` |
+| `isUnlocked(): bool` | Returns true if `vault_unlocked_at` exists in the session and is within the configured TTL |
+| `lock(): void` | Removes `vault_unlocked_at` from the session |
+
+**TTL check:** `now()->timestamp - $unlockedAt < $ttl * 60`, where `$ttl = config('vault.session_ttl_minutes', 30)`.
+
+---
+
+## 13. Activity Log Entries
+
+Activity is recorded via `RecordActivity::run($subject, $action, $description)`.
+
+| Action key | Subject model | Description format |
+|---|---|---|
+| `credential_created` | `Credential` | `"Credential \"{name}\" created by {user->name}."` |
+| `credential_updated` | `Credential` | `"Credential \"{name}\" updated by {user->name}."` |
+| `credential_deleted` | `User` (deleter) | `"Credential \"{name}\" deleted by {user->name}."` |
+| `credential_positions_assigned` | `Credential` | `"Credential \"{name}\" position access updated by {user->name}."` |
+
+Access log events (`created`, `updated`, `deleted`, `viewed_password`, `viewed_totp`, `positions_assigned`) go to `credential_access_logs`, not the general `activity_logs` table.
+
+---
+
+## 14. Data Flow Diagrams
+
+### Password Reveal Flow
+
+```
+User clicks "Reveal" on vault.detail
+    │
+    ▼
+revealPassword() → authorize('view', credential)
+    │
+    ├── VaultSession::isUnlocked() == true
+    │       │
+    │       └── Set $revealedPassword = credential->password (decrypted via mutator)
+    │           RecordCredentialAccess: 'viewed_password'
+    │
+    └── VaultSession::isUnlocked() == false
+            │
+            └── Set reauthPurpose = 'password'
+                Open reauth-modal
+                    │
+                User enters password → reauth()
+                    │
+                    ├── ReauthenticateVaultSession::run() == false
+                    │       └── Set reauthError, stay in modal
+                    │
+                    └── ReauthenticateVaultSession::run() == true
+                            │
+                            └── VaultSession::unlock()
+                                Set $revealedPassword = credential->password
+                                RecordCredentialAccess: 'viewed_password'
+                                Close reauth-modal, show toast
+```
+
+### TOTP Reveal Flow
+
+```
+User clicks "Show Code" on vault.detail
+    │
+    ▼
+showTotp() → authorize('view', credential)
+    │
+    └── Always: Set reauthPurpose = 'totp', open reauth-modal
+        (vault session state is irrelevant for TOTP)
+            │
+        User enters password → reauth()
+            │
+            └── ReauthenticateVaultSession::run() == true
+                    │
+                    └── VaultSession::unlock()
+                        GenerateTotpCode::run() → {code, seconds_remaining}
+                        RecordCredentialAccess: 'viewed_totp'
+                        Open totp-modal
+                        wire:poll.1000ms calls refreshTotp() to update countdown
+```
+
+### Staff Departure / Credential Rotation Flow
+
+```
+Admin removes a user from a staff position
+    │
+    ▼
+UnassignStaffPosition::run($position, $actingUser)
+    │
+    ├── FlagCredentialsAfterPositionRemoval::run($user, $position)
+    │       │
+    │       └── Query: credentials assigned to $position
+    │               WHERE EXISTS (access log from $user)
+    │               → credential->update(['needs_password_change' => true])
+    │
+    └── position->update(['user_id' => null])
+        (rest of unassign logic)
+
+Vault Manager visits vault.index / vault.detail
+    └── "Needs Rotation" badge shown on flagged credentials
+```
+
+### Credential Creation Flow
+
+```
+Vault Manager clicks "Add Credential" on vault.index
+    │
+    ▼
+openCreate() → authorize('manage-vault')
+    │
+    └── Open create-credential-modal
+            │
+        User fills form → create()
+            │
+            ├── authorize('manage-vault')
+            ├── validate()
+            ├── CreateCredential::run(user, data)
+            │       ├── Credential::create() — mutators encrypt sensitive fields
+            │       ├── RecordActivity: 'credential_created'
+            │       └── RecordCredentialAccess: 'created'
+            ├── Close modal, show toast
+            └── Unset $credentials computed property to force refresh
+```
+
+---
+
+## 15. Configuration
+
+### `config/vault.php`
+
+| Key | Env var | Default | Description |
+|---|---|---|---|
+| `vault.key` | `VAULT_KEY` | `null` | Base64-encoded 32-byte AES-256-CBC encryption key. **Required.** App will throw `RuntimeException` on any vault operation if unset. |
+| `vault.session_ttl_minutes` | `VAULT_SESSION_TTL_MINUTES` | `30` | How many minutes a vault session remains unlocked after re-authentication. |
+
+**Generating a vault key:**
+```bash
+php -r "echo base64_encode(random_bytes(32)).PHP_EOL;"
+```
+Add the output to `.env` as `VAULT_KEY=<value>`.
+
+**Important:** `VAULT_KEY` must be stored separately from `APP_KEY` and never committed to version control. A database dump + `APP_KEY` alone cannot decrypt vault data; `VAULT_KEY` is also required.
+
+---
+
+## 16. Test Coverage
+
+All vault tests are in the `vault` Pest group. Run with:
+```
+./vendor/bin/pest --group=vault
+```
+
+### Action Tests (`tests/Feature/Actions/Vault/`)
+
+| File | Cases covered |
+|---|---|
+| `CreateCredentialTest.php` | Creates record, encrypts sensitive fields, decrypts via model, sets `created_by`, defaults `needs_password_change` to false, records activity, handles nullable optional fields |
+| `UpdateCredentialTest.php` | Updates plain fields, updates encrypted fields, clears `needs_password_change` on password change, does not clear flag when other fields update, does not update password on empty string, sets `updated_by`, records activity |
+| `DeleteCredentialTest.php` | Deletes record, removes pivot rows, removes access logs, records activity on deleter's user model |
+| `AssignCredentialPositionsTest.php` | Assigns multiple positions, removes positions via sync, clears all positions on empty array, records activity |
+| `FlagCredentialsAfterPositionRemovalTest.php` | Flags credentials the departing user accessed, does not flag unaccessed credentials, does not flag credentials accessed only by others, does not flag credentials on a different position |
+| `GenerateTotpCodeTest.php` | Returns a 6-digit code, returns `seconds_remaining` in 1–30 range, does not include raw secret in return value |
+| `ReauthenticateVaultSessionTest.php` | Returns true and unlocks on correct password, returns false on wrong password, does not modify session on wrong password |
+| `RecordCredentialAccessTest.php` | Creates a log entry, CreateCredential logs `created`, UpdateCredential logs `updated`, DeleteCredential logs `deleted` (records before clearing), AssignCredentialPositions logs `positions_assigned` |
+
+### Policy Tests (`tests/Feature/Policies/CredentialPolicyTest.php`)
+
+Covers: Vault Manager can view/update/delete/managePositions; position holder can view/update but not delete/managePositions; staff with no position cannot view; staff whose position is not assigned cannot view.
+
+### Gate Tests (`tests/Feature/Gates/VaultGatesTest.php`)
+
+Covers: `manage-vault` granted to Vault Manager, denied to JrCrew without role, denied to regular member; `view-vault` granted to JrCrew/CrewMember/Officer, denied to `StaffRank::None`.
+
+### Service Tests
+
+| File | Cases covered |
+|---|---|
+| `tests/Feature/Services/VaultEncrypterTest.php` | Round-trip encrypt/decrypt, different ciphertext per call (IV randomization), throws `RuntimeException` when `VAULT_KEY` is null |
+| `tests/Feature/Services/VaultSessionTest.php` | Locked by default, unlocked after `unlock()`, locked after `lock()`, locked when timestamp is older than TTL, unlocked when timestamp is within TTL |
+
+### Livewire Tests
+
+| File | Cases covered |
+|---|---|
+| `tests/Feature/Livewire/VaultTest.php` | Vault Manager can create via index, non-Vault-Manager JrCrew cannot create; Vault Manager can delete/update credential; password reveals after successful re-auth; rejects on wrong password; reveals immediately when session already unlocked; position holder can reveal their credential's password; TOTP code shown after re-auth; TOTP always requires re-auth even with session unlocked; TOTP refresh works without re-auth |
+| `tests/Feature/Livewire/CredentialAccessLogPageTest.php` | Renders for `Logs - Viewer` role, forbidden to other users, displays log entries with human-readable action text |
+
+---
+
+## 17. File Map
+
+```
+app/
+  Actions/
+    CreateCredential.php
+    UpdateCredential.php
+    DeleteCredential.php
+    AssignCredentialPositions.php
+    FlagCredentialsAfterPositionRemoval.php
+    GenerateTotpCode.php
+    ReauthenticateVaultSession.php
+    RecordCredentialAccess.php
+    UnassignStaffPosition.php          ← integrates FlagCredentialsAfterPositionRemoval
+  Models/
+    Credential.php
+    CredentialAccessLog.php
+    StaffPosition.php                  ← credentials() relationship added
+  Policies/
+    CredentialPolicy.php
+  Providers/
+    AuthServiceProvider.php            ← view-vault, manage-vault, view-credential-access-log gates
+  Services/
+    VaultEncrypter.php
+    VaultSession.php
+
+config/
+  vault.php
+
+database/migrations/
+  2026_04_12_000001_create_credentials_table.php
+  2026_04_12_000002_create_credential_staff_position_table.php
+  2026_04_12_000003_create_credential_access_logs_table.php
+  2026_04_12_000004_seed_vault_manager_role.php
+
+resources/views/livewire/
+  vault/
+    index.blade.php
+    detail.blade.php
+  admin-manage-credential-access-log-page.blade.php
+  admin-control-panel-tabs.blade.php  ← credential-access-log tab added
+
+routes/
+  web.php                              ← vault.index, vault.detail routes
+
+tests/Feature/
+  Actions/Vault/
+    AssignCredentialPositionsTest.php
+    CreateCredentialTest.php
+    DeleteCredentialTest.php
+    FlagCredentialsAfterPositionRemovalTest.php
+    GenerateTotpCodeTest.php
+    ReauthenticateVaultSessionTest.php
+    RecordCredentialAccessTest.php
+    UpdateCredentialTest.php
+  Gates/
+    VaultGatesTest.php
+  Livewire/
+    CredentialAccessLogPageTest.php
+    VaultTest.php
+  Policies/
+    CredentialPolicyTest.php
+  Services/
+    VaultEncrypterTest.php
+    VaultSessionTest.php
+```
+
+---
+
+## 18. Known Issues & Improvement Opportunities
+
+- **Session TTL is per-browser-session, not per-tab.** If the same user has the vault open in two tabs, unlocking in one tab unlocks both. This is inherent to session-based TTL design.
+- **TOTP refresh via `wire:poll.1000ms`** polls every second for the full duration a TOTP modal is open. This is a minor performance concern but unlikely to matter in practice given typical vault usage patterns.
+- **Access log cascade delete.** When a credential is deleted, all of its access logs are also deleted by `DeleteCredential` (and the `cascade` foreign key). This means post-deletion audit history for that credential is not preserved. Admins who need to audit deletions should rely on the `activity_logs` table (`credential_deleted` action on the deleter's user record) rather than `credential_access_logs`.
+- **No credential factory `withTotp()` documented here.** Tests reference `Credential::factory()->withTotp()` and `Credential::factory()->needsPasswordChange()` factory states, which are expected to exist in `database/factories/CredentialFactory.php`.
+- **`view-vault` gate vs `CredentialPolicy::viewAny()`** express the same JrCrew rank requirement in two places. They are consistent, but a future refactor could unify them.
+- **Position holders can update but not create or delete.** There is no UI flow for a position holder to add a new credential — they can only view and update existing ones assigned to their position. This is by design but worth surfacing in user documentation.
+- **No expiry / rotation reminders.** The `needs_password_change` flag requires a Vault Manager to notice the badge and manually change the password. There is no automated notification or scheduled reminder when a flag is set.

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -29,6 +29,7 @@
         <env name="QUEUE_CONNECTION" value="sync"/>
         <env name="SESSION_DRIVER" value="array"/>
         <env name="TELESCOPE_ENABLED" value="false"/>
+        <env name="VAULT_KEY" value="97geDlwyB0M6t41Lv6R9z9kOmqg02Z/rvCk5m/8Q0GU="/>
         <ini name="memory_limit" value="2G"/>
     </php>
 </phpunit>

--- a/resources/library/books/staff-handbook/07-administration/06-credential-vault/01-vault-overview.md
+++ b/resources/library/books/staff-handbook/07-administration/06-credential-vault/01-vault-overview.md
@@ -1,0 +1,43 @@
+---
+title: 'Vault Overview'
+visibility: staff
+order: 1
+summary: 'Learn what the Credential Vault is and who can access what.'
+---
+
+## What Is the Credential Vault?
+
+The **Staff Credential Vault** is a secure, centralized place to store the usernames, passwords, and two-factor authentication codes for services that multiple staff members need to access -- things like hosting control panels, social media accounts, or community tools. Instead of sharing passwords in Discord or email, everything lives in one place with proper access controls.
+
+You can reach the vault by clicking **Vault** in the Ready Room navigation.
+
+## Who Can See What
+
+Access to the vault depends on your staff role. There are two levels:
+
+- **Vault Managers** -- can see every credential in the vault, create new ones, edit or delete them, and control which staff positions have access. Vault Managers are typically senior staff or admins.
+- **Position holders** -- if your staff position has been granted access to a specific credential, you can view and edit that credential. You'll only see credentials that are assigned to your position.
+
+If you're staff but don't hold a position assigned to any credential, you'll see the vault page but it'll be empty. That's expected -- it means you don't need any shared credentials for your current role.
+
+## What Gets Stored
+
+Each credential entry can hold:
+
+- **Name** -- a clear label like "Apex Hosting Admin" or "Community Twitter"
+- **Website URL** -- the login page (optional but helpful)
+- **Username** and **Email** -- the account login details
+- **Password** -- stored encrypted, requires re-authentication to reveal
+- **TOTP** -- a two-factor authentication secret, if the account uses TOTP codes
+- **Notes** -- anything useful to know about the account
+- **Recovery Codes** -- backup codes in case 2FA is unavailable
+
+## Security and Re-Authentication
+
+Passwords and TOTP codes are treated with extra care. The vault uses a **vault session** system to protect sensitive data:
+
+- When you first try to reveal a password or view a TOTP code, you'll be asked to confirm your identity by entering your **Lighthouse website password** (not your Minecraft password).
+- After re-authenticating, your vault session stays unlocked for **30 minutes**. During that window, you can reveal passwords without re-entering your password each time.
+- **TOTP codes always require re-authentication**, even if your session is already unlocked. This extra step keeps two-factor codes protected.
+
+If your session times out or you haven't authenticated yet, the vault will prompt you to re-authenticate before showing sensitive data.

--- a/resources/library/books/staff-handbook/07-administration/06-credential-vault/02-viewing-credentials.md
+++ b/resources/library/books/staff-handbook/07-administration/06-credential-vault/02-viewing-credentials.md
@@ -1,0 +1,50 @@
+---
+title: 'Viewing Credentials'
+visibility: staff
+order: 2
+summary: 'How to find, open, and read credentials -- including revealing passwords and TOTP codes.'
+---
+
+## Opening the Vault
+
+Navigate to the vault by clicking **Vault** in the Ready Room. You'll see a table listing every credential your position has access to. Each row shows the credential name, the website it's for, and when it was last accessed (and by whom).
+
+If a credential shows an orange **Needs Rotation** badge, the password should be updated -- see [[books/staff-handbook/administration/credential-vault/03-editing-credentials|Editing Credentials]] for how to do that.
+
+## Viewing a Credential
+
+Click any credential's name to open its detail page. The detail page shows:
+
+- **Username** and **Email** for the account
+- **Password** -- hidden by default (shown as dots)
+- **TOTP** badge and a **Show Code** button (if the account uses two-factor authentication)
+- **Notes** and **Recovery Codes** (if recorded)
+
+At the top, you'll also see when the credential was added and when it was last updated.
+
+## Revealing a Password
+
+Passwords aren't shown in plaintext until you confirm your identity. Here's how it works:
+
+1. Click **Reveal** next to the password field.
+2. If your vault session is already unlocked, the password appears immediately.
+3. If your session has expired or this is your first reveal today, a **Confirm Your Identity** modal will appear. Enter your **Lighthouse website password** and click **Unlock & Reveal**.
+4. The password is shown in plaintext on the detail page.
+
+Your vault session stays unlocked for 30 minutes after you re-authenticate. Within that window, clicking **Reveal** on any credential will show the password right away -- no need to re-enter your password each time.
+
+## Viewing a TOTP Code
+
+**TOTP** (Time-based One-Time Password) codes are used for two-factor authentication. They're short numeric codes that change every 30 seconds. If a credential has a TOTP secret configured, you'll see a **Show Code** button on the detail page.
+
+1. Click **Show Code** next to the TOTP badge.
+2. A **Confirm Your Identity** modal will appear -- TOTP always requires re-authentication, even if your vault session is unlocked.
+3. Enter your **Lighthouse website password** and click **Unlock & Reveal**.
+4. A popup shows the current six-digit code with a countdown timer.
+5. The code auto-refreshes so it's always current. Close the popup when you're done.
+
+## The "Needs Rotation" Flag
+
+If a credential shows a **Needs Rotation** badge in orange, it means a staff member who previously accessed this credential has since left the position they used it from. The password may have been exposed and should be changed.
+
+If you see this badge and have edit access, update the password as soon as possible. If you're not a Vault Manager, flag it to someone who is.

--- a/resources/library/books/staff-handbook/07-administration/06-credential-vault/03-editing-credentials.md
+++ b/resources/library/books/staff-handbook/07-administration/06-credential-vault/03-editing-credentials.md
@@ -1,0 +1,45 @@
+---
+title: 'Editing Credentials'
+visibility: staff
+order: 3
+summary: 'How to update usernames, passwords, TOTP secrets, notes, and recovery codes.'
+---
+
+## Who Can Edit
+
+Any staff member whose position has access to a credential can edit it. This lets you keep the information current -- for example, updating the password after a rotation or adding notes for the next person who logs in.
+
+**Vault Managers** can also edit the credential's name and website URL, which position holders cannot change.
+
+## How to Edit a Credential
+
+1. Open the credential from the [[books/staff-handbook/administration/credential-vault/02-viewing-credentials|vault index]] or navigate directly to its detail page.
+2. Click **Edit** in the top-right corner of the page.
+3. A panel opens with the fields you can update.
+4. Make your changes and click **Save Changes**.
+
+## What You Can Edit
+
+For position holders (staff with assigned access):
+
+- **Username** -- the login name for the account
+- **Email** -- the email address for the account
+- **New Password** -- leave this blank if you don't want to change the password
+- **TOTP Secret** -- the raw TOTP secret key (not a code -- this is the secret used to generate codes)
+- **Notes** -- free-form notes about the account
+- **Recovery Codes** -- backup codes for account recovery
+
+Vault Managers can also edit:
+
+- **Name** -- the display name for this credential
+- **Website URL** -- the URL of the login page
+
+## Updating a Password
+
+When you open the edit panel, the **New Password** field is blank on purpose. If you leave it blank and save, the existing password is kept as-is. Only fill in the **New Password** field if you're actually changing the password.
+
+After rotating a password on the external service, update it here right away so the credential stays accurate for everyone who needs it.
+
+## Clearing the "Needs Rotation" Flag
+
+The **Needs Rotation** flag is automatically cleared when you update the password. If you see a credential flagged for rotation, update the password on the external service first, then save the new password in the vault. The badge will disappear once the credential is saved.

--- a/resources/library/books/staff-handbook/07-administration/06-credential-vault/04-managing-the-vault.md
+++ b/resources/library/books/staff-handbook/07-administration/06-credential-vault/04-managing-the-vault.md
@@ -1,0 +1,61 @@
+---
+title: 'Managing the Vault'
+visibility: officer
+order: 4
+summary: 'Vault Manager guide: adding credentials, controlling position access, and deletions.'
+---
+
+## Who This Page Is For
+
+This page is for **Vault Managers** -- the staff members responsible for keeping the vault organized and ensuring credentials are properly secured. Vault Managers can see all credentials, create and delete entries, and control which positions have access to each one.
+
+## Adding a New Credential
+
+1. Go to the [vault index]({{url:/vault}}).
+2. Click **Add Credential** in the top-right corner.
+3. Fill in the credential details:
+   - **Name** (required) -- use something descriptive, like "Apex Hosting Admin" or "Community YouTube"
+   - **Website URL** (optional) -- the login page, so staff can navigate there easily
+   - **Username** (required)
+   - **Email** (optional)
+   - **Password** (required)
+   - **TOTP Secret** (optional) -- only needed if the account uses TOTP two-factor authentication
+   - **Notes** (optional) -- useful context about the account
+   - **Recovery Codes** (optional) -- paste backup codes here
+4. Click **Add Credential** to save.
+
+After creating the credential, it appears in the vault but no positions have access yet. Staff won't see it until you assign position access.
+
+## Managing Position Access
+
+Position access controls which staff positions can view and edit a credential. Every staff member currently holding one of those positions will have access.
+
+To manage access:
+
+1. Open the credential's detail page.
+2. Click **Manage Access** at the top of the page.
+3. In the **Manage Position Access** modal, use the dropdown to select a position and click **Add**.
+4. To remove a position's access, click **Remove** next to it in the list.
+
+Keep access limited to positions that genuinely need the credential. It's easier to add access later than to deal with a breach.
+
+## What Happens When a Position Holder Leaves
+
+When a staff member is removed from a position, the system automatically checks if they accessed any credentials through that position. If they did, those credentials are flagged with a **Needs Rotation** badge.
+
+This flag means: "someone who is no longer in this role had access to this password." You should:
+
+1. Log in to the external service and change the password.
+2. Update the credential in the vault with the new password.
+
+The **Needs Rotation** badge clears automatically when the password is updated. Keep an eye on the vault index for any orange badges -- they're a prompt to act.
+
+## Deleting a Credential
+
+Deleting a credential is permanent. All access logs for that credential are also removed.
+
+1. Open the credential's detail page.
+2. Click **Delete** in the top-right corner.
+3. A confirmation modal will ask you to confirm. Click **Delete Permanently** to proceed.
+
+Only delete credentials when an account is being fully decommissioned or the credential is no longer needed by anyone on staff. If the password has just changed, use **Edit** instead.

--- a/resources/library/books/staff-handbook/07-administration/06-credential-vault/_index.md
+++ b/resources/library/books/staff-handbook/07-administration/06-credential-vault/_index.md
@@ -1,0 +1,8 @@
+---
+title: 'Credential Vault'
+visibility: staff
+order: 6
+summary: 'Securely access and manage shared staff credentials for community services.'
+---
+
+The Staff Credential Vault is where shared login credentials for Lighthouse's external services and tools are stored. Access is controlled by role -- you'll only see credentials that are relevant to your staff position.

--- a/resources/views/dashboard/ready-room.blade.php
+++ b/resources/views/dashboard/ready-room.blade.php
@@ -1,7 +1,7 @@
 <x-layouts.app>
-    <div class="mb-6 flex items-center justify-between">
+    <div class="mb-6 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
         <flux:heading size="xl">Staff Ready Room</flux:heading>
-        <div class="flex gap-2">
+        <div class="flex flex-col gap-2 sm:flex-row sm:flex-wrap">
             @can('review-staff-applications')
                 <flux:button href="{{ route('admin.applications.index') }}" wire:navigate icon="document-text">
                     View Applications
@@ -18,6 +18,11 @@
             @can('manage-blog')
                 <flux:button href="{{ route('blog.manage') }}" wire:navigate icon="pencil-square">
                     Blog Management
+                </flux:button>
+            @endcan
+            @can('view-vault')
+                <flux:button href="{{ route('vault.index') }}" wire:navigate icon="key">
+                    Vault
                 </flux:button>
             @endcan
         </div>

--- a/resources/views/livewire/admin-control-panel-tabs.blade.php
+++ b/resources/views/livewire/admin-control-panel-tabs.blade.php
@@ -70,6 +70,7 @@ new class extends Component {
             || $user->can('view-discord-api-log')
             || $user->can('view-activity-log')
             || $user->can('view-discipline-report-log')
+            || $user->can('view-credential-access-log')
         );
     }
 
@@ -114,6 +115,7 @@ new class extends Component {
                 $user?->can('view-discord-api-log') => 'discord-api-log',
                 $user?->can('view-activity-log') => 'activity-log',
                 $user?->can('view-discipline-report-log') => 'discipline-report-log',
+                $user?->can('view-credential-access-log') => 'credential-access-log',
                 default => 'mc-command-log',
             },
             'config' => match (true) {
@@ -259,6 +261,9 @@ new class extends Component {
                 @can('view-discipline-report-log')
                     <flux:tab name="discipline-report-log">Reports Log</flux:tab>
                 @endcan
+                @can('view-credential-access-log')
+                    <flux:tab name="credential-access-log">Credential Access Log</flux:tab>
+                @endcan
             </flux:tabs>
 
             <flux:tab.panel name="mc-command-log">
@@ -279,6 +284,11 @@ new class extends Component {
             <flux:tab.panel name="discipline-report-log">
                 @can('view-discipline-report-log')
                     <livewire:admin-manage-discipline-reports-page />
+                @endcan
+            </flux:tab.panel>
+            <flux:tab.panel name="credential-access-log">
+                @can('view-credential-access-log')
+                    <livewire:admin-manage-credential-access-log-page />
                 @endcan
             </flux:tab.panel>
         </flux:tab.group>

--- a/resources/views/livewire/admin-manage-credential-access-log-page.blade.php
+++ b/resources/views/livewire/admin-manage-credential-access-log-page.blade.php
@@ -1,0 +1,82 @@
+<?php
+
+use App\Models\CredentialAccessLog;
+use Livewire\Volt\Component;
+use Livewire\WithPagination;
+
+new class extends Component
+{
+    use WithPagination;
+
+    public string $filterAction = '';
+
+    public array $distinctActions = [];
+
+    public function mount(): void
+    {
+        $this->authorize('view-credential-access-log');
+
+        $this->distinctActions = CredentialAccessLog::select('action')
+            ->distinct()
+            ->orderBy('action')
+            ->pluck('action')
+            ->toArray();
+    }
+
+    public function updatedFilterAction(): void
+    {
+        $this->resetPage();
+    }
+
+    #[\Livewire\Attributes\Computed]
+    public function logs()
+    {
+        return CredentialAccessLog::query()
+            ->with(['credential', 'user'])
+            ->when($this->filterAction, fn ($q) => $q->where('action', $this->filterAction))
+            ->orderByDesc('created_at')
+            ->paginate(25);
+    }
+}; ?>
+
+<div class="w-full max-w-full space-y-6">
+    <div class="flex items-center gap-4">
+        <flux:heading size="xl">Credential Access Log</flux:heading>
+        <flux:spacer />
+        <flux:select wire:model.live="filterAction" size="sm" class="w-56">
+            <flux:select.option value="">All Actions</flux:select.option>
+            @foreach ($distinctActions as $action)
+                <flux:select.option value="{{ $action }}">{{ Str::of($action)->replace('_', ' ')->title() }}</flux:select.option>
+            @endforeach
+        </flux:select>
+    </div>
+
+    <flux:table :paginate="$this->logs">
+        <flux:table.columns>
+            <flux:table.column>Date / Time</flux:table.column>
+            <flux:table.column>User</flux:table.column>
+            <flux:table.column>Credential</flux:table.column>
+            <flux:table.column>Action</flux:table.column>
+        </flux:table.columns>
+        <flux:table.rows>
+            @foreach ($this->logs as $log)
+                <flux:table.row wire:key="log-{{ $log->id }}">
+                    <flux:table.cell class="text-sm text-zinc-500">
+                        {{ $log->created_at->format('M j, Y g:i A') }}
+                    </flux:table.cell>
+                    <flux:table.cell>
+                        {{ $log->user?->name ?? '(deleted user)' }}
+                    </flux:table.cell>
+                    <flux:table.cell>
+                        {{ $log->credential?->name ?? '(deleted credential)' }}
+                    </flux:table.cell>
+                    <flux:table.cell>
+                        <flux:badge color="zinc" size="sm">
+                            {{ Str::of($log->action)->replace('_', ' ')->title() }}
+                        </flux:badge>
+                    </flux:table.cell>
+                </flux:table.row>
+            @endforeach
+        </flux:table.rows>
+    </flux:table>
+</div>

--- a/resources/views/livewire/vault/detail.blade.php
+++ b/resources/views/livewire/vault/detail.blade.php
@@ -1,0 +1,635 @@
+<?php
+
+use App\Actions\AssignCredentialPositions;
+use App\Actions\DeleteCredential;
+use App\Actions\GenerateTotpCode;
+use App\Actions\ReauthenticateVaultSession;
+use App\Actions\RecordCredentialAccess;
+use App\Actions\UpdateCredential;
+use App\Models\Credential;
+use App\Models\StaffPosition;
+use App\Services\VaultSession;
+use Flux\Flux;
+use Illuminate\Support\Facades\Hash;
+use Livewire\Volt\Component;
+
+new class extends Component
+{
+    public Credential $credential;
+
+    // Edit fields (Vault Manager — all fields)
+    public string $editName = '';
+
+    public string $editWebsiteUrl = '';
+
+    public string $editUsername = '';
+
+    public string $editEmail = '';
+
+    public string $editPassword = '';
+
+    public string $editTotpSecret = '';
+
+    public string $editNotes = '';
+
+    public string $editRecoveryCodes = '';
+
+    // Position assignment
+    public ?int $addPositionId = null;
+
+    // Password reveal
+    public ?string $revealedPassword = null;
+
+    // TOTP display
+    public ?string $totpCode = null;
+
+    public int $totpSecondsRemaining = 0;
+
+    // Re-auth modal
+    public string $reauthPassword = '';
+
+    public string $reauthError = '';
+
+    // 'password' | 'totp' — what to do after successful re-auth
+    public string $reauthPurpose = 'password';
+
+    public function mount(Credential $credential): void
+    {
+        $this->authorize('view', $credential);
+        $this->credential = $credential;
+    }
+
+    #[\Livewire\Attributes\Computed]
+    public function isSessionUnlocked(): bool
+    {
+        return app(VaultSession::class)->isUnlocked();
+    }
+
+    public function revealPassword(): void
+    {
+        $this->authorize('view', $this->credential);
+
+        if (app(VaultSession::class)->isUnlocked()) {
+            $this->revealedPassword = $this->credential->password;
+            RecordCredentialAccess::run($this->credential, auth()->user(), 'viewed_password');
+        } else {
+            $this->reauthPurpose = 'password';
+            $this->reauthPassword = '';
+            $this->reauthError = '';
+            Flux::modal('reauth-modal')->show();
+        }
+    }
+
+    public function showTotp(): void
+    {
+        $this->authorize('view', $this->credential);
+
+        // TOTP always requires re-auth, even if vault session is unlocked
+        $this->reauthPurpose = 'totp';
+        $this->reauthPassword = '';
+        $this->reauthError = '';
+        Flux::modal('reauth-modal')->show();
+    }
+
+    public function refreshTotp(): void
+    {
+        $this->authorize('view', $this->credential);
+
+        // Auto-refresh: does not require re-auth, just fetches next code
+        if ($this->totpCode === null) {
+            return;
+        }
+
+        $result = GenerateTotpCode::run($this->credential);
+        $this->totpCode = $result['code'];
+        $this->totpSecondsRemaining = $result['seconds_remaining'];
+    }
+
+    public function closeTotp(): void
+    {
+        $this->totpCode = null;
+        $this->totpSecondsRemaining = 0;
+        Flux::modal('totp-modal')->close();
+    }
+
+    public function reauth(): void
+    {
+        $this->authorize('view', $this->credential);
+
+        $this->validate(['reauthPassword' => 'required|string']);
+
+        $user = auth()->user();
+
+        if ($this->reauthPurpose === 'totp') {
+            // TOTP re-auth verifies identity only — does not unlock the vault session
+            if (! Hash::check($this->reauthPassword, $user->password)) {
+                $this->reauthError = 'Incorrect password. Please try again.';
+
+                return;
+            }
+        } else {
+            // Password reveal unlocks the vault session for the configured TTL
+            $success = ReauthenticateVaultSession::run($user, $this->reauthPassword);
+
+            if (! $success) {
+                $this->reauthError = 'Incorrect password. Please try again.';
+
+                return;
+            }
+        }
+
+        $this->reauthPassword = '';
+        $this->reauthError = '';
+
+        Flux::modal('reauth-modal')->close();
+
+        if ($this->reauthPurpose === 'totp') {
+            $result = GenerateTotpCode::run($this->credential);
+            $this->totpCode = $result['code'];
+            $this->totpSecondsRemaining = $result['seconds_remaining'];
+            RecordCredentialAccess::run($this->credential, $user, 'viewed_totp');
+            Flux::modal('totp-modal')->show();
+        } else {
+            Flux::toast('Vault session unlocked.', 'Done', variant: 'success');
+            $this->revealedPassword = $this->credential->password;
+            RecordCredentialAccess::run($this->credential, $user, 'viewed_password');
+        }
+    }
+
+    #[\Livewire\Attributes\Computed]
+    public function isVaultManager(): bool
+    {
+        return auth()->user()->hasRole('Vault Manager') || auth()->user()->isAdmin();
+    }
+
+    #[\Livewire\Attributes\Computed]
+    public function assignedPositions()
+    {
+        return $this->credential->staffPositions()->with('user')->ordered()->get();
+    }
+
+    #[\Livewire\Attributes\Computed]
+    public function availablePositions()
+    {
+        $assignedIds = $this->assignedPositions->pluck('id');
+
+        return StaffPosition::ordered()->get()->filter(fn ($p) => ! $assignedIds->contains($p->id));
+    }
+
+    public function openEdit(): void
+    {
+        $this->authorize('update', $this->credential);
+
+        $this->editUsername = $this->credential->username ?? '';
+        $this->editEmail = $this->credential->email ?? '';
+        $this->editPassword = '';
+        $this->editTotpSecret = '';
+        $this->editNotes = $this->credential->notes ?? '';
+        $this->editRecoveryCodes = $this->credential->recovery_codes ?? '';
+
+        if ($this->isVaultManager) {
+            $this->editName = $this->credential->name;
+            $this->editWebsiteUrl = $this->credential->website_url ?? '';
+        }
+
+        Flux::modal('edit-credential-modal')->show();
+    }
+
+    public function saveEdit(): void
+    {
+        $this->authorize('update', $this->credential);
+
+        if ($this->isVaultManager) {
+            $this->validate([
+                'editName' => 'required|string|max:255',
+                'editWebsiteUrl' => 'nullable|url|max:500',
+                'editUsername' => 'required|string|max:500',
+                'editEmail' => 'nullable|email|max:500',
+                'editPassword' => 'nullable|string|max:1000',
+                'editTotpSecret' => 'nullable|string|max:500',
+                'editNotes' => 'nullable|string|max:5000',
+                'editRecoveryCodes' => 'nullable|string|max:5000',
+            ]);
+
+            $data = [
+                'name' => $this->editName,
+                'website_url' => $this->editWebsiteUrl ?: null,
+                'username' => $this->editUsername,
+                'email' => $this->editEmail ?: null,
+                'notes' => $this->editNotes ?: null,
+                'recovery_codes' => $this->editRecoveryCodes ?: null,
+            ];
+
+            if ($this->editTotpSecret !== '') {
+                $data['totp_secret'] = $this->editTotpSecret;
+            }
+        } else {
+            // Position holders cannot edit name or website URL
+            $this->validate([
+                'editUsername' => 'required|string|max:500',
+                'editEmail' => 'nullable|email|max:500',
+                'editPassword' => 'nullable|string|max:1000',
+                'editTotpSecret' => 'nullable|string|max:500',
+                'editNotes' => 'nullable|string|max:5000',
+                'editRecoveryCodes' => 'nullable|string|max:5000',
+            ]);
+
+            $data = [
+                'username' => $this->editUsername,
+                'email' => $this->editEmail ?: null,
+                'notes' => $this->editNotes ?: null,
+                'recovery_codes' => $this->editRecoveryCodes ?: null,
+            ];
+
+            if ($this->editTotpSecret !== '') {
+                $data['totp_secret'] = $this->editTotpSecret;
+            }
+        }
+
+        if ($this->editPassword !== '') {
+            $data['password'] = $this->editPassword;
+        }
+
+        $this->credential = UpdateCredential::run($this->credential, auth()->user(), $data);
+
+        if (array_key_exists('password', $data)) {
+            $this->revealedPassword = null;
+        }
+
+        $this->editPassword = '';
+        $this->editTotpSecret = '';
+
+        Flux::modal('edit-credential-modal')->close();
+        Flux::toast('Credential updated.', 'Done', variant: 'success');
+        unset($this->assignedPositions, $this->availablePositions);
+    }
+
+    public function confirmDelete(): void
+    {
+        $this->authorize('delete', $this->credential);
+        Flux::modal('delete-confirm-modal')->show();
+    }
+
+    public function delete(): void
+    {
+        $this->authorize('delete', $this->credential);
+
+        DeleteCredential::run($this->credential, auth()->user());
+
+        Flux::modal('delete-confirm-modal')->close();
+
+        $this->redirect(route('vault.index'), navigate: true);
+    }
+
+    public function openManagePositions(): void
+    {
+        $this->authorize('managePositions', $this->credential);
+        $this->addPositionId = null;
+        Flux::modal('manage-positions-modal')->show();
+    }
+
+    public function addPosition(): void
+    {
+        $this->authorize('managePositions', $this->credential);
+
+        $this->validate(['addPositionId' => 'required|integer|exists:staff_positions,id']);
+
+        $current = $this->credential->staffPositions->pluck('id')->toArray();
+        if (! in_array($this->addPositionId, $current)) {
+            $current[] = $this->addPositionId;
+            AssignCredentialPositions::run($this->credential, auth()->user(), $current);
+            $this->credential = $this->credential->fresh();
+        }
+
+        $this->addPositionId = null;
+        unset($this->assignedPositions, $this->availablePositions);
+        Flux::toast('Position added.', 'Done', variant: 'success');
+    }
+
+    public function removePosition(int $positionId): void
+    {
+        $this->authorize('managePositions', $this->credential);
+
+        $current = $this->credential->staffPositions->pluck('id')
+            ->filter(fn ($id) => $id !== $positionId)
+            ->values()
+            ->toArray();
+
+        AssignCredentialPositions::run($this->credential, auth()->user(), $current);
+        $this->credential = $this->credential->fresh();
+
+        unset($this->assignedPositions, $this->availablePositions);
+        Flux::toast('Position removed.', 'Done', variant: 'success');
+    }
+}; ?>
+
+<div>
+    <div class="mb-6 flex items-center gap-4">
+        <flux:button href="{{ route('vault.index') }}" wire:navigate variant="ghost" icon="arrow-left" size="sm">
+            Back to Vault
+        </flux:button>
+    </div>
+
+    <div class="space-y-6">
+        <div class="flex items-center justify-between">
+            <div>
+                <flux:heading size="xl">
+                    {{ $credential->name }}
+                    @if ($credential->needs_password_change)
+                        <flux:badge color="orange" class="ml-2">Needs Rotation</flux:badge>
+                    @endif
+                </flux:heading>
+                @if ($credential->website_url)
+                    <flux:link href="{{ $credential->website_url }}" target="_blank" rel="noopener noreferrer" class="text-sm">
+                        {{ $credential->website_url }}
+                    </flux:link>
+                @endif
+            </div>
+            <div class="flex gap-2">
+                @can('update', $credential)
+                    <flux:button variant="ghost" icon="pencil-square" wire:click="openEdit">Edit</flux:button>
+                @endcan
+                @can('managePositions', $credential)
+                    <flux:button variant="ghost" icon="user-group" wire:click="openManagePositions">Manage Access</flux:button>
+                @endcan
+                @can('delete', $credential)
+                    <flux:button variant="danger" icon="trash" wire:click="confirmDelete">Delete</flux:button>
+                @endcan
+            </div>
+        </div>
+
+        <flux:card class="space-y-4">
+            <flux:heading size="md">Credentials</flux:heading>
+
+            <div class="grid grid-cols-1 gap-4 sm:grid-cols-2">
+                <div>
+                    <flux:text variant="subtle" class="text-xs uppercase tracking-wide">Username</flux:text>
+                    <flux:text class="mt-1 font-mono">{{ $credential->username }}</flux:text>
+                </div>
+
+                @if ($credential->email)
+                    <div>
+                        <flux:text variant="subtle" class="text-xs uppercase tracking-wide">Email</flux:text>
+                        <flux:text class="mt-1 font-mono">{{ $credential->email }}</flux:text>
+                    </div>
+                @endif
+
+                <div>
+                    <flux:text variant="subtle" class="text-xs uppercase tracking-wide">Password</flux:text>
+                    @if ($revealedPassword !== null)
+                        <flux:text class="mt-1 font-mono break-all">{{ $revealedPassword }}</flux:text>
+                    @else
+                        <div class="mt-1 flex items-center gap-2">
+                            <flux:text class="font-mono text-zinc-400">••••••••••••</flux:text>
+                            <flux:button size="xs" variant="ghost" wire:click="revealPassword">Reveal</flux:button>
+                        </div>
+                        <flux:text variant="subtle" class="mt-1 text-xs">Re-authentication required to reveal</flux:text>
+                    @endif
+                </div>
+
+                @if ($credential->getRawOriginal('totp_secret'))
+                    <div>
+                        <flux:text variant="subtle" class="text-xs uppercase tracking-wide">TOTP</flux:text>
+                        <div class="mt-1 flex items-center gap-2">
+                            <flux:badge color="blue" size="sm">TOTP configured</flux:badge>
+                            <flux:button size="xs" variant="ghost" wire:click="showTotp">Show Code</flux:button>
+                        </div>
+                        <flux:text variant="subtle" class="mt-1 text-xs">Re-authentication required to view code</flux:text>
+                    </div>
+                @endif
+            </div>
+        </flux:card>
+
+        @if ($credential->notes)
+            <flux:card class="space-y-2">
+                <flux:heading size="md">Notes</flux:heading>
+                <flux:text class="whitespace-pre-wrap">{{ $credential->notes }}</flux:text>
+            </flux:card>
+        @endif
+
+        @if ($credential->getRawOriginal('recovery_codes'))
+            <flux:card class="space-y-2">
+                <flux:heading size="md">Recovery Codes</flux:heading>
+                <flux:text class="whitespace-pre-wrap font-mono">{{ $credential->recovery_codes }}</flux:text>
+            </flux:card>
+        @endif
+
+        @can('managePositions', $credential)
+            <flux:card class="space-y-4">
+                <div class="flex items-center justify-between">
+                    <flux:heading size="md">Position Access</flux:heading>
+                </div>
+                @if ($this->assignedPositions->isEmpty())
+                    <flux:text variant="subtle" class="text-sm">No positions assigned — only Vault Managers can view this credential.</flux:text>
+                @else
+                    <flux:table>
+                        <flux:table.columns>
+                            <flux:table.column>Position</flux:table.column>
+                            <flux:table.column>Held By</flux:table.column>
+                            <flux:table.column></flux:table.column>
+                        </flux:table.columns>
+                        <flux:table.rows>
+                            @foreach ($this->assignedPositions as $position)
+                                <flux:table.row wire:key="pos-{{ $position->id }}">
+                                    <flux:table.cell>{{ $position->title }}</flux:table.cell>
+                                    <flux:table.cell>
+                                        {{ $position->user?->name ?? '(vacant)' }}
+                                    </flux:table.cell>
+                                    <flux:table.cell>
+                                        <flux:button size="sm" variant="danger" icon="x-mark" wire:click="removePosition({{ $position->id }})">Remove</flux:button>
+                                    </flux:table.cell>
+                                </flux:table.row>
+                            @endforeach
+                        </flux:table.rows>
+                    </flux:table>
+                @endif
+            </flux:card>
+        @endcan
+
+        <flux:text variant="subtle" class="text-xs">
+            Added by {{ $credential->createdBy->name }} on {{ $credential->created_at->format('M j, Y') }}
+            @if ($credential->updatedBy)
+                · Last updated by {{ $credential->updatedBy->name }} on {{ $credential->updated_at->format('M j, Y') }}
+            @endif
+        </flux:text>
+    </div>
+
+    {{-- Edit modal --}}
+    @can('update', $credential)
+        <flux:modal name="edit-credential-modal" class="w-full max-w-2xl">
+            <div class="space-y-6">
+                <flux:heading size="lg">Edit Credential</flux:heading>
+
+                <div class="grid grid-cols-1 gap-4 sm:grid-cols-2">
+                    @if ($this->isVaultManager)
+                        <flux:field class="sm:col-span-2">
+                            <flux:label>Name <span class="text-red-500">*</span></flux:label>
+                            <flux:input wire:model="editName" />
+                            <flux:error name="editName" />
+                        </flux:field>
+
+                        <flux:field class="sm:col-span-2">
+                            <flux:label>Website URL</flux:label>
+                            <flux:input wire:model="editWebsiteUrl" type="url" />
+                            <flux:error name="editWebsiteUrl" />
+                        </flux:field>
+                    @endif
+
+                    <flux:field>
+                        <flux:label>Username <span class="text-red-500">*</span></flux:label>
+                        <flux:input wire:model="editUsername" />
+                        <flux:error name="editUsername" />
+                    </flux:field>
+
+                    <flux:field>
+                        <flux:label>Email</flux:label>
+                        <flux:input wire:model="editEmail" type="email" />
+                        <flux:error name="editEmail" />
+                    </flux:field>
+
+                    <flux:field>
+                        <flux:label>New Password</flux:label>
+                        <flux:description>Leave blank to keep the current password.</flux:description>
+                        <flux:input wire:model="editPassword" type="password" />
+                        <flux:error name="editPassword" />
+                    </flux:field>
+
+                    <flux:field>
+                        <flux:label>TOTP Secret</flux:label>
+                        <flux:description>Leave blank to keep the current secret.</flux:description>
+                        <flux:input wire:model="editTotpSecret" />
+                        <flux:error name="editTotpSecret" />
+                    </flux:field>
+
+                    <flux:field class="sm:col-span-2">
+                        <flux:label>Notes</flux:label>
+                        <flux:textarea wire:model="editNotes" rows="3" />
+                        <flux:error name="editNotes" />
+                    </flux:field>
+
+                    <flux:field class="sm:col-span-2">
+                        <flux:label>Recovery Codes</flux:label>
+                        <flux:textarea wire:model="editRecoveryCodes" rows="3" />
+                        <flux:error name="editRecoveryCodes" />
+                    </flux:field>
+                </div>
+
+                <div class="flex justify-end gap-2">
+                    <flux:button variant="ghost" x-on:click="$flux.modal('edit-credential-modal').close()">Cancel</flux:button>
+                    <flux:button variant="primary" wire:click="saveEdit">Save Changes</flux:button>
+                </div>
+            </div>
+        </flux:modal>
+    @endcan
+
+    @can('delete', $credential)
+        {{-- Delete confirmation modal --}}
+        <flux:modal name="delete-confirm-modal" class="w-full max-w-md">
+            <div class="space-y-6">
+                <div>
+                    <flux:heading size="lg">Delete Credential</flux:heading>
+                    <flux:text class="mt-2">
+                        Are you sure you want to delete <strong>{{ $credential->name }}</strong>?
+                        This cannot be undone. All access logs for this credential will also be removed.
+                    </flux:text>
+                </div>
+                <div class="flex justify-end gap-2">
+                    <flux:button variant="ghost" x-on:click="$flux.modal('delete-confirm-modal').close()">Cancel</flux:button>
+                    <flux:button variant="danger" wire:click="delete">Delete Permanently</flux:button>
+                </div>
+            </div>
+        </flux:modal>
+    @endcan
+
+    {{-- Re-auth modal --}}
+    <flux:modal name="reauth-modal" class="w-full max-w-sm">
+        <div class="space-y-6">
+            <div>
+                <flux:heading size="lg">Confirm Your Identity</flux:heading>
+                <flux:text class="mt-2">
+                    @if ($reauthPurpose === 'totp')
+                        Enter your Lighthouse password to view the current TOTP code.
+                    @else
+                        Enter your Lighthouse password to unlock the vault and reveal this credential.
+                    @endif
+                </flux:text>
+            </div>
+
+            <flux:field>
+                <flux:label>Password</flux:label>
+                <flux:input wire:model="reauthPassword" type="password" wire:keydown.enter="reauth" autofocus />
+                @if ($reauthError)
+                    <flux:error>{{ $reauthError }}</flux:error>
+                @endif
+            </flux:field>
+
+            <div class="flex justify-end gap-2">
+                <flux:button variant="ghost" x-on:click="$flux.modal('reauth-modal').close()">Cancel</flux:button>
+                <flux:button variant="primary" wire:click="reauth">
+                    {{ $reauthPurpose === 'totp' ? 'View Code' : 'Unlock & Reveal' }}
+                </flux:button>
+            </div>
+        </div>
+    </flux:modal>
+
+    {{-- TOTP modal --}}
+    @if ($totpCode !== null)
+        <flux:modal name="totp-modal" class="w-full max-w-sm">
+            <div class="space-y-6">
+                <flux:heading size="lg">TOTP Code</flux:heading>
+
+                <div class="text-center">
+                    <flux:text class="font-mono text-4xl font-bold tracking-widest">{{ $totpCode }}</flux:text>
+                    <flux:text variant="subtle" class="mt-2 text-sm">
+                        Expires in <span wire:poll.1000ms="refreshTotp">{{ $totpSecondsRemaining }}</span> seconds
+                    </flux:text>
+                </div>
+
+                <div class="flex justify-end">
+                    <flux:button variant="ghost" wire:click="closeTotp">Close</flux:button>
+                </div>
+            </div>
+        </flux:modal>
+    @endif
+
+    @can('managePositions', $credential)
+        {{-- Manage position access modal --}}
+        <flux:modal name="manage-positions-modal" class="w-full max-w-lg">
+            <div class="space-y-6">
+                <flux:heading size="lg">Manage Position Access</flux:heading>
+
+                <div class="space-y-2">
+                    <flux:text variant="subtle" class="text-sm">Add a staff position to grant everyone who holds that position access to view and update this credential.</flux:text>
+                </div>
+
+                @if ($this->availablePositions->isNotEmpty())
+                    <div class="flex gap-2">
+                        <div class="flex-1">
+                            <flux:select wire:model="addPositionId">
+                                <flux:select.option value="">Select a position...</flux:select.option>
+                                @foreach ($this->availablePositions as $position)
+                                    <flux:select.option value="{{ $position->id }}">
+                                        {{ $position->title }}
+                                        @if ($position->user)
+                                            ({{ $position->user->name }})
+                                        @else
+                                            (vacant)
+                                        @endif
+                                    </flux:select.option>
+                                @endforeach
+                            </flux:select>
+                        </div>
+                        <flux:button variant="primary" wire:click="addPosition">Add</flux:button>
+                    </div>
+                    <flux:error name="addPositionId" />
+                @else
+                    <flux:text variant="subtle" class="text-sm">All positions have been assigned access.</flux:text>
+                @endif
+
+                <div class="flex justify-end">
+                    <flux:button variant="ghost" x-on:click="$flux.modal('manage-positions-modal').close()">Done</flux:button>
+                </div>
+            </div>
+        </flux:modal>
+    @endcan
+</div>

--- a/resources/views/livewire/vault/index.blade.php
+++ b/resources/views/livewire/vault/index.blade.php
@@ -1,0 +1,244 @@
+<?php
+
+use App\Actions\CreateCredential;
+use App\Models\Credential;
+use Flux\Flux;
+use Livewire\Volt\Component;
+
+new class extends Component
+{
+    public string $name = '';
+
+    public string $website_url = '';
+
+    public string $username = '';
+
+    public string $email = '';
+
+    public string $password = '';
+
+    public string $totp_secret = '';
+
+    public string $notes = '';
+
+    public string $recovery_codes = '';
+
+    public function mount(): void
+    {
+        $this->authorize('view-vault');
+    }
+
+    #[\Livewire\Attributes\Computed]
+    public function credentials()
+    {
+        $user = auth()->user();
+
+        $withLastAccess = fn ($q) => $q->with([
+            'latestAccessLog.user',
+        ]);
+
+        if ($user->hasRole('Vault Manager') || $user->isAdmin()) {
+            return Credential::orderBy('name')->tap($withLastAccess)->get();
+        }
+
+        $positionId = $user->staffPosition?->id;
+
+        if ($positionId === null) {
+            return collect();
+        }
+
+        return Credential::whereHas('staffPositions', function ($query) use ($positionId) {
+            $query->where('staff_positions.id', $positionId);
+        })->orderBy('name')->tap($withLastAccess)->get();
+    }
+
+    public function openCreate(): void
+    {
+        $this->authorize('manage-vault');
+        $this->reset(['name', 'website_url', 'username', 'email', 'password', 'totp_secret', 'notes', 'recovery_codes']);
+        Flux::modal('create-credential-modal')->show();
+    }
+
+    public function create(): void
+    {
+        $this->authorize('manage-vault');
+
+        $this->validate([
+            'name' => 'required|string|max:255',
+            'website_url' => 'nullable|url|max:500',
+            'username' => 'required|string|max:500',
+            'email' => 'nullable|email|max:500',
+            'password' => 'required|string|max:1000',
+            'totp_secret' => 'nullable|string|max:500',
+            'notes' => 'nullable|string|max:5000',
+            'recovery_codes' => 'nullable|string|max:5000',
+        ]);
+
+        CreateCredential::run(auth()->user(), [
+            'name' => $this->name,
+            'website_url' => $this->website_url ?: null,
+            'username' => $this->username,
+            'email' => $this->email ?: null,
+            'password' => $this->password,
+            'totp_secret' => $this->totp_secret ?: null,
+            'notes' => $this->notes ?: null,
+            'recovery_codes' => $this->recovery_codes ?: null,
+        ]);
+
+        Flux::modal('create-credential-modal')->close();
+        Flux::toast('Credential added to vault.', 'Done', variant: 'success');
+        $this->reset(['name', 'website_url', 'username', 'email', 'password', 'totp_secret', 'notes', 'recovery_codes']);
+        unset($this->credentials);
+    }
+}; ?>
+
+<div class="space-y-6">
+    <div class="flex items-center justify-between">
+        <flux:heading size="xl">Staff Credential Vault</flux:heading>
+        @can('manage-vault')
+            <flux:button variant="primary" icon="plus" wire:click="openCreate">
+                Add Credential
+            </flux:button>
+        @endcan
+    </div>
+
+    <flux:table>
+        <flux:table.columns>
+            <flux:table.column>Name</flux:table.column>
+            <flux:table.column>Website</flux:table.column>
+            <flux:table.column>TOTP</flux:table.column>
+            <flux:table.column>Password Changed</flux:table.column>
+            <flux:table.column>Last Accessed</flux:table.column>
+        </flux:table.columns>
+        <flux:table.rows>
+            @forelse ($this->credentials as $credential)
+                <flux:table.row wire:key="credential-{{ $credential->id }}">
+                    <flux:table.cell>
+                        <flux:link href="{{ route('vault.detail', $credential) }}" wire:navigate>
+                            {{ $credential->name }}
+                            @if ($credential->needs_password_change)
+                                <flux:badge color="orange" size="sm" class="ml-2">Needs Rotation</flux:badge>
+                            @endif
+                        </flux:link>
+                    </flux:table.cell>
+                    <flux:table.cell>
+                        @if ($credential->website_url)
+                            <flux:link href="{{ $credential->website_url }}" target="_blank" rel="noopener noreferrer" class="text-sm">
+                                {{ parse_url($credential->website_url, PHP_URL_HOST) ?? $credential->website_url }}
+                            </flux:link>
+                        @else
+                            <flux:text variant="subtle" class="text-sm">—</flux:text>
+                        @endif
+                    </flux:table.cell>
+                    <flux:table.cell>
+                        @if ($credential->getRawOriginal('totp_secret'))
+                            <flux:badge color="blue" size="sm">TOTP</flux:badge>
+                        @else
+                            <flux:text variant="subtle" class="text-sm">—</flux:text>
+                        @endif
+                    </flux:table.cell>
+                    <flux:table.cell>
+                        @if ($credential->password_changed_at)
+                            <flux:text variant="subtle" class="text-sm">
+                                {{ $credential->password_changed_at->format('M j, Y') }}
+                            </flux:text>
+                        @else
+                            <flux:text variant="subtle" class="text-sm">—</flux:text>
+                        @endif
+                    </flux:table.cell>
+                    <flux:table.cell>
+                        @if ($credential->latestAccessLog)
+                            <flux:text variant="subtle" class="text-sm">
+                                @if ($credential->latestAccessLog->user)
+                                    <flux:link href="{{ route('profile.show', $credential->latestAccessLog->user) }}" wire:navigate class="text-sm">
+                                        {{ $credential->latestAccessLog->user->name }}
+                                    </flux:link>
+                                @else
+                                    (deleted)
+                                @endif
+                                <br>
+                                <span class="text-xs">{{ $credential->latestAccessLog->created_at->diffForHumans() }}</span>
+                            </flux:text>
+                        @else
+                            <flux:text variant="subtle" class="text-sm">—</flux:text>
+                        @endif
+                    </flux:table.cell>
+                </flux:table.row>
+            @empty
+                <flux:table.row>
+                    <flux:table.cell colspan="5">
+                        <flux:text variant="subtle" class="py-4 text-center">
+                            No credentials in the vault yet.
+                            @can('manage-vault')
+                                Use "Add Credential" to get started.
+                            @endcan
+                        </flux:text>
+                    </flux:table.cell>
+                </flux:table.row>
+            @endforelse
+        </flux:table.rows>
+    </flux:table>
+
+    @can('manage-vault')
+        <flux:modal name="create-credential-modal" class="w-full max-w-2xl">
+            <div class="space-y-6">
+                <flux:heading size="lg">Add Credential</flux:heading>
+
+                <div class="grid grid-cols-1 gap-4 sm:grid-cols-2">
+                    <flux:field class="sm:col-span-2">
+                        <flux:label>Name <span class="text-red-500">*</span></flux:label>
+                        <flux:input wire:model="name" placeholder="e.g. Apex Hosting Admin" />
+                        <flux:error name="name" />
+                    </flux:field>
+
+                    <flux:field class="sm:col-span-2">
+                        <flux:label>Website URL</flux:label>
+                        <flux:input wire:model="website_url" type="url" placeholder="https://example.com/login" />
+                        <flux:error name="website_url" />
+                    </flux:field>
+
+                    <flux:field>
+                        <flux:label>Username <span class="text-red-500">*</span></flux:label>
+                        <flux:input wire:model="username" />
+                        <flux:error name="username" />
+                    </flux:field>
+
+                    <flux:field>
+                        <flux:label>Email</flux:label>
+                        <flux:input wire:model="email" type="email" />
+                        <flux:error name="email" />
+                    </flux:field>
+
+                    <flux:field>
+                        <flux:label>Password <span class="text-red-500">*</span></flux:label>
+                        <flux:input wire:model="password" type="password" />
+                        <flux:error name="password" />
+                    </flux:field>
+
+                    <flux:field>
+                        <flux:label>TOTP Secret</flux:label>
+                        <flux:input wire:model="totp_secret" placeholder="Leave blank if not applicable" />
+                        <flux:error name="totp_secret" />
+                    </flux:field>
+
+                    <flux:field class="sm:col-span-2">
+                        <flux:label>Notes</flux:label>
+                        <flux:textarea wire:model="notes" rows="3" />
+                        <flux:error name="notes" />
+                    </flux:field>
+
+                    <flux:field class="sm:col-span-2">
+                        <flux:label>Recovery Codes</flux:label>
+                        <flux:textarea wire:model="recovery_codes" rows="3" placeholder="Paste recovery codes here" />
+                        <flux:error name="recovery_codes" />
+                    </flux:field>
+                </div>
+
+                <div class="flex justify-end gap-2">
+                    <flux:button variant="ghost" x-on:click="$flux.modal('create-credential-modal').close()">Cancel</flux:button>
+                    <flux:button variant="primary" wire:click="create">Add Credential</flux:button>
+                </div>
+            </div>
+        </flux:modal>
+    @endcan
+</div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -256,4 +256,13 @@ Route::prefix('finance')
         Volt::route('/reports', 'finance.reports')->name('reports.index');
     });
 
+// Staff Credential Vault
+Route::prefix('vault')
+    ->name('vault.')
+    ->middleware(['auth', 'can:view-vault'])
+    ->group(function () {
+        Volt::route('/', 'vault.index')->name('index');
+        Volt::route('/{credential}', 'vault.detail')->name('detail');
+    });
+
 Route::get('/{slug}', [PageController::class, 'show'])->name('pages.show');

--- a/tests/Feature/Actions/Vault/AssignCredentialPositionsTest.php
+++ b/tests/Feature/Actions/Vault/AssignCredentialPositionsTest.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Actions\AssignCredentialPositions;
+use App\Models\Credential;
+use App\Models\StaffPosition;
+use App\Models\User;
+
+uses()->group('vault', 'actions');
+
+it('assigns positions to a credential', function () {
+    $user = User::factory()->withRole('Vault Manager')->create();
+    $credential = Credential::factory()->create(['created_by' => $user->id]);
+    $position1 = StaffPosition::factory()->create();
+    $position2 = StaffPosition::factory()->create();
+
+    AssignCredentialPositions::run($credential, $user, [$position1->id, $position2->id]);
+
+    $this->assertDatabaseHas('credential_staff_position', [
+        'credential_id' => $credential->id,
+        'staff_position_id' => $position1->id,
+    ]);
+    $this->assertDatabaseHas('credential_staff_position', [
+        'credential_id' => $credential->id,
+        'staff_position_id' => $position2->id,
+    ]);
+});
+
+it('removes positions no longer in the sync list', function () {
+    $user = User::factory()->withRole('Vault Manager')->create();
+    $credential = Credential::factory()->create(['created_by' => $user->id]);
+    $position1 = StaffPosition::factory()->create();
+    $position2 = StaffPosition::factory()->create();
+
+    $credential->staffPositions()->attach([$position1->id, $position2->id]);
+
+    AssignCredentialPositions::run($credential, $user, [$position1->id]);
+
+    $this->assertDatabaseHas('credential_staff_position', [
+        'credential_id' => $credential->id,
+        'staff_position_id' => $position1->id,
+    ]);
+    $this->assertDatabaseMissing('credential_staff_position', [
+        'credential_id' => $credential->id,
+        'staff_position_id' => $position2->id,
+    ]);
+});
+
+it('clears all positions when synced with an empty array', function () {
+    $user = User::factory()->withRole('Vault Manager')->create();
+    $credential = Credential::factory()->create(['created_by' => $user->id]);
+    $position = StaffPosition::factory()->create();
+    $credential->staffPositions()->attach($position->id);
+
+    AssignCredentialPositions::run($credential, $user, []);
+
+    $this->assertDatabaseMissing('credential_staff_position', [
+        'credential_id' => $credential->id,
+    ]);
+});
+
+it('records activity on position assignment', function () {
+    $user = User::factory()->withRole('Vault Manager')->create();
+    $credential = Credential::factory()->create(['created_by' => $user->id]);
+    $position = StaffPosition::factory()->create();
+
+    AssignCredentialPositions::run($credential, $user, [$position->id]);
+
+    $this->assertDatabaseHas('activity_logs', [
+        'subject_type' => Credential::class,
+        'subject_id' => $credential->id,
+        'action' => 'credential_positions_assigned',
+    ]);
+});

--- a/tests/Feature/Actions/Vault/CreateCredentialTest.php
+++ b/tests/Feature/Actions/Vault/CreateCredentialTest.php
@@ -1,0 +1,116 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Actions\CreateCredential;
+use App\Models\Credential;
+use App\Models\User;
+
+uses()->group('vault', 'actions');
+
+it('creates a credential record', function () {
+    $user = User::factory()->withRole('Vault Manager')->create();
+
+    $credential = CreateCredential::run($user, [
+        'name' => 'Test Service',
+        'username' => 'admin',
+        'password' => 's3cr3t!',
+    ]);
+
+    expect($credential)->toBeInstanceOf(Credential::class)
+        ->and($credential->name)->toBe('Test Service');
+});
+
+it('stores sensitive fields encrypted in the database', function () {
+    $user = User::factory()->withRole('Vault Manager')->create();
+
+    $credential = CreateCredential::run($user, [
+        'name' => 'Encrypt Test',
+        'username' => 'myusername',
+        'email' => 'admin@example.com',
+        'password' => 'plaintext-password',
+        'notes' => 'Some notes',
+    ]);
+
+    $raw = Credential::query()->toBase()->where('id', $credential->id)->first();
+
+    expect($raw->username)->not->toBe('myusername')
+        ->and($raw->email)->not->toBe('admin@example.com')
+        ->and($raw->password)->not->toBe('plaintext-password')
+        ->and($raw->notes)->not->toBe('Some notes');
+});
+
+it('decrypts sensitive fields correctly via model attributes', function () {
+    $user = User::factory()->withRole('Vault Manager')->create();
+
+    $credential = CreateCredential::run($user, [
+        'name' => 'Decrypt Test',
+        'username' => 'myusername',
+        'email' => 'admin@example.com',
+        'password' => 'plaintext-password',
+        'notes' => 'Some notes',
+    ]);
+
+    $fresh = $credential->fresh();
+
+    expect($fresh->username)->toBe('myusername')
+        ->and($fresh->email)->toBe('admin@example.com')
+        ->and($fresh->password)->toBe('plaintext-password')
+        ->and($fresh->notes)->toBe('Some notes');
+});
+
+it('sets created_by to the creator', function () {
+    $user = User::factory()->withRole('Vault Manager')->create();
+
+    $credential = CreateCredential::run($user, [
+        'name' => 'Test',
+        'username' => 'user',
+        'password' => 'pass',
+    ]);
+
+    expect($credential->created_by)->toBe($user->id);
+});
+
+it('defaults needs_password_change to false', function () {
+    $user = User::factory()->withRole('Vault Manager')->create();
+
+    $credential = CreateCredential::run($user, [
+        'name' => 'Test',
+        'username' => 'user',
+        'password' => 'pass',
+    ]);
+
+    expect($credential->needs_password_change)->toBeFalse();
+});
+
+it('records activity on creation', function () {
+    $user = User::factory()->withRole('Vault Manager')->create();
+
+    $credential = CreateCredential::run($user, [
+        'name' => 'Activity Test',
+        'username' => 'user',
+        'password' => 'pass',
+    ]);
+
+    $this->assertDatabaseHas('activity_logs', [
+        'subject_type' => Credential::class,
+        'subject_id' => $credential->id,
+        'action' => 'credential_created',
+    ]);
+});
+
+it('handles nullable optional fields', function () {
+    $user = User::factory()->withRole('Vault Manager')->create();
+
+    $credential = CreateCredential::run($user, [
+        'name' => 'Minimal',
+        'username' => 'admin',
+        'password' => 'pass',
+    ]);
+
+    expect($credential->website_url)->toBeNull()
+        ->and($credential->email)->toBeNull()
+        ->and($credential->totp_secret)->toBeNull()
+        ->and($credential->notes)->toBeNull()
+        ->and($credential->recovery_codes)->toBeNull();
+});

--- a/tests/Feature/Actions/Vault/DeleteCredentialTest.php
+++ b/tests/Feature/Actions/Vault/DeleteCredentialTest.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Actions\DeleteCredential;
+use App\Models\Credential;
+use App\Models\CredentialAccessLog;
+use App\Models\StaffPosition;
+use App\Models\User;
+
+uses()->group('vault', 'actions');
+
+it('deletes the credential record', function () {
+    $user = User::factory()->withRole('Vault Manager')->create();
+    $credential = Credential::factory()->create(['created_by' => $user->id]);
+
+    DeleteCredential::run($credential, $user);
+
+    $this->assertDatabaseMissing('credentials', ['id' => $credential->id]);
+});
+
+it('removes pivot rows from credential_staff_position', function () {
+    $user = User::factory()->withRole('Vault Manager')->create();
+    $credential = Credential::factory()->create(['created_by' => $user->id]);
+    $position = StaffPosition::factory()->create();
+    $credential->staffPositions()->attach($position->id);
+
+    DeleteCredential::run($credential, $user);
+
+    $this->assertDatabaseMissing('credential_staff_position', [
+        'credential_id' => $credential->id,
+        'staff_position_id' => $position->id,
+    ]);
+});
+
+it('removes access logs for the credential', function () {
+    $user = User::factory()->withRole('Vault Manager')->create();
+    $credential = Credential::factory()->create(['created_by' => $user->id]);
+    CredentialAccessLog::create([
+        'credential_id' => $credential->id,
+        'user_id' => $user->id,
+        'action' => 'viewed_password',
+        'created_at' => now(),
+    ]);
+
+    DeleteCredential::run($credential, $user);
+
+    $this->assertDatabaseMissing('credential_access_logs', [
+        'credential_id' => $credential->id,
+    ]);
+});
+
+it('records activity on deletion', function () {
+    $user = User::factory()->withRole('Vault Manager')->create();
+    $credential = Credential::factory()->create(['created_by' => $user->id, 'name' => 'Gone Credential']);
+
+    DeleteCredential::run($credential, $user);
+
+    $this->assertDatabaseHas('activity_logs', [
+        'subject_type' => User::class,
+        'subject_id' => $user->id,
+        'action' => 'credential_deleted',
+    ]);
+});

--- a/tests/Feature/Actions/Vault/FlagCredentialsAfterPositionRemovalTest.php
+++ b/tests/Feature/Actions/Vault/FlagCredentialsAfterPositionRemovalTest.php
@@ -1,0 +1,107 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Actions\CreateCredential;
+use App\Actions\FlagCredentialsAfterPositionRemoval;
+use App\Models\CredentialAccessLog;
+use App\Models\StaffPosition;
+use App\Models\User;
+
+uses()->group('vault', 'actions');
+
+it('flags credentials that the departing user accessed', function () {
+    $manager = User::factory()->withRole('Vault Manager')->create();
+    $departing = User::factory()->create();
+    $position = StaffPosition::factory()->assignedTo($departing->id)->create();
+
+    $credential = CreateCredential::run($manager, [
+        'name' => 'Accessed Credential',
+        'username' => 'admin',
+        'password' => 'secret',
+    ]);
+    $credential->staffPositions()->attach($position->id);
+
+    // Simulate the departing user having accessed this credential
+    CredentialAccessLog::create([
+        'credential_id' => $credential->id,
+        'user_id' => $departing->id,
+        'action' => 'viewed_password',
+        'created_at' => now(),
+    ]);
+
+    FlagCredentialsAfterPositionRemoval::run($departing, $position);
+
+    expect($credential->fresh()->needs_password_change)->toBeTrue();
+});
+
+it('does not flag credentials the departing user never accessed', function () {
+    $manager = User::factory()->withRole('Vault Manager')->create();
+    $departing = User::factory()->create();
+    $position = StaffPosition::factory()->assignedTo($departing->id)->create();
+
+    $credential = CreateCredential::run($manager, [
+        'name' => 'Unaccessed Credential',
+        'username' => 'admin',
+        'password' => 'secret',
+    ]);
+    $credential->staffPositions()->attach($position->id);
+
+    // No access log for the departing user
+
+    FlagCredentialsAfterPositionRemoval::run($departing, $position);
+
+    expect($credential->fresh()->needs_password_change)->toBeFalse();
+});
+
+it('does not flag credentials accessed only by other users', function () {
+    $manager = User::factory()->withRole('Vault Manager')->create();
+    $departing = User::factory()->create();
+    $otherUser = User::factory()->create();
+    $position = StaffPosition::factory()->assignedTo($departing->id)->create();
+
+    $credential = CreateCredential::run($manager, [
+        'name' => 'Other User Credential',
+        'username' => 'admin',
+        'password' => 'secret',
+    ]);
+    $credential->staffPositions()->attach($position->id);
+
+    // Only the OTHER user accessed this credential
+    CredentialAccessLog::create([
+        'credential_id' => $credential->id,
+        'user_id' => $otherUser->id,
+        'action' => 'viewed_password',
+        'created_at' => now(),
+    ]);
+
+    FlagCredentialsAfterPositionRemoval::run($departing, $position);
+
+    expect($credential->fresh()->needs_password_change)->toBeFalse();
+});
+
+it('does not flag credentials not assigned to the departing position', function () {
+    $manager = User::factory()->withRole('Vault Manager')->create();
+    $departing = User::factory()->create();
+    $position = StaffPosition::factory()->assignedTo($departing->id)->create();
+    $otherPosition = StaffPosition::factory()->create();
+
+    // Credential is on a DIFFERENT position
+    $credential = CreateCredential::run($manager, [
+        'name' => 'Different Position Credential',
+        'username' => 'admin',
+        'password' => 'secret',
+    ]);
+    $credential->staffPositions()->attach($otherPosition->id);
+
+    CredentialAccessLog::create([
+        'credential_id' => $credential->id,
+        'user_id' => $departing->id,
+        'action' => 'viewed_password',
+        'created_at' => now(),
+    ]);
+
+    FlagCredentialsAfterPositionRemoval::run($departing, $position);
+
+    expect($credential->fresh()->needs_password_change)->toBeFalse();
+});

--- a/tests/Feature/Actions/Vault/GenerateTotpCodeTest.php
+++ b/tests/Feature/Actions/Vault/GenerateTotpCodeTest.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Actions\CreateCredential;
+use App\Actions\GenerateTotpCode;
+use App\Models\User;
+
+uses()->group('vault', 'actions');
+
+it('returns a 6-digit TOTP code', function () {
+    $user = User::factory()->withRole('Vault Manager')->create();
+    // Use a well-known base32 TOTP secret
+    $credential = CreateCredential::run($user, [
+        'name' => 'TOTP Test',
+        'username' => 'admin',
+        'password' => 'pass',
+        'totp_secret' => 'JBSWY3DPEHPK3PXP',
+    ]);
+
+    $result = GenerateTotpCode::run($credential);
+
+    expect($result['code'])->toMatch('/^\d{6}$/')
+        ->and($result['seconds_remaining'])->toBeGreaterThanOrEqual(1)
+        ->and($result['seconds_remaining'])->toBeLessThanOrEqual(30);
+});
+
+it('does not include the raw TOTP secret in the return value', function () {
+    $user = User::factory()->withRole('Vault Manager')->create();
+    $credential = CreateCredential::run($user, [
+        'name' => 'TOTP Secret Test',
+        'username' => 'admin',
+        'password' => 'pass',
+        'totp_secret' => 'JBSWY3DPEHPK3PXP',
+    ]);
+
+    $result = GenerateTotpCode::run($credential);
+
+    expect($result)->not->toHaveKey('secret')
+        ->and(array_keys($result))->toEqual(['code', 'seconds_remaining']);
+});

--- a/tests/Feature/Actions/Vault/ReauthenticateVaultSessionTest.php
+++ b/tests/Feature/Actions/Vault/ReauthenticateVaultSessionTest.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Actions\ReauthenticateVaultSession;
+use App\Models\User;
+use App\Services\VaultSession;
+
+uses()->group('vault', 'actions');
+
+it('returns true and unlocks the session on correct password', function () {
+    $user = User::factory()->create(['password' => bcrypt('correct-password')]);
+
+    $result = ReauthenticateVaultSession::run($user, 'correct-password');
+
+    expect($result)->toBeTrue()
+        ->and(app(VaultSession::class)->isUnlocked())->toBeTrue();
+});
+
+it('returns false and does not unlock the session on wrong password', function () {
+    $user = User::factory()->create(['password' => bcrypt('correct-password')]);
+
+    $result = ReauthenticateVaultSession::run($user, 'wrong-password');
+
+    expect($result)->toBeFalse()
+        ->and(app(VaultSession::class)->isUnlocked())->toBeFalse();
+});
+
+it('does not modify the session when the password is wrong', function () {
+    $user = User::factory()->create(['password' => bcrypt('correct-password')]);
+
+    // Ensure session is locked
+    app(VaultSession::class)->lock();
+
+    ReauthenticateVaultSession::run($user, 'wrong-password');
+
+    expect(session('vault_unlocked_at'))->toBeNull();
+});

--- a/tests/Feature/Actions/Vault/RecordCredentialAccessTest.php
+++ b/tests/Feature/Actions/Vault/RecordCredentialAccessTest.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Actions\AssignCredentialPositions;
+use App\Actions\CreateCredential;
+use App\Actions\DeleteCredential;
+use App\Actions\RecordCredentialAccess;
+use App\Actions\UpdateCredential;
+use App\Models\Credential;
+use App\Models\User;
+
+uses()->group('vault', 'actions');
+
+it('records a credential access log entry', function () {
+    $user = User::factory()->withRole('Vault Manager')->create();
+    $credential = CreateCredential::run($user, [
+        'name' => 'Test',
+        'username' => 'admin',
+        'password' => 'pass',
+    ]);
+
+    RecordCredentialAccess::run($credential, $user, 'viewed_password');
+
+    $this->assertDatabaseHas('credential_access_logs', [
+        'credential_id' => $credential->id,
+        'user_id' => $user->id,
+        'action' => 'viewed_password',
+    ]);
+});
+
+it('CreateCredential logs a created access entry', function () {
+    $user = User::factory()->withRole('Vault Manager')->create();
+
+    $credential = CreateCredential::run($user, [
+        'name' => 'Create Log Test',
+        'username' => 'admin',
+        'password' => 'pass',
+    ]);
+
+    $this->assertDatabaseHas('credential_access_logs', [
+        'credential_id' => $credential->id,
+        'user_id' => $user->id,
+        'action' => 'created',
+    ]);
+});
+
+it('UpdateCredential logs an updated access entry', function () {
+    $user = User::factory()->withRole('Vault Manager')->create();
+    $credential = CreateCredential::run($user, [
+        'name' => 'Update Log Test',
+        'username' => 'admin',
+        'password' => 'pass',
+    ]);
+
+    UpdateCredential::run($credential, $user, ['name' => 'Updated Name']);
+
+    $this->assertDatabaseHas('credential_access_logs', [
+        'credential_id' => $credential->id,
+        'user_id' => $user->id,
+        'action' => 'updated',
+    ]);
+});
+
+it('DeleteCredential logs a deleted access entry that persists after deletion', function () {
+    $user = User::factory()->withRole('Vault Manager')->create();
+    $credential = CreateCredential::run($user, [
+        'name' => 'Delete Log Test',
+        'username' => 'admin',
+        'password' => 'pass',
+    ]);
+    $credentialId = $credential->id;
+
+    DeleteCredential::run($credential, $user);
+
+    // The credential is gone
+    $this->assertDatabaseMissing('credentials', ['id' => $credentialId]);
+
+    // The 'deleted' audit entry is preserved with credential_id nullified
+    $this->assertDatabaseHas('credential_access_logs', [
+        'credential_id' => null,
+        'user_id' => $user->id,
+        'action' => 'deleted',
+    ]);
+});
+
+it('AssignCredentialPositions logs a positions_assigned access entry', function () {
+    $user = User::factory()->withRole('Vault Manager')->create();
+    $credential = CreateCredential::run($user, [
+        'name' => 'Assign Log Test',
+        'username' => 'admin',
+        'password' => 'pass',
+    ]);
+
+    AssignCredentialPositions::run($credential, $user, []);
+
+    $this->assertDatabaseHas('credential_access_logs', [
+        'credential_id' => $credential->id,
+        'user_id' => $user->id,
+        'action' => 'positions_assigned',
+    ]);
+});

--- a/tests/Feature/Actions/Vault/UpdateCredentialTest.php
+++ b/tests/Feature/Actions/Vault/UpdateCredentialTest.php
@@ -1,0 +1,121 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Actions\UpdateCredential;
+use App\Models\Credential;
+use App\Models\User;
+
+uses()->group('vault', 'actions');
+
+it('updates plain fields', function () {
+    $user = User::factory()->withRole('Vault Manager')->create();
+    $credential = Credential::factory()->create(['created_by' => $user->id]);
+
+    $updated = UpdateCredential::run($credential, $user, [
+        'name' => 'New Name',
+        'website_url' => 'https://example.com',
+    ]);
+
+    expect($updated->name)->toBe('New Name')
+        ->and($updated->website_url)->toBe('https://example.com');
+});
+
+it('updates encrypted fields correctly', function () {
+    $user = User::factory()->withRole('Vault Manager')->create();
+    $credential = Credential::factory()->create(['created_by' => $user->id]);
+
+    $updated = UpdateCredential::run($credential, $user, [
+        'username' => 'newuser',
+        'email' => 'new@example.com',
+    ]);
+
+    expect($updated->username)->toBe('newuser')
+        ->and($updated->email)->toBe('new@example.com');
+});
+
+it('clears needs_password_change when password is updated', function () {
+    $user = User::factory()->withRole('Vault Manager')->create();
+    $credential = Credential::factory()->needsPasswordChange()->create(['created_by' => $user->id]);
+
+    expect($credential->needs_password_change)->toBeTrue();
+
+    $updated = UpdateCredential::run($credential, $user, [
+        'password' => 'brand-new-password',
+    ]);
+
+    expect($updated->needs_password_change)->toBeFalse();
+});
+
+it('stamps password_changed_at when password is updated', function () {
+    $user = User::factory()->withRole('Vault Manager')->create();
+    $credential = Credential::factory()->create(['created_by' => $user->id]);
+
+    $before = now()->subSecond();
+    $updated = UpdateCredential::run($credential, $user, ['password' => 'brand-new-password']);
+
+    expect($updated->password_changed_at)->not->toBeNull()
+        ->and($updated->password_changed_at->isAfter($before))->toBeTrue();
+});
+
+it('does not update password_changed_at when only other fields are updated', function () {
+    $user = User::factory()->withRole('Vault Manager')->create();
+    $original = now()->subDay();
+    $credential = Credential::factory()->create([
+        'created_by' => $user->id,
+        'password_changed_at' => $original,
+    ]);
+
+    UpdateCredential::run($credential, $user, ['name' => 'Different Name']);
+
+    expect($credential->fresh()->password_changed_at->toDateString())->toBe($original->toDateString());
+});
+
+it('does not clear needs_password_change when only other fields are updated', function () {
+    $user = User::factory()->withRole('Vault Manager')->create();
+    $credential = Credential::factory()->needsPasswordChange()->create(['created_by' => $user->id]);
+
+    $updated = UpdateCredential::run($credential, $user, [
+        'username' => 'updateduser',
+        'notes' => 'Updated notes only',
+    ]);
+
+    expect($updated->needs_password_change)->toBeTrue();
+});
+
+it('does not update password when password field is empty string', function () {
+    $user = User::factory()->withRole('Vault Manager')->create();
+    $credential = Credential::factory()->needsPasswordChange()->create(['created_by' => $user->id]);
+    $originalPassword = $credential->password;
+
+    $updated = UpdateCredential::run($credential, $user, [
+        'password' => '',
+        'name' => 'Some Update',
+    ]);
+
+    expect($updated->password)->toBe($originalPassword)
+        ->and($updated->needs_password_change)->toBeTrue();
+});
+
+it('sets updated_by to the updater', function () {
+    $creator = User::factory()->withRole('Vault Manager')->create();
+    $updater = User::factory()->withRole('Vault Manager')->create();
+    $credential = Credential::factory()->create(['created_by' => $creator->id]);
+
+    $updated = UpdateCredential::run($credential, $updater, ['name' => 'Changed']);
+
+    expect($updated->updated_by)->toBe($updater->id);
+});
+
+it('records activity on update', function () {
+    $user = User::factory()->withRole('Vault Manager')->create();
+    $credential = Credential::factory()->create(['created_by' => $user->id]);
+
+    UpdateCredential::run($credential, $user, ['name' => 'Changed']);
+
+    $this->assertDatabaseHas('activity_logs', [
+        'subject_type' => Credential::class,
+        'subject_id' => $credential->id,
+        'action' => 'credential_updated',
+    ]);
+});

--- a/tests/Feature/Gates/VaultGatesTest.php
+++ b/tests/Feature/Gates/VaultGatesTest.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Enums\StaffRank;
+use App\Models\User;
+
+uses()->group('vault', 'gates');
+
+// === manage-vault ===
+
+it('grants manage-vault to user with Vault Manager role', function () {
+    $user = User::factory()->withRole('Vault Manager')->create();
+
+    expect($user->can('manage-vault'))->toBeTrue();
+});
+
+it('denies manage-vault to a JrCrew staff member without the Vault Manager role', function () {
+    $user = User::factory()->create(['staff_rank' => StaffRank::JrCrew]);
+
+    expect($user->can('manage-vault'))->toBeFalse();
+});
+
+it('denies manage-vault to a regular member', function () {
+    $user = User::factory()->create();
+
+    expect($user->can('manage-vault'))->toBeFalse();
+});
+
+it('grants manage-vault to an admin regardless of role', function () {
+    $user = User::factory()->admin()->create();
+
+    expect($user->can('manage-vault'))->toBeTrue();
+});
+
+// === view-vault ===
+
+dataset('view_vault_allowed_ranks', [
+    StaffRank::JrCrew,
+    StaffRank::CrewMember,
+    StaffRank::Officer,
+]);
+
+it('grants view-vault to staff at or above JrCrew', function (StaffRank $rank) {
+    $user = User::factory()->create(['staff_rank' => $rank]);
+
+    expect($user->can('view-vault'))->toBeTrue();
+})->with('view_vault_allowed_ranks');
+
+it('denies view-vault to a user with no staff rank', function () {
+    $user = User::factory()->create(['staff_rank' => StaffRank::None]);
+
+    expect($user->can('view-vault'))->toBeFalse();
+});
+
+it('grants view-vault to an admin regardless of staff rank', function () {
+    $user = User::factory()->admin()->create(['staff_rank' => StaffRank::None]);
+
+    expect($user->can('view-vault'))->toBeTrue();
+});

--- a/tests/Feature/Livewire/CredentialAccessLogPageTest.php
+++ b/tests/Feature/Livewire/CredentialAccessLogPageTest.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Actions\CreateCredential;
+use App\Actions\RecordCredentialAccess;
+use App\Models\User;
+
+use function Pest\Livewire\livewire;
+
+uses()->group('vault', 'livewire');
+
+it('renders for a user with the Logs - Viewer role', function () {
+    $viewer = User::factory()->withRole('Logs - Viewer')->create();
+    $this->actingAs($viewer);
+
+    livewire('admin-manage-credential-access-log-page')
+        ->assertOk();
+});
+
+it('is forbidden to users without the Logs - Viewer role', function () {
+    $user = User::factory()->create();
+    $this->actingAs($user);
+
+    livewire('admin-manage-credential-access-log-page')
+        ->assertForbidden();
+});
+
+it('displays log entries in the table', function () {
+    $manager = User::factory()->withRole('Vault Manager')->create();
+    $credential = CreateCredential::run($manager, [
+        'name' => 'Logged Credential',
+        'username' => 'admin',
+        'password' => 'pass',
+    ]);
+
+    RecordCredentialAccess::run($credential, $manager, 'viewed_password');
+
+    $viewer = User::factory()->withRole('Logs - Viewer')->create();
+    $this->actingAs($viewer);
+
+    livewire('admin-manage-credential-access-log-page')
+        ->assertSee('Logged Credential')
+        ->assertSee('Viewed Password');
+});

--- a/tests/Feature/Livewire/VaultTest.php
+++ b/tests/Feature/Livewire/VaultTest.php
@@ -1,0 +1,201 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Enums\StaffRank;
+use App\Models\Credential;
+use App\Models\User;
+
+use function Pest\Livewire\livewire;
+
+uses()->group('vault', 'livewire');
+
+// === vault index ===
+
+it('allows a Vault Manager to create a credential via the index component', function () {
+    $user = User::factory()->withRole('Vault Manager')->create(['staff_rank' => StaffRank::JrCrew]);
+    $this->actingAs($user);
+
+    livewire('vault.index')
+        ->call('create', [])
+        ->set('name', 'New Service')
+        ->set('username', 'admin')
+        ->set('password', 'secret123')
+        ->call('create');
+
+    $this->assertDatabaseHas('credentials', ['name' => 'New Service']);
+});
+
+it('rejects a non-Vault-Manager JrCrew from calling create on the vault index', function () {
+    $user = User::factory()->create(['staff_rank' => StaffRank::JrCrew]);
+    $this->actingAs($user);
+
+    livewire('vault.index')
+        ->set('name', 'Hacked')
+        ->set('username', 'hacker')
+        ->set('password', 'pass')
+        ->call('create')
+        ->assertForbidden();
+});
+
+// === vault detail ===
+
+it('allows a Vault Manager to delete a credential', function () {
+    $user = User::factory()->withRole('Vault Manager')->create(['staff_rank' => StaffRank::JrCrew]);
+    $credential = Credential::factory()->create(['created_by' => $user->id]);
+    $this->actingAs($user);
+
+    livewire('vault.detail', ['credential' => $credential])
+        ->call('delete');
+
+    $this->assertDatabaseMissing('credentials', ['id' => $credential->id]);
+});
+
+it('rejects a position holder (non-Vault-Manager) from deleting a credential', function () {
+    $manager = User::factory()->withRole('Vault Manager')->create(['staff_rank' => StaffRank::JrCrew]);
+    $credential = Credential::factory()->create(['created_by' => $manager->id]);
+
+    // Give the jrCrew user a position and assign it to the credential so they can view it
+    $jrCrew = User::factory()->create(['staff_rank' => StaffRank::JrCrew]);
+    $position = \App\Models\StaffPosition::factory()->assignedTo($jrCrew->id)->create();
+    $credential->staffPositions()->attach($position->id);
+    $this->actingAs($jrCrew);
+
+    livewire('vault.detail', ['credential' => $credential])
+        ->call('delete')
+        ->assertForbidden();
+});
+
+it('allows a Vault Manager to update a credential', function () {
+    $user = User::factory()->withRole('Vault Manager')->create(['staff_rank' => StaffRank::JrCrew]);
+    $credential = Credential::factory()->create(['created_by' => $user->id]);
+    $this->actingAs($user);
+
+    livewire('vault.detail', ['credential' => $credential])
+        ->set('editName', 'Updated Name')
+        ->set('editUsername', 'newuser')
+        ->set('editPassword', '')
+        ->call('saveEdit');
+
+    expect($credential->fresh()->name)->toBe('Updated Name');
+});
+
+// === password reveal ===
+
+it('reveals the password after successful re-authentication', function () {
+    $user = User::factory()->withRole('Vault Manager')->create([
+        'staff_rank' => StaffRank::JrCrew,
+        'password' => bcrypt('my-vault-password'),
+    ]);
+    $credential = Credential::factory()->create(['created_by' => $user->id]);
+    $this->actingAs($user);
+
+    livewire('vault.detail', ['credential' => $credential])
+        ->set('reauthPassword', 'my-vault-password')
+        ->call('reauth')
+        ->assertSet('revealedPassword', $credential->fresh()->password);
+});
+
+it('does not reveal the password with a wrong re-auth password', function () {
+    $user = User::factory()->withRole('Vault Manager')->create([
+        'staff_rank' => StaffRank::JrCrew,
+        'password' => bcrypt('correct-password'),
+    ]);
+    $credential = Credential::factory()->create(['created_by' => $user->id]);
+    $this->actingAs($user);
+
+    livewire('vault.detail', ['credential' => $credential])
+        ->set('reauthPassword', 'wrong-password')
+        ->call('reauth')
+        ->assertSet('revealedPassword', null)
+        ->assertSet('reauthError', 'Incorrect password. Please try again.');
+});
+
+it('reveals the password immediately when the vault session is already unlocked', function () {
+    $user = User::factory()->withRole('Vault Manager')->create(['staff_rank' => StaffRank::JrCrew]);
+    $credential = Credential::factory()->create(['created_by' => $user->id]);
+    $this->actingAs($user);
+
+    // Unlock the session before mounting the component
+    session(['vault_unlocked_at' => now()->timestamp]);
+
+    livewire('vault.detail', ['credential' => $credential])
+        ->call('revealPassword')
+        ->assertSet('revealedPassword', $credential->fresh()->password);
+});
+
+it('enforces policy on reveal: position holder can reveal their credential password', function () {
+    $manager = User::factory()->withRole('Vault Manager')->create(['staff_rank' => StaffRank::JrCrew]);
+    $credential = Credential::factory()->create(['created_by' => $manager->id]);
+
+    $jrCrew = User::factory()->create([
+        'staff_rank' => StaffRank::JrCrew,
+        'password' => bcrypt('staff-pass'),
+    ]);
+    $position = \App\Models\StaffPosition::factory()->assignedTo($jrCrew->id)->create();
+    $credential->staffPositions()->attach($position->id);
+    $this->actingAs($jrCrew);
+
+    livewire('vault.detail', ['credential' => $credential])
+        ->set('reauthPassword', 'staff-pass')
+        ->call('reauth')
+        ->assertSet('revealedPassword', $credential->fresh()->password);
+});
+
+// === TOTP display ===
+
+it('shows the TOTP code after successful re-authentication', function () {
+    $user = User::factory()->withRole('Vault Manager')->create([
+        'staff_rank' => StaffRank::JrCrew,
+        'password' => bcrypt('vault-pass'),
+    ]);
+    $credential = Credential::factory()->withTotp()->create(['created_by' => $user->id]);
+    $this->actingAs($user);
+
+    livewire('vault.detail', ['credential' => $credential])
+        ->set('reauthPurpose', 'totp')
+        ->set('reauthPassword', 'vault-pass')
+        ->call('reauth')
+        ->assertSet('totpCode', fn ($code) => (bool) preg_match('/^\d{6}$/', $code))
+        ->assertSet('revealedPassword', null); // should not reveal password when purpose is totp
+});
+
+it('always requires re-auth to show TOTP code even when vault session is unlocked', function () {
+    $user = User::factory()->withRole('Vault Manager')->create([
+        'staff_rank' => StaffRank::JrCrew,
+        'password' => bcrypt('vault-pass'),
+    ]);
+    $credential = Credential::factory()->withTotp()->create(['created_by' => $user->id]);
+    $this->actingAs($user);
+
+    // Unlock the vault session
+    session(['vault_unlocked_at' => now()->timestamp]);
+
+    // showTotp() should set reauthPurpose to 'totp' without showing the code directly
+    livewire('vault.detail', ['credential' => $credential])
+        ->call('showTotp')
+        ->assertSet('totpCode', null)
+        ->assertSet('reauthPurpose', 'totp');
+});
+
+it('refreshes the TOTP code without re-auth', function () {
+    $user = User::factory()->withRole('Vault Manager')->create([
+        'staff_rank' => StaffRank::JrCrew,
+        'password' => bcrypt('vault-pass'),
+    ]);
+    $credential = Credential::factory()->withTotp()->create(['created_by' => $user->id]);
+    $this->actingAs($user);
+
+    $component = livewire('vault.detail', ['credential' => $credential])
+        ->set('reauthPurpose', 'totp')
+        ->set('reauthPassword', 'vault-pass')
+        ->call('reauth');
+
+    $firstCode = $component->get('totpCode');
+
+    // refreshTotp can be called without re-auth
+    $component->call('refreshTotp');
+
+    // The code may or may not change (same 30-second window), but it should still be a 6-digit string
+    expect($component->get('totpCode'))->toMatch('/^\d{6}$/');
+});

--- a/tests/Feature/Policies/CredentialPolicyTest.php
+++ b/tests/Feature/Policies/CredentialPolicyTest.php
@@ -1,0 +1,110 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Enums\StaffRank;
+use App\Models\Credential;
+use App\Models\StaffPosition;
+use App\Models\User;
+
+uses()->group('vault', 'policies');
+
+// === Vault Manager access ===
+
+it('allows Vault Manager to view any credential', function () {
+    $user = User::factory()->withRole('Vault Manager')->create(['staff_rank' => StaffRank::JrCrew]);
+    $credential = Credential::factory()->create(['created_by' => $user->id]);
+
+    expect($user->can('view', $credential))->toBeTrue();
+});
+
+it('allows Vault Manager to update any credential', function () {
+    $user = User::factory()->withRole('Vault Manager')->create(['staff_rank' => StaffRank::JrCrew]);
+    $credential = Credential::factory()->create(['created_by' => $user->id]);
+
+    expect($user->can('update', $credential))->toBeTrue();
+});
+
+it('allows Vault Manager to delete any credential', function () {
+    $user = User::factory()->withRole('Vault Manager')->create(['staff_rank' => StaffRank::JrCrew]);
+    $credential = Credential::factory()->create(['created_by' => $user->id]);
+
+    expect($user->can('delete', $credential))->toBeTrue();
+});
+
+it('allows Vault Manager to manage positions on any credential', function () {
+    $user = User::factory()->withRole('Vault Manager')->create(['staff_rank' => StaffRank::JrCrew]);
+    $credential = Credential::factory()->create(['created_by' => $user->id]);
+
+    expect($user->can('managePositions', $credential))->toBeTrue();
+});
+
+// === Position holder access ===
+
+it('allows position holder to view a credential their position is assigned to', function () {
+    $manager = User::factory()->withRole('Vault Manager')->create(['staff_rank' => StaffRank::JrCrew]);
+    $credential = Credential::factory()->create(['created_by' => $manager->id]);
+
+    $jrCrew = User::factory()->create(['staff_rank' => StaffRank::JrCrew]);
+    $position = StaffPosition::factory()->assignedTo($jrCrew->id)->create();
+    $credential->staffPositions()->attach($position->id);
+
+    expect($jrCrew->can('view', $credential))->toBeTrue();
+});
+
+it('allows position holder to update a credential their position is assigned to', function () {
+    $manager = User::factory()->withRole('Vault Manager')->create(['staff_rank' => StaffRank::JrCrew]);
+    $credential = Credential::factory()->create(['created_by' => $manager->id]);
+
+    $jrCrew = User::factory()->create(['staff_rank' => StaffRank::JrCrew]);
+    $position = StaffPosition::factory()->assignedTo($jrCrew->id)->create();
+    $credential->staffPositions()->attach($position->id);
+
+    expect($jrCrew->can('update', $credential))->toBeTrue();
+});
+
+it('denies position holder from deleting a credential', function () {
+    $manager = User::factory()->withRole('Vault Manager')->create(['staff_rank' => StaffRank::JrCrew]);
+    $credential = Credential::factory()->create(['created_by' => $manager->id]);
+
+    $jrCrew = User::factory()->create(['staff_rank' => StaffRank::JrCrew]);
+    $position = StaffPosition::factory()->assignedTo($jrCrew->id)->create();
+    $credential->staffPositions()->attach($position->id);
+
+    expect($jrCrew->can('delete', $credential))->toBeFalse();
+});
+
+it('denies position holder from managing positions on a credential', function () {
+    $manager = User::factory()->withRole('Vault Manager')->create(['staff_rank' => StaffRank::JrCrew]);
+    $credential = Credential::factory()->create(['created_by' => $manager->id]);
+
+    $jrCrew = User::factory()->create(['staff_rank' => StaffRank::JrCrew]);
+    $position = StaffPosition::factory()->assignedTo($jrCrew->id)->create();
+    $credential->staffPositions()->attach($position->id);
+
+    expect($jrCrew->can('managePositions', $credential))->toBeFalse();
+});
+
+// === No position access ===
+
+it('denies staff member with no assigned position from viewing an unassigned credential', function () {
+    $manager = User::factory()->withRole('Vault Manager')->create(['staff_rank' => StaffRank::JrCrew]);
+    $credential = Credential::factory()->create(['created_by' => $manager->id]);
+
+    $jrCrew = User::factory()->create(['staff_rank' => StaffRank::JrCrew]);
+
+    expect($jrCrew->can('view', $credential))->toBeFalse();
+});
+
+it('denies staff member whose position is not assigned from viewing a credential', function () {
+    $manager = User::factory()->withRole('Vault Manager')->create(['staff_rank' => StaffRank::JrCrew]);
+    $credential = Credential::factory()->create(['created_by' => $manager->id]);
+
+    $jrCrew = User::factory()->create(['staff_rank' => StaffRank::JrCrew]);
+    $otherPosition = StaffPosition::factory()->assignedTo($jrCrew->id)->create();
+    // credential is assigned to a DIFFERENT position
+    $assignedPosition = StaffPosition::factory()->create();
+    $credential->staffPositions()->attach($assignedPosition->id);
+
+    expect($jrCrew->can('view', $credential))->toBeFalse();
+});

--- a/tests/Feature/Services/VaultEncrypterTest.php
+++ b/tests/Feature/Services/VaultEncrypterTest.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Services\VaultEncrypter;
+
+uses()->group('vault', 'services');
+
+it('encrypts and decrypts a string round-trip', function () {
+    $encrypter = app(VaultEncrypter::class);
+
+    $original = 'super-secret-password-123!';
+    $encrypted = $encrypter->encrypt($original);
+
+    expect($encrypted)->not->toBe($original)
+        ->and($encrypter->decrypt($encrypted))->toBe($original);
+});
+
+it('produces different ciphertext for the same plaintext', function () {
+    $encrypter = app(VaultEncrypter::class);
+
+    $a = $encrypter->encrypt('same-value');
+    $b = $encrypter->encrypt('same-value');
+
+    expect($a)->not->toBe($b);
+});
+
+it('throws a RuntimeException when VAULT_KEY is not set', function () {
+    config(['vault.key' => null]);
+
+    new VaultEncrypter;
+})->throws(RuntimeException::class);

--- a/tests/Feature/Services/VaultSessionTest.php
+++ b/tests/Feature/Services/VaultSessionTest.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Services\VaultSession;
+
+uses()->group('vault', 'services');
+
+it('is locked by default', function () {
+    $session = app(VaultSession::class);
+
+    expect($session->isUnlocked())->toBeFalse();
+});
+
+it('is unlocked after calling unlock()', function () {
+    $session = app(VaultSession::class);
+    $session->unlock();
+
+    expect($session->isUnlocked())->toBeTrue();
+});
+
+it('is locked after calling lock()', function () {
+    $session = app(VaultSession::class);
+    $session->unlock();
+    $session->lock();
+
+    expect($session->isUnlocked())->toBeFalse();
+});
+
+it('is locked when vault_unlocked_at is older than TTL', function () {
+    $ttl = (int) config('vault.session_ttl_minutes', 30);
+    $expiredTimestamp = now()->subMinutes($ttl + 1)->timestamp;
+
+    session(['vault_unlocked_at' => $expiredTimestamp]);
+
+    $session = app(VaultSession::class);
+
+    expect($session->isUnlocked())->toBeFalse();
+});
+
+it('is unlocked when vault_unlocked_at is within TTL', function () {
+    $ttl = (int) config('vault.session_ttl_minutes', 30);
+    $recentTimestamp = now()->subMinutes($ttl - 1)->timestamp;
+
+    session(['vault_unlocked_at' => $recentTimestamp]);
+
+    $session = app(VaultSession::class);
+
+    expect($session->isUnlocked())->toBeTrue();
+});


### PR DESCRIPTION
* PRD #453: Public Contact Us Form with Guest Conversation Thread (#461)

* feat: add ContactInquiry enum, schema columns, and role seed #454

- Add ThreadType::ContactInquiry = 'contact_inquiry' with label
- Migration: add guest_name, guest_email, conversation_token (unique) to threads
- Migration: add guest_email_sent (nullable boolean) to messages
- Migration: seed 'Contact - Receive Submissions' role (idempotent)
- Thread model: add guest_name, guest_email, conversation_token to fillable
- Message model: add guest_email_sent to fillable and casts

Closes #454



* feat: add site footer with Contact Us link and copyright #455

- New partials/footer.blade.php: copyright line and /contact link, styled with Flux UI zinc/border design language
- Included in layouts/app/sidebar.blade.php after the main slot, so it appears on every page

Closes #455



* feat: contact form, CreateContactInquiry action, and guest-nullable migrations #456

- Added /contact route (public, no auth required) with Volt component
- CreateContactInquiry action: creates ContactInquiry thread with UUID token, sends confirmation email to guest, notifies staff with "Contact - Receive Submissions" role (plus admins), adds staff as participants, logs activity
- ContactSubmissionConfirmationNotification (mail-only) sent to guest email
- NewContactInquiryNotification (multi-channel) sent to staff via TicketNotificationService
- Honeypot hidden field silently rejects bot submissions
- IP rate limiting: max 5/hour per IP
- Conditional hCaptcha: verified when HCAPTCHA_SITE_KEY/SECRET_KEY env vars present
- Migration: make threads.created_by_user_id nullable (guest threads have no user)
- Migration: make messages.user_id nullable (guest messages have no user)
- Added hcaptcha service config and .env.example keys

Closes #456



* feat: contact inquiry staff list view with gate, route, and sidebar nav #457

- Added view-contact-inquiries gate (hasRole 'Contact - Receive Submissions', admins via hasRole override)
- Added /contact-inquiries route group (auth + can:view-contact-inquiries middleware)
- Created contact/inquiry-list Volt component: lists ContactInquiry threads sorted by last activity, Open/Closed filter tabs, unread indicator, category badge extracted from subject prefix, guest name/email/status display
- Added Contact Inquiries nav item to sidebar under Management group (canany updated)
- 11 new tests covering access control, list rendering, filtering, sorting, and unread indicators

Closes #457



* feat: staff reply composer, guest email dispatch, and thread detail view #458

- SendGuestConversationEmail action: dispatches ContactGuestReplyNotification to guest_email, sets guest_email_sent=true
- ContactGuestReplyNotification: mail-only notification sent to guest on staff reply with email ON
- contact-guest-reply mail template: shows staff reply body, conversation link, instructions not to reply by email
- Added GET /contact-inquiries/{thread} route
- Created contact/view-inquiry Volt component:
  - Thread header: subject (category stripped), category badge, guest name/email, status, created-at
  - Status management: select dropdown + Update Status button (Resolved, Closed, etc.)
  - Message list: guest messages (blue), staff replies (zinc, with emailed badge if guest_email_sent), internal notes (amber with Internal Note badge)
  - Reply composer: Reply/Internal Note toggle (Flux radio segmented), Email guest checkbox (visible on Reply only, default ON)
  - Submitting reply with emailGuest=true calls SendGuestConversationEmail
  - Submitting reply with emailGuest=false saves without emailing (guest_email_sent=false)
  - Internal notes skip email and are saved as MessageKind::InternalNote
  - Reply form hidden when thread is Closed or Resolved
- 18 new tests; full suite: 2501 passed

Closes #458



* feat: guest conversation page at /contact/thread/{token} #459

- Added public route GET /contact/thread/{token} -> contact.guest-thread
- contact/guest-thread Volt component:
  - Resolves thread by conversation_token (returns 404 if not found)
  - Internal notes excluded at query level (not client-side filtering)
  - Messages displayed chronologically: guest messages (blue, attributed to guest_name), staff messages (zinc, attributed to staff display name)
  - Open/Pending: reply form shown; guest reply creates MessageKind::Message with guest_email_sent=false, notifies staff participants via TicketNotificationService
  - Closed/Resolved: reply form hidden, closed banner shown with link to /contact
  - No authentication required
- 14 tests covering: public access, 404 on invalid/missing token, message order, internal note exclusion, open/pending reply form, closed/resolved banner, guest reply creation, staff notification, message attribution

Closes #459



* feat: link contact inquiry threads to user on registration #460

When a user registers with an email that matches a ContactInquiry guest_email, they are automatically added as a participant on those threads via LinkContactThreadsOnRegistration action.

Closes #460



* docs: add technical reference for contact-us-form feature #453



* docs: add user handbook pages for contact-us-form #453

Added two new pages to the Getting Help chapter covering the public Contact Us form and the guest conversation thread. Updated the chapter _index.md to mention both support options.



* docs: add staff handbook pages for contact-us-form #453



* fix: address CodeRabbit feedback on PRD #453 (round 1)



* fix: address CodeRabbit feedback on PRD #453 (round 2)



* fix: use correct app layout for contact form and guest thread

Both components were using components.layouts.app.sidebar directly, bypassing the flux:main wrapper that provides sidebar offset. Changed to components.layouts.app which wraps content in flux:main.

Also removed dead <x-slot name="header"> from contact form (the sidebar layout has no $header slot).



* fix: move footer into flux:main so it spans the content column correctly

Footer was placed at the body level in sidebar.blade.php, outside the flux:main wrapper, causing it to be squished by the sidebar CSS. Moved it into app.blade.php inside flux:main so it stays in the content column alongside the header and page content.



* fix: sticky footer — push footer to bottom on short pages

Made flux:main a flex column container with flex-1 on the page content wrapper, so the footer stays at the bottom of the viewport on pages that don't fill the full screen height.



* feat: surface contact inquiries in Discussions page

Adds a Contact Inquiries tab to the Discussions page for users with the view-contact-inquiries gate. Shows open/pending inquiries with guest name, category, unread indicator, and links to the existing detail view.

Removes the dedicated Contact Inquiries nav item from the sidebar since staff can now access them from Discussions.



* fix: address CodeRabbit feedback on PRD #453 (round 3)



---------



* fix: match contact inquiry UI to discussions chat style, fix back button (#462)

- Replaced card-style message rendering in view-inquiry with chat-bubble layout matching view-topic (chat-message-start/end, chat-bubble, avatars)
- Guest messages show left-aligned blue bubble with initial-based avatar
- Own staff replies show right-aligned cyan bubble; others left neutral
- Internal notes show left-aligned amber bubble with badge (unchanged visually)
- Added #[Url] to \$filter in topics-list so /discussions?filter=contact works
- Changed "Back to Inquiries" button from contact-inquiries.index to discussions.index?filter=contact so staff land on the correct tab

Closes #453 (test feedback)



* fix: rename honeypot property to website to avoid bot detection (#463)

* fix: rename honeypot property to website to avoid bot detection

The wire:model="honeypot" attribute was visible in HTML source, tipping off bots that could be programmed to skip fields named "honeypot". Renaming to "website" makes it indistinguishable from a normal optional field.



* fix: update ContactFormTest to use renamed website property

Follows up the honeypot→website rename.



---------



* fix: address CodeRabbit feedback on PR #464 (#465)

- Use unsignedBigInteger()->change() instead of foreignId()->change() in both nullable migrations to preserve FK constraints correctly
- Add server-side status guard in sendReply() so stale tabs cannot append messages to closed/resolved contact inquiries
- Remove Resolved from Discussions contact tab filter so it matches the main inquiry queue (both now only hide Closed threads)
- Add test for server-side sendReply guard on closed threads



* PRD: Ministry Finance Tracking System (#466) (#483)

* feat: create financial system table migrations #467

Seven migrations: financial_accounts, financial_categories (with parent/child hierarchy), financial_tags, financial_transactions (income/expense/transfer with nullable category for transfers), financial_transaction_tags pivot, monthly_budgets (unique per category+month), and financial_period_reports (unique per month).



* feat: seed financial accounts, categories, and roles #467

Seed migration creates four accounts (Cash, Stripe, RelayFi Checking, RelayFi Savings) and all expense/income categories with correct parent/child relationships. Second migration seeds three financial roles (Financials - View, Treasurer, Manage) for gate assignment.



* feat: create Eloquent models for financial system #467

Seven models with correct fillable fields, casts, and relationships: FinancialAccount (hasMany transactions/incomingTransfers), FinancialCategory (self-referential parent/children hierarchy, hasMany transactions and budgets), FinancialTag (belongsToMany transactions), FinancialTransaction (belongsTo account/category/targetAccount/enteredBy, belongsToMany tags), FinancialTransactionTag (Pivot), MonthlyBudget (belongsTo category), FinancialPeriodReport (belongsTo publishedBy, isPublished helper).



* feat: add financial gates with hierarchy and tests

Closes #467

Three gates in AuthServiceProvider: financials-view (View|Treasurer| Manage), financials-treasurer (Treasurer|Manage), financials-manage (Manage only). Higher tiers imply lower tiers. 18 gate hierarchy tests verify all grant/deny combinations.



* feat: add financial account actions #468

CreateFinancialAccount, UpdateFinancialAccount, ArchiveFinancialAccount action classes following AsAction pattern.



* feat: add currentBalance() to FinancialAccount model #468

Computes opening_balance + income credits - expense debits - transfers out + transfers in. Transfers are stored as single transaction records with source account_id and target_account_id; balance query handles both sides correctly.



* feat: account management UI, route, factories, and tests

Closes #468

finances.accounts Volt component lets financials-manage users create, rename, and archive accounts. Account list shows computed current balance for each account. Route /finances/accounts requires financials-view; manage actions gate-checked in component. Archived accounts show a badge. FinancialAccount and FinancialTransaction factories added. 14 tests cover balance calculation (opening, income, expense, transfer debit/credit) and authorization (manage/view/none).



* feat: add category and tag action classes #469

CreateFinancialCategory (enforces no sub-subcategory constraint, auto-assigns sort_order), UpdateFinancialCategory (rename), ArchiveFinancialCategory, ReorderFinancialCategory (set sort_order), CreateFinancialTag, ArchiveFinancialTag.



* feat: category & tag management UI, route, factories, and tests

Closes #469

finances.categories Volt component: two sections (Categories and Tags), each with create/archive. Categories show top-level + indented subcategories grouped by expense/income type, each with rename/ reorder/archive actions. Tags show name and archived status with archive button. All manage actions gate-checked. /finances/categories route added. FinancialCategory and FinancialTag factories added. 14 tests cover hierarchy constraint (no sub-subcategory), sequential sort_order assignment, CRUD operations, and authorization for all five manage operations.



* feat: add RecordFinancialTransaction action #470

Records income or expense transaction with account, amount, date, category, optional notes, and optional tag sync via pivot table.



* feat: finance dashboard, transaction entry form, and ready room button

Closes #470

finances.dashboard Volt component: account balance cards for all active accounts, entry form gated behind financials-treasurer showing type/account/amount/date/category (filtered by type)/optional subcategory/multi-checkbox tags/notes. Category dropdown updates live when type changes. Route /finances/dashboard added. Finance button added to Staff Ready Room top bar, gated behind financials-view. 11 tests cover income/expense recording, balance updates, subcategory resolution, tag attachment, view-vs-treasurer authorization, route access, and ready room button visibility.



* feat: transaction ledger with filtering, edit, and delete #471

- Add isInPublishedMonth() to FinancialTransaction model using whereDate() to correctly handle date column stored as datetime in SQLite
- Create UpdateFinancialTransaction action with published-month guard
- Create DeleteFinancialTransaction action with published-month guard
- Rewrite finances.dashboard component to include full ledger:
  - Filters: date range (from/to), account, category (incl. subcategories), tag
  - Edit modal with full field set and tag sync
  - Delete with confirmation; both guard against published months via toast
  - Edit/delete buttons hidden for published-month rows in the UI
- Create FinancialPeriodReportFactory with published() and forMonth() states
- Add 13 tests covering filtering logic, edit/delete auth, and published-month immutability

Closes #471



* feat: transfer transaction type between accounts #472

- Add targetAccountId field to RecordFinancialTransaction action
- Update finances.dashboard component:
  - Add Transfer option to type selector
  - Show "To Account" selector only for transfers
  - Hide category/tag fields for transfers
  - Show "From → To" account names for transfers in ledger
  - Show neutral zinc badge for Transfer type
  - Validate source != destination (different:accountId rule)
- 7 tests covering: record transfer, balance math (source debit, destination credit), same-account rejection, missing target rejection, exclusion from category filter, and ledger display

Closes #472



* feat: monthly budget entry with pre-fill and variance #473

- Add SaveMonthlyBudget action (upserts category/month/amount rows)
- Create finances.budget Livewire Volt page at /finances/budget/{month?} with month navigation (prev/next), per-category planned/actual/variance table, and treasurer-only save button
- Pre-fill logic: when no budget rows exist for the selected month, load planned amounts from the previous month as editable defaults
- Actual amounts include transactions in subcategories of the top-level category and are scoped to the selected month
- Fix date:Y-m-d cast on MonthlyBudget and FinancialPeriodReport models so dates are stored as Y-m-d (not Y-m-d H:i:s), enabling updateOrCreate to correctly match existing rows without unique constraint violations
- Add MonthlyBudgetFactory with forMonth() and forCategory() states
- 14 tests covering navigation, pre-fill, save/update, auth, variance calculation, subcategory aggregation, and month scoping

Closes #473



* feat: 3-month rolling trend column in budget view #474

- Add publishedMonths() helper to budget component — fetches the 3 most recently published FinancialPeriodReport month dates
- Add trendForCategory(int $categoryId) — sums actuals per category (including subcategories) across published months and returns the average; returns null when no published months exist
- Update budgetRows() to include 'trend' key
- Add "3-Mo Trend" column to the budget table; shows "—" when null
- 5 new tests: null when no published months, 1-month average, 2-month average, exactly-3-month cap (4 published months → uses 3 most recent), unpublished months excluded from trend

Closes #474



* feat: period report publishing and immutability #475

- Create PublishPeriodReport action: validates no existing published report for the month and at least one transaction exists; creates/updates the FinancialPeriodReport record with published_at and published_by
- Create finances.reports Livewire Volt page at /finances/reports:
  - Table listing all months that have transactions (newest first)
  - Shows total income, expenses, net change, and published/unpublished status
  - Treasurer sees a "Publish Report" button for unpublished months
  - Clicking opens a pre-publish summary modal with: income/expense/net totals, account balances as of end of month, and budget variance per category (planned vs actual)
  - Confirming calls PublishPeriodReport; handles double-publish gracefully with a toast error
- Add /finances/reports route
- 11 tests covering route access, action publish/fail/double-publish, component publish flow, view-only auth enforcement, and end-to-end immutability of edit/delete for transactions in published months

Closes #475



* feat: period report staff view and PDF download #476

- Install barryvdh/laravel-dompdf for PDF generation
- Create finances/period-report-pdf.blade.php: a clean PDF template with summary totals, account balances, budget variance, and transactions by category (styled for DomPDF with DejaVu Sans font)
- Create PeriodReportPdfController: route handler at /finances/reports/{month}/pdf that validates the month is published, builds the full summary, and returns a downloadable PDF
- Update finances.reports component:
  - View-only users now see only published months (filtered from FinancialPeriodReport records rather than all months with transactions)
  - Treasurers still see all months (published + unpublished) for management
  - Add "View" button (opens detail modal) and "PDF" button for published rows
  - Add view-report-modal showing the full period breakdown inline
  - Unpublished rows show "Publish" button for treasurers only
- 6 tests: view-only sees only published months, treasurer sees all, view modal opens correctly, PDF download 200/404 for pub/unpub months, unauthenticated redirect

Closes #476



* feat: add Income Statement board report for financials-manage users #477

- New Volt component finances.board-reports with custom date range and trimester quick-select presets (T1 Jan-Apr, T2 May-Aug, T3 Sep-Dec)
- Income/expense breakdown by top-level category with subcategory detail
- Transfers excluded from all totals
- PDF download via IncomeStatementPdfController (Gate::allows check)
- Routes: /finances/board-reports and /finances/board-reports/income-statement/pdf
- 17 tests covering auth, category totals, transfer exclusion, date range, trimesters, PDF

Closes #477



* feat: add Balance Sheet and Cash Flow board reports #478

- Extended finances.board-reports Volt component with balanceSheet() and cashFlow() methods sharing the same date range and trimester controls
- Balance Sheet: account balances as of end-of-period including transfers, opening balances; net assets total
- Cash Flow Statement: operating activities (income/expense by category) and financing activities (inter-account transfers listed individually); transfers excluded from net change to avoid double-counting
- BalanceSheetPdfController: GET /finances/board-reports/balance-sheet/pdf?end=Y-m
- CashFlowPdfController: GET /finances/board-reports/cash-flow/pdf?start=Y-m&end=Y-m
- Blade PDF templates for both reports using DomPDF / DejaVu Sans
- 13 tests: balance math with opening balance and transfers, date boundary, financing section content, transfer exclusion from net, PDF auth (manage/treasurer/unauthed)

Closes #478



* feat: add finance red flag to staff meeting page #479

- financeRedFlag() method on manage-meeting component checks whether any FinancialPeriodReport has published_at within the last 14 days
- When no recent report exists, a red callout banner "Finance Report Overdue" appears at the top of the meeting page for all authenticated staff
- Banner includes a link to the finance dashboard for users with financials-view
- 6 tests: flag shows when no reports, shows when last report >14 days ago, hides when report published within 14 days, hides when published today, method returns true/false correctly

Closes #479



* feat: add public /finances transparency page #480

- New Volt component finances.public at GET /finances (no auth required)
- Three visibility tiers:
  - Public/unauthenticated: income total, expense total, net per published month + YTD
  - Resident+: above + top-level income/expense category breakdown per month
  - financials-view staff: above + subcategory breakdown with transaction counts
- Only published FinancialPeriodReport months ever appear; unpublished data is never shown
- Year-to-date summary card at top (current year, published months only)
- Empty state when no months published yet
- 10 tests: public access, unpublished exclusion, tier visibility (public/resident/staff), YTD published-only, empty state

Closes #480



* docs: add technical and user documentation for Ministry Finance Tracking System

- Technical reference doc: docs/features/Ministry Finance Tracking System.md Covers all 7 tables, 14 actions, 7 Volt components, 4 PDF controllers, 3 authorization gates, 11 routes, 12 test files (113 tests), and 18 known issues/improvement opportunities
- User handbook: resources/library/books/user-handbook/03-website/09-finances/
  - _index.md: Financial Transparency section intro (public)
  - 01-financial-transparency.md: Explains the public /finances page, visibility tiers, and why Lighthouse publishes financial data



* docs: add staff handbook pages for Ministry Finance Tracking System

Covers all three permission tiers (view, treasurer, manage) with 7 content pages: access overview, ledger viewing, recording transactions, monthly budgets, period reports, board reports, and managing accounts/ categories/tags.



* fix: replace SQLite-only strftime with cross-database month expression for PRD #466

The reports page used strftime('%Y-%m', transacted_at) to enumerate distinct months, which is SQLite-only syntax. CI runs PostgreSQL where this function does not exist. Replace with a DB::getDriverName() match expression that uses to_char() on pgsql, DATE_FORMAT() on mysql, and strftime() as the SQLite default.



* fix: address CodeRabbit feedback on PR #483 for PRD #466

- UpdateFinancialTransaction: add target_account_id param, clear financial_category_id on transfer type change, block moving transaction dates into published months
- reports: remove is_archived filter from summaryForMonth accounts and categories queries so archiving doesn't silently drop rows from historical published reports
- reports: fix income variance sign (actual - planned, not planned - actual) so beating an income target shows green
- reports: openViewModal now 404s if the requested month is not published, closing the server-side authorization gap
- reports: closeViewModal/closePublishModal methods clear Livewire state before closing to prevent stale summaryForMonth re-renders
- Tests: add coverage for moving tx date into published month, and openViewModal 404 for unpublished month



* fix: address CodeRabbit round 2 feedback on PR #483 for PRD #466

- dashboard: hide Edit button for transfer transactions in ledger; add server-side guard in openEditModal to reject transfers with a toast (transfers must be deleted and re-entered)
- reports: add #[Locked] to viewMonth and publishMonth properties to prevent browser-side mutation via $wire — defense-in-depth alongside the server-side published checks added in the previous commit
- tests: remove dead call('updateTransaction', [...]) in ledger test (updateTransaction() reads component properties, not method args)
- tests: update publish flow tests to use openPublishModal() instead of direct property sets, which are now blocked by #[Locked]



---------



* fix: resolve parent portal crash when viewing as staff admin (#485)

User::getRouteKeyName() returns 'slug', so the parent-portal.show route generates URLs like /parent-portal/torgan. The mount() method was passing that slug directly to User::findOrFail() which queries by primary key (integer), causing a bigint type mismatch on PostgreSQL.

Fixed by using User::where('slug', $user)->firstOrFail() to look up by the route key that the URL actually contains.

Fixes #481



* fix: address test feedback for PRD: Ministry Finance Tracking System (#466) round 2 (#490)

* fix: add finance navigation bar to all finance pages

Adds a consistent nav bar at the top of each finance page (dashboard, budget, reports, board-reports, accounts, categories) so users with financials-manage can navigate directly to account and category management. Manage-gated pages (board-reports, accounts, categories) are hidden from users who only have financials-view/treasurer.

Fixes #487



* feat: snapshot published report summaries to survive account/category renames

When a period is published via PublishPeriodReport, compute and store a JSON snapshot of the report payload (income, expense, net, account balances, budget variances) in summary_snapshot on financial_period_reports.

summaryForMonth() now returns the snapshot directly for published months instead of running live queries, so renaming an account or category after publication does not silently alter historical report display.

Unpublished months still use live queries (pre-publish preview remains accurate). Tests verify snapshot is stored at publish time and that post-publication renames do not affect the returned summary.

Fixes #484



* fix: cast sum() results to int in FinancialAccount::currentBalance()

PostgreSQL returns sum() as a string (bigint text) which PHP arithmetic can promote to float, causing a TypeError on the int return type. Added (int) casts to credits, debits, transfersOut, and transfersIn to match the pattern already used in summaryForMonth().

Fixes #489



* fix: add clarifying comment about archived accounts in snapshot computation



---------



* fix: address test feedback for PRD: Ministry Finance Tracking System (#466) round 3 (#503)

* fix: make Staff Ready Room buttons wrap below title on mobile

Fixes #498



* fix: update fiscal year to start in October for board report trimesters

T1: Oct–Jan, T2: Feb–May, T3: Jun–Sep. Updated mount() default, applyTrimester() logic, button labels, and trimester preset tests.

Fixes #497



* fix: convert Record Transaction form to a modal on Finance Dashboard

Replaced the always-visible form card with an "Add Transaction" button that opens a flux:modal. Modal closes automatically after a successful save or when the user clicks Cancel.

Fixes #492



* fix: accept dollar-format amounts on transaction form, convert to cents on save

Amount field now accepts '10.00', '10', '9.99' etc. Component converts to integer cents (round * 100) before passing to actions. Edit modal pre-fills the stored cents value as formatted dollars. Updated all transaction tests to use dollar strings.

Fixes #493



* fix: always show tags field on transaction form, add Manage Tags section to dashboard

Tags field now always visible for non-transfer transactions (no longer hidden when no tags exist). Added a Manage Tags card to the Finance Dashboard for financials-manage users to create and archive tags without navigating away.

Fixes #494



* fix: replace two-step category cascade with flat grouped dropdown

Single select shows all non-archived categories/subcategories grouped by parent using <optgroup>. No more loading delay or dependent selects. Edit modal pre-selects the stored category ID directly. Updated all tests to drop subcategoryId references.

Fixes #495



* fix: allow Ticket-Manager to see department tickets, allow assignee to view assigned ticket

Two visibility bugs:
1. viewDepartment gate required Ticket-User but not Ticket-Manager — a department manager without Ticket-User could not see their dept's tickets. Fixed by including Ticket-Manager in the viewDepartment policy check.
2. isVisibleTo() checked participants but not assigned_to_user_id — a staff member assigned to a ticket who was not yet a participant got Access Denied. Fixed by adding an assigned_to_user_id check before the participant check.

Fixes #500



* feat: add organization field to transactions with searchable create-or-select modal

- Add financial_organizations table and FinancialOrganization model
- Add organization_id nullable FK on financial_transactions
- CreateFinancialOrganization and ArchiveFinancialOrganization actions
- Organization picker modal on dashboard (search + create-inline)
- Edit transaction modal supports org picker and clear
- Manage Organizations card for financials-manage users (archive)
- Organization column in transaction ledger
- 13 tests covering CRUD, picker, auth rules

Fixes #499



* fix: address CodeRabbit feedback on PR #503

- ArchiveFinancialOrganization: add RecordActivity audit log entry
- CreateFinancialOrganization: add RecordActivity audit log entry
- RecordFinancialTransaction: normalize transfer-only fields on create (financial_category_id, organization_id, target_account_id) to match the same invariant already enforced in UpdateFinancialTransaction
- dashboard openEditModal: always clear editOrganizationId/Name/Search before hydrating, preventing stale org from bleeding into next edit



* fix: resolve org name server-side in selectOrganization/selectEditOrganization

Pass only the ID in wire:click buttons and look up the name via FinancialOrganization::findOrFail() instead of passing raw strings through wire:click attributes (which were escaped with addslashes — fragile for names with special characters).



* perf: cache tags and organizations as computed properties

Add #[Computed] to tags() and organizations() methods so Livewire caches the DB query result per render cycle instead of re-running it on every call. tags() was called 5 times per render, organizations() twice — each as a fresh DB query. Update all blade call sites from method syntax ($this->tags()) to property syntax ($this->tags).



---------



* fix: address test feedback for PRD: Ministry Finance Tracking System (#466) round 4 (#506)

* fix: show explanation for transfers in ledger action column instead of no button

Transfers cannot be edited (delete and re-enter if needed), but the missing edit button gave no indication of this. Now shows a subtle text label explaining the constraint so users understand why the edit button is absent.

Fixes #505



* fix: fix Add Transaction modal button and remove Manage Tags section

- Add openRecordTransactionModal() PHP method that calls Flux::modal()->show() (the JS wire:click=$flux.modal().show() pattern does not work in Volt)
- Change Add Transaction button wire:click to call the PHP method
- Remove the Manage Tags section from the dashboard entirely



* fix: rename Categories button, fix Add Organization modal buttons

- Rename 'Categories' nav button to 'Categories & Tags'
- Fix 'Add Organization' buttons in Record Transaction and Edit Transaction modals to use PHP methods instead of broken JS wire:click pattern



---------



* fix: address test feedback for PRD: Ministry Finance Tracking System (#466) round 5 (#508)

* fix: include admin tickets in parent portal child ticket list

Admin tickets are created by staff with the child as a participant, not the creator. Broadened the query to include threads where any child is a participant, and map tickets to children via participant record when the child is not the creator.

Fixes #502



* fix: move Manage Organizations to Categories & Tags page, add Organization ledger filter

- Remove Manage Organizations section from Finance Dashboard
- Add Organizations management section to Categories & Tags page (shows all orgs including archived, with archive action)
- Add Organization filter dropdown to Transaction Ledger
- Rename "Categories" nav button to "Categories & Tags" on categories page
- Update organization archive tests to use finances.categories component

Fixes #507



* feat: send AccountLinkedNotification to parent and User - Manager staff

When a Minecraft or Discord account is linked:
- Notify parent via mail (unconditional)
- Notify staff with 'User - Manager' role via their staff_alerts preferences

Notification includes account name, type, and full counts of active/disabled Minecraft and Discord accounts for the user.

Fixes #504



---------



* fix: address test feedback for PRD: Ministry Finance Tracking System (#466) round 6 (#514)

* fix: populate edit amount field, inline filters, transfer tooltip

- #511: use number_format with no thousands separator so type=number inputs correctly display values like $1,000.00 (comma made field blank)
- #512: move Tag and Organization filters into the same grid as date/account/ category; 6-col on desktop, 2-col on tablet, 1-col on mobile
- #509: replace inline transfer-cannot-be-edited text with a disabled Edit button wrapped in a Flux tooltip

Fixes #511
Fixes #512
Fixes #509



* fix: block archiving a financial account with a non-zero balance

ArchiveFinancialAccount::handle() now throws a RuntimeException if currentBalance() != 0, preventing funds from being locked in an archived account. The archiveAccount() method in accounts.blade.php catches the exception and surfaces the message as a danger toast.

Fixes #510



---------



* fix: address test feedback for PRD: Ministry Finance Tracking System (#466) round 7 (#518)

* feat: convert period reports modal into dedicated detail page #491

- Add GET /finances/reports/{month} route for report detail page
- New finances.reports.show Volt component with transaction list, publish button (unpublished/treasurer), and PDF button (published)
- Add sequential publish guard to PublishPeriodReport action — blocks publishing a month when earlier months have unpublished transactions
- Strip reports.blade.php of view/publish modals; month column is now a link
- Update existing tests to use the new detail-page component
- Add ReportDetailPageTest with full coverage of access control, content, publish flow, sequential guard, and edit/delete on detail page

Closes #491



* fix: wrap disabled Transfer Edit button in span so tooltip renders #517

Flux UI tooltips do not display on disabled buttons. Wrapping the disabled button in an inline span allows the tooltip to attach to the parent element and display correctly on hover.

Fixes #517

* feat: add Open Admin Ticket action to user profile Actions dropdown #516

Adds a menu item in the Actions dropdown on the user profile page that navigates to the create-admin-ticket page with the user pre-filled via the existing user_id query parameter. Only visible to staff with the createAsStaff Thread policy and not shown when viewing your own profile.

Fixes #516

* feat: replace Edit Transaction tag checkbox list with modal-based tag picker #513

The tags field in the Edit Transaction modal now uses the same button → modal → search/create flow as the Organization picker. Tags and Organization buttons sit side by side in one row. Selected tags render as flux:badge elements with inline × removal. A new edit-tag-picker modal supports live search, tag selection (no dupes), and inline tag creation. Adds five new tests covering the tag picker methods.

Fixes #513

* fix: address CodeRabbit review for PRD #466

- Apply inline-flex span wrapper to disabled Transfer Edit button on report detail page, matching the dashboard pattern from #517 (tooltip on disabled elements requires a non-disabled parent wrapper)
- Replace flat checkbox tag list in detail-page Edit Transaction modal with button->modal->search/create picker matching the dashboard pattern from #513: selected tags render as badge pills with x removal, openEditTagPickerModal / selectEditTag / removeEditTag / createEditTagInline / filteredEditTags added
- Add editTagSearch property and include it in openEditModal and updateTransaction resets

Not fixed: N+1 query concern in summary() — tracked in #519 for separate refactor



---------



* Revert "fix: address test feedback for PRD: Ministry Finance Tracking System …" (#521)

This reverts commit 0e2b20a0dfe711efc18dbeda04dc06b44126bb77.

* Revert "fix: address test feedback for PRD: Ministry Finance Tracking System …" (#522)

This reverts commit 463f0e710bf2de55ce8382e22a89fd347a91a099.

* Revert "fix: address test feedback for PRD: Ministry Finance Tracking System …" (#523)

This reverts commit f5f95a9ed2e51d7722c2d1abc070ffe8ae11453e.

* Revert "fix: address test feedback for PRD: Ministry Finance Tracking System …" (#524)

This reverts commit 43d9c4d7e33ba057fcfe343db3db3e33fc005496.

* Revert "fix: address test feedback for PRD: Ministry Finance Tracking System …" (#525)

This reverts commit f3562dbeb8a3023c8f20bf36550ce5007d3d421f.

* Revert "fix: address test feedback for PRD: Ministry Finance Tracking System …" (#526)

This reverts commit 58aac18b752ef8cc99657d555d562107eafab0e4.

* Revert "fix: resolve parent portal crash when viewing as staff admin (#485)" (#527)

This reverts commit 095c08d57b1568fa51f1948e933d5b82be876443.

* Revert "PRD: Ministry Finance Tracking System (#466) (#483)" (#528)

This reverts commit 2bfa73bdc3683a2ea576287ad3f6bb4dde660c68.

* PRD: Double-Entry Accounting Ledger System (#529) (#544)

* feat: finance infrastructure — schema, roles, gates & chart of accounts #530

Adds the full database schema for the double-entry accounting system (11 tables), seeds the standard nonprofit chart of accounts (16 accounts, codes 1000–5060), creates three Finance roles (View/Record/Manage), defines tiered authorization gates, and implements the Chart of Accounts management UI with add/deactivate/reactivate support for Finance - Manage users. FY start month seeded to SiteConfig (default: October/10).

Closes #530



* feat: fiscal periods — auto-generation & list view #531

Adds GenerateFinancialPeriods action that idempotently creates 12 monthly periods for a given FY (e.g. Oct 2025–Sep 2026 for FY 2026 with Oct start). Uses SiteConfig finance_fy_start_month; safe to call multiple times. Adds fiscal periods list page at /finance/periods showing current FY periods with status badges (Open/Reconciling/Closed) and closed-date + closer name for closed periods. Prior FY periods displayed in a collapsed section.

Closes #531



* feat: add vendor/tag management pages and inline search modals #532

- Vendor management: create, deactivate, reactivate vendors (Finance - Manage)
- Tag management: create, edit, delete tags with color support (Finance - Manage)
- Vendor search modal: search-or-create with active vendor filtering
- Tag search modal: search-or-create with multi-select exclusion support
- Both modals dispatch events (vendor-selected / tag-selected) to parent components
- 22 tests covering all CRUD operations and modal behaviour

Closes #532



* feat: simple journal entries with income/expense/transfer forms and list view #533

- ParseDollarAmount action: parse "10", "10.0", "10.00", "0.99" to integer cents
- CreateJournalEntry action: auto-generates correct debit/credit lines per type
  - Income: Debit bank account / Credit revenue account
  - Expense: Debit expense account / Credit bank account
  - Transfer: Debit to-account / Credit from-account
- PostJournalEntry action: validates balance, period open, posts entry as immutable
- create-journal-entry Volt component: income/expense/transfer form with preview
  - Vendor selection via modal (#532), tag multi-select via modal (#532)
  - Save as draft or Preview→Post flow
  - Blocks posting to closed periods
- journal-entries Volt component: paginated list with filters by date, type, account, vendor, tag
- Routes: /finance/journal and /finance/journal/create
- 25 tests covering all acceptance criteria

Closes #533



* feat: budget management with FY grid entry, copy prior year, and variance report #534

- CopyPriorYearBudgets action: copies all budget amounts from one FY to another
- budgets Volt component: inline editable grid (revenue/expense × 12 months) with FY totals
  - Finance - Manage users can type amounts per cell; saved immediately on change
  - "Copy from prior year" button pre-fills from last FY's budgets
  - Budget vs. Actual tab shows budgeted + posted actuals side-by-side per month
  - Variance color-coded green (on/under budget) vs red (over budget)
- Route: /finance/budgets
- 13 tests covering CRUD, copy logic, variance calculation, draft exclusion

Closes #534



* feat: manual journal entries and reversing entry workflow #535

- CreateReversingEntry action: inverts debit/credit lines, sets reverses_entry_id, saves as draft
- FinancialJournalEntry: added reversedBy() HasOne relationship
- create-manual-entry Volt component: N-line form with running debit/credit totals and balance indicator
  - Balance validation blocks posting when debits ≠ credits
  - Save as draft or post directly
  - Route: /finance/journal/create/manual
- journal-entries list: added reverse() method + "Reverse" button on posted entries
  - Shows "Reverses #ID" / "Reversed by #ID" links in Lines column
  - Finance - View users cannot trigger reversals
- 12 tests covering all acceptance criteria

Closes #535



* feat: restricted funds management, designation, and balance summary #536

- FinancialRestrictedFundFactory with inactive state
- restricted-funds Volt component: create, edit, deactivate, reactivate funds (Finance - Manage)
  - Balance summary per fund: received/spent/remaining from posted entries
  - Inactive fund toggle
  - Route: /finance/restricted-funds
- create-journal-entry: added restricted fund selector to income and expense forms
- 13 tests covering CRUD, balance calculation (received/spent), draft exclusion, form assignment

Closes #536



* feat: bank reconciliation workflow #537

- CompleteReconciliation action validates cleared balance equals statement balance before marking reconciliation completed
- bank-reconciliation Livewire component: mark/unmark lines cleared, statement balance entry, complete button gated on isBalanced
- fiscal-periods updated to show reconciliation status per bank account with links to reconciliation page for Finance - Record users
- Route: /finance/reconciliation/{accountId}/{periodId}
- 12 tests covering action validation, UI interactions, and access control

Closes #537



* feat: period close workflow with GAAP closing entries #538

- CloseFinancialPeriod action: validates all bank accounts have completed reconciliations; generates revenue closing entry (Dr revenue / Cr Net Assets) and expense closing entry (Dr Net Assets / Cr expense accounts); restricted-fund-tagged revenue credited to Net Assets — Restricted; marks period as closed and logs activity
- CreateJournalEntry now rejects entries to closed periods
- fiscal-periods: Close Period button for Finance - Record users with wire:confirm prompt; shows toast on success or failure
- 9 tests: action validation, balanced closing entries, period lock, and UI access control

Closes #538



* feat: operational reports — Statement of Activities, General Ledger, Trial Balance #539

- reports.blade.php: tabbed report interface
  - Statement of Activities: revenue/expense totals, net change; filterable by FY, period, and custom date range; draft entries excluded
  - General Ledger: posted lines per account with running balance; filterable by account, date range, and entry type; CSV export
  - Trial Balance: all accounts with debit/credit totals; balanced indicator
- Route: /finance/reports
- 13 tests covering access, totals accuracy, running balance, draft exclusion, and CSV export structure

Closes #539



* feat: Balance Sheet, Cash Flow reports & PDF/print export #540

- Statement of Financial Position: cumulative asset balances as of selected date, net assets split unrestricted/restricted, checks assets = net assets
- Statement of Cash Flow: cash inflows (revenue) and outflows (expenses) for selected period; net change in cash; reuses existing Activities filters
- Print / PDF export button (browser print via window.print()) on all reports; print-specific CSS hides navigation and adds report header
- Both reports added as tabs in existing reports.blade.php
- 5 tests: balance sheet asset balances, draft exclusion, unrestricted/ restricted properties, cash flow net change, draft exclusion

Closes #540



* feat: Budget vs. Actual Variance Report as standalone tab in reports #541

- Budget vs. Actual tab added to reports page (standalone from budgets page)
- Shows budget, actual, and variance per account per month for selected FY
- Variance color-coded: green = favorable (under for expenses, over for revenue), red = unfavorable
- Accounts with no budget set show zero budget; full actual amount is the variance
- FY rollup: all periods for the selected fiscal year displayed
- Draft entries excluded from actual figures
- 5 tests: under-budget expense, over-budget revenue, no-budget account, FY rollup period inclusion, draft exclusion

Closes #541



* feat: community finance view for Resident+ members #542

- finance-community-view gate: Resident+ users, not in brig
- community-finance.blade.php: shows only closed periods, most recent first; revenue and expense totals grouped by account; restricted fund summaries (received/spent/remaining) for periods with restricted activity; Finance - View+ users see "Staff Finance Portal" link
- Route: /finance/overview (uses finance-community-view gate, separate from staff finance routes)
- 10 tests: access control (Resident/Traveler/Stowaway/unauthenticated), open periods excluded, revenue/expense grouping, restricted fund display, staff portal link visibility

Closes #542



* feat: public finance dashboard with donation goal progress bar #543

- public-dashboard.blade.php: accessible to all including guests; last 3 closed fiscal months with income/expense totals; no account names or transaction detail exposed
- Donation goal progress bar: goal = sum of budgeted amounts for revenue accounts with subtype 'donations' in the current open period; falls back to legacy SiteConfig donation_goal if no budget set; progress = posted income against donation accounts; progress bar caps at 100%
- Route: /finance (public, no auth)
- 9 tests: guest access, 3-period limit, open periods excluded, graceful empty state, income totals, donation goal from budget, progress tracking, percent capped at 100

Closes #543



* docs: add technical reference for Double-Entry Accounting Ledger System

Comprehensive 18-section documentation covering all models, actions, gates, routes, Volt components, migrations, and test coverage for the full accounting ledger feature (PRD #529).



* fix: address test feedback for PRD #529 (#545-#548)

- Fix #548: Add isAdmin() bypass to finance-community-view gate so admin users are never denied access to the community finance overview page
- Fix #547: Change wire:model to wire:model.live on flux:tabs in reports so clicking tabs triggers a Livewire re-render and changes the view
- Fix #546: Add postEntry() method and Post button for draft journal entries on the journal list page, so drafts can be posted directly without navigating away



* fix: address CodeRabbit review round 2 for PRD #529

- Fix GL running balance to respect account normal_balance: credit-normal accounts (revenue, liability) now show positive balances for credits instead of inverting the sign
- Add liabilities section to Balance Sheet: implement bsLiabilityRows and bsTotalLiabilities properties; update bsIsBalanced to use the correct equation (Assets = Liabilities + Net Assets); add liabilities UI section
- Add wire:key to loops in reports.blade.php: revenue rows, expense rows, trial balance rows, balance sheet asset and liability rows, variance rows
- Add wire:key to loops in journal-entries.blade.php: account/vendor/tag filter select options, entry tag badges, entry line items
- Fix test: explicitly set normal_balance=debit for bank account fixture in GL running balance test (factory defaults are randomized)



* feat: add finance navigation partial and Staff Ready Room link

- Created shared nav partial at resources/views/livewire/finance/partials/nav.blade.php with buttons for Journal, Reports, Periods (all finance-view users) and Accounts, Budgets, Restricted Funds, Vendors, Tags (finance-manage only)
- Included the nav partial at the top of all 8 finance staff pages
- Added Finance Tracker card to Staff Ready Room (/staff) for users with finance-view permission
- Nav uses filled/ghost variants to highlight the active page via routeIs()
- Nav is hidden on print for the Reports page

Fixes #545



* fix: move Finance button to Ready Room header, remove misplaced card from /staff

The Finance entry point belongs in the Staff Ready Room (/ready-room) header alongside View Applications, View Tickets, and Blog Management — not as a card on the public /staff page. Added @can('finance-view')-gated Finance button with banknotes icon to ready-room.blade.php and removed the card that was incorrectly added to livewire/staff/page.blade.php.

Refs #545



* fix: address CodeRabbit review round 3 for PRD #529

11 comments addressed:

- fiscal-periods: guard GenerateFinancialPeriods behind finance-manage (view users should not mutate data on page load)
- fiscal-periods: gate closePeriod behind finance-manage (was finance-record, allowing record-level users to lock the ledger for everyone)
- fiscal-periods: add wire:key to bank-account inner loop and prior-FY cards
- journal-entries: enforce reverse invariant server-side — load reversedBy relation and throw if entry already reversed before calling CreateReversingEntry
- reports: fix getCumulativeBalance sign for credit-normal account types (liability, net_assets, revenue) so individual rows sum to the displayed total
- restricted-funds: use net ledger movement (credit-debit for income, debit-credit for expense) instead of debit-only for fund balance queries
- restricted-funds: add RecordActivity logging to createFund, updateFund, deactivate, reactivate
- restricted-funds: make empty-state copy permission-aware (@can finance-manage)
- budgets: add wire:key to budget entry tab account/period loops
- budgets: add wire:key to variance tab account/period loops
- budgets: fix variance color logic — revenue accounts: positive variance is good (green); expense accounts: negative variance is good (green)
- tests: update FiscalPeriodsTest to assert finance-view does NOT auto-generate periods; add PeriodCloseTest for finance-record cannot closePeriod



* fix: address CI failure and CodeRabbit review round 4 for PRD #529

- Fix UniqueConstraintViolation in CommunityFinanceTest: pin fiscal_year/month_number in factory calls so random values can't collide across two factory creates
- PeriodCloseTest/CommunityFinanceTest: change reconcileAllBanks/reconcileAllForPeriod to use updateOrCreate so existing in_progress reconciliations are properly promoted
- PeriodCloseTest: add bank account to 'closes the period' test so the reconciliation gate is actually exercised, not skipped due to zero active bank accounts
- CloseFinancialPeriod: add lockForUpdate inside DB::transaction to prevent two concurrent requests from each generating closing entries before either flips status
- fiscal-periods: add catch(Throwable) fallback for DB/system errors in closePeriod
- budgets: guard ensurePeriodsExist behind finance-manage and validate year range; validate account/period IDs in updateBudget before writing
- reports: fix getActivitiesAccountTotals to compute correct sign per normal_balance (debit-normal accounts now return debit-credit, not credit-debit) so expense totals are positive and refund-heavy periods reduce rather than inflate totals; remove abs()
- reports: fix CSV injection - escape cell values starting with formula trigger chars
- reports: fix balance sheet net assets queries to filter by fund_type, not subtype
- reports: label cash flow tab as Operating Activities Only with explanatory note
- reports: hide Period/Date filters on Variance tab since they are not applied there
- restricted-funds: wrap all four mutation methods in DB::transaction so fund changes and activity log entries succeed or fail together



* docs: add Finance System staff handbook chapter

Adds a new section 10-finance to the staff handbook with 4 chapters and 9 content pages covering:

- Finance roles and access (the three roles and what each can do)
- Recording income, expenses, and transfers (guided entry form)
- Viewing and managing journal entries (filtering, posting, reversals)
- Bank reconciliation (step-by-step process)
- Closing fiscal periods (prerequisites and process)
- Setting budgets (entry grid, copy from prior year, budget vs. actual)
- Financial reports (all six tabs: Activities, GL, Trial Balance, Balance Sheet, Cash Flow, Budget vs. Actual)
- Chart of accounts management (add, edit, deactivate)
- Restricted funds, vendors, and tags management

All 57 docs tests pass.



* fix: address CodeRabbit round 5 feedback (4 comments)

- reports: cash-flow inflow/outflow signs now derived from signed values so refund-heavy periods don't render '+$-10.00' or '-$-10.00'; use abs() with conditional sign and color for both cashInflows/cashOutflows
- reports: hide 'All Years' FY option on Variance tab since getVariancePeriodsProperty() returns empty when filterFyYear is blank, making 'All Years' silently clear the report
- restricted-funds: add editId validation rule (required, integer, exists) before findOrFail() so stale component state fails gracefully
- restricted-funds: guard updateFund() with fill()+isDirty() so activity is only logged when values actually changed; guard deactivate()/reactivate() to no-op if fund is already in the target is_active state



* fix: use flux:modal.trigger for New Fund button on restricted funds page

The New Fund button used wire:click="$flux.modal(...).show()" which is Alpine.js syntax and does nothing when evaluated as a Livewire action. Replaced with flux:modal.trigger (the correct Flux UI pattern), and replaced inline wire:click cancel buttons inside modals with flux:modal.close.

Fixes #553



* fix: allow zero-balance reconciliation to be completed

isBalanced previously required statementBalanceCents > 0, blocking accounts with no activity (e.g. savings account with 0.00 balance and no transactions this period). Changed to require the statementBalance field to be non-empty (explicitly entered) and difference === 0, which correctly handles both zero-balance and positive-balance accounts.

Fixes #552



* fix: replace wire:confirm with Flux modal for Post confirmation on journal entries

Added pendingPostId property and showPostConfirm() method to store the entry ID and open a flux:modal. postEntry() now reads from pendingPostId instead of taking an argument. Added confirm-post modal at the bottom of the template with Cancel/Post buttons using flux:modal.close.

Fixes #549



* fix: replace wire:confirm with Flux modal for Close Period confirmation

Added pendingClosePeriodId property and showCloseConfirm() method. closePeriod() now reads from pendingClosePeriodId instead of taking an argument. Added confirm-close-period modal at the bottom of the template with Cancel/Close Period buttons using flux:modal.close.

Fixes #550



* fix: add Manual Entry button to Journal page and update staff handbook docs

Added a Manual Entry button (outline variant, next to New Entry primary button) on the Journal Entries page linking to finance.journal.create-manual. Updated staff handbook pages to reference the Manual Entry button by its actual location instead of a non-existent menu item.

Fixes #555



* fix: add Generate Next FY Periods button to fiscal periods page

Adds a Finance - Manage button to generate the next fiscal year's 12 periods. The button is:
- Disabled unless we are in month 11 or 12 of the current FY (last 2 months, computed from FY start month in SiteConfig)
- Hidden once next FY periods already exist
- Opens a Flux modal confirmation before generating

Computation: fyMonthNumber = ((calendarMonth - startMonth + 12) % 12) + 1; canGenerate = fyMonthNumber >= 11

Fixes #554



* fix: replace wire:confirm on restricted funds Deactivate with Flux modal

Added pendingDeactivateFundId property, showDeactivateConfirm() method, and confirm-deactivate-fund Flux modal. Updated test to use the new two-step showDeactivateConfirm + deactivate call pattern.

Fixes #556



* fix: replace wire:confirm on Reverse button with Flux modal

Added pendingReverseId property, showReverseConfirm() method, and confirm-reverse Flux modal to journal-entries component. Updated existing tests to use the two-step showReverseConfirm + reverse pattern.

Fixes #557



* fix: allow editing and deleting draft journal entries

Added edit-journal-entry Volt component that loads an existing draft entry pre-populated with all fields (date, description, accounts, amount, vendor, restricted fund, tags). Supports income, expense, transfer, and manual (journal) entry types. Includes a Delete Draft button with Flux confirmation modal. Redirects with an error if a posted entry ID is used.

Added route /journal/{entryId}/edit (finance.journal.edit) and an Edit button on the journal entries list for draft entries. The Edit button appears alongside the existing Post button.

4 new tests: load edit page, save changes, delete draft, redirect on posted entry.

Fixes #558



* fix: limit financial amount input to 9 integer digits ($999,999,999.99 max)

Adds regex validation to all three journal entry forms (create, manual create, edit) and to ParseDollarAmount action, rejecting amounts with more than 9 integer digits. Prevents oversized values from breaking downstream calculations.

Fixes #560



* fix: label non-production emails with environment name

Adds [ENV] prefix to all email subjects in non-production environments via a MessageSending event listener in AppServiceProvider. Also …