### PR TITLE
Staff Modal, Report Evidence Images & Finance Dashboard

### DIFF
--- a/app/Actions/AttachDisciplineReportImages.php
+++ b/app/Actions/AttachDisciplineReportImages.php
@@ -19,7 +19,10 @@ class AttachDisciplineReportImages
             throw new \RuntimeException('Cannot attach images to a published discipline report.');
         }
 
-        $maxKb = SiteConfig::getValue('max_image_size_kb', '2048');
+        $maxKb = (int) (SiteConfig::getValue('max_image_size_kb', '2048') ?: 2048);
+        if ($maxKb <= 0) {
+            $maxKb = 2048;
+        }
 
         foreach ($files as $file) {
             /** @var UploadedFile $file */

--- a/app/Actions/AttachDisciplineReportImages.php
+++ b/app/Actions/AttachDisciplineReportImages.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Actions;
+
+use App\Models\DisciplineReport;
+use App\Models\DisciplineReportImage;
+use App\Models\SiteConfig;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Validator;
+use Lorisleiva\Actions\Concerns\AsAction;
+
+class AttachDisciplineReportImages
+{
+    use AsAction;
+
+    public function handle(DisciplineReport $report, array $files): void
+    {
+        if ($report->isPublished()) {
+            throw new \RuntimeException('Cannot attach images to a published discipline report.');
+        }
+
+        $maxKb = SiteConfig::getValue('max_image_size_kb', '2048');
+
+        foreach ($files as $file) {
+            /** @var UploadedFile $file */
+            $validator = Validator::make(
+                ['file' => $file],
+                ['file' => "mimes:jpg,jpeg,png,gif,webp|max:{$maxKb}"]
+            );
+
+            $validator->validate();
+
+            $path = $file->store("report-evidence/{$report->id}", config('filesystems.public_disk'));
+
+            DisciplineReportImage::create([
+                'discipline_report_id' => $report->id,
+                'path' => $path,
+                'original_filename' => $file->getClientOriginalName(),
+            ]);
+        }
+    }
+}

--- a/app/Models/DisciplineReport.php
+++ b/app/Models/DisciplineReport.php
@@ -10,6 +10,7 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\MorphMany;
 
 class DisciplineReport extends Model
@@ -83,6 +84,11 @@ class DisciplineReport extends Model
     public function isPublished(): bool
     {
         return $this->status === ReportStatus::Published;
+    }
+
+    public function images(): HasMany
+    {
+        return $this->hasMany(DisciplineReportImage::class);
     }
 
     public function violatedRules(): BelongsToMany

--- a/app/Models/DisciplineReport.php
+++ b/app/Models/DisciplineReport.php
@@ -76,6 +76,13 @@ class DisciplineReport extends Model
         return $query->where('subject_user_id', $user->id);
     }
 
+    protected static function booted(): void
+    {
+        static::deleting(function (DisciplineReport $report) {
+            $report->images()->each->delete();
+        });
+    }
+
     public function isDraft(): bool
     {
         return $this->status === ReportStatus::Draft;

--- a/app/Models/DisciplineReport.php
+++ b/app/Models/DisciplineReport.php
@@ -79,7 +79,7 @@ class DisciplineReport extends Model
     protected static function booted(): void
     {
         static::deleting(function (DisciplineReport $report) {
-            $report->images()->each->delete();
+            $report->images->each->delete();
         });
     }
 

--- a/app/Models/DisciplineReportImage.php
+++ b/app/Models/DisciplineReportImage.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Support\Facades\Storage;
+
+class DisciplineReportImage extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'discipline_report_id',
+        'path',
+        'original_filename',
+    ];
+
+    protected static function booted(): void
+    {
+        static::deleting(function (DisciplineReportImage $image) {
+            Storage::disk(config('filesystems.public_disk'))->delete($image->path);
+        });
+    }
+
+    public function report(): BelongsTo
+    {
+        return $this->belongsTo(DisciplineReport::class, 'discipline_report_id');
+    }
+
+    public function url(): string
+    {
+        return \App\Services\StorageService::publicUrl($this->path);
+    }
+}

--- a/database/factories/DisciplineReportImageFactory.php
+++ b/database/factories/DisciplineReportImageFactory.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\DisciplineReport;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class DisciplineReportImageFactory extends Factory
+{
+    public function definition(): array
+    {
+        return [
+            'discipline_report_id' => DisciplineReport::factory(),
+            'path' => 'report-evidence/1/'.$this->faker->uuid().'.jpg',
+            'original_filename' => $this->faker->word().'.jpg',
+        ];
+    }
+}

--- a/database/migrations/2026_04_26_024008_create_discipline_report_images_table.php
+++ b/database/migrations/2026_04_26_024008_create_discipline_report_images_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('discipline_report_images', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('discipline_report_id')->constrained('discipline_reports')->cascadeOnDelete();
+            $table->string('path');
+            $table->string('original_filename');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('discipline_report_images');
+    }
+};

--- a/docs/features/staff-modal-evidence-finance.md
+++ b/docs/features/staff-modal-evidence-finance.md
@@ -1,0 +1,831 @@
+# Staff Modal, Report Evidence Images & Finance Dashboard — Technical Documentation
+
+> **Audience:** Project owner, developers, AI agents
+> **Generated:** 2026-04-26
+> **Generator:** `/document-feature` skill
+
+---
+
+## Table of Contents
+
+1. [Overview](#1-overview)
+2. [Database Schema](#2-database-schema)
+3. [Models & Relationships](#3-models--relationships)
+4. [Enums Reference](#4-enums-reference)
+5. [Authorization & Permissions](#5-authorization--permissions)
+6. [Routes](#6-routes)
+7. [User Interface Components](#7-user-interface-components)
+8. [Actions (Business Logic)](#8-actions-business-logic)
+9. [Notifications](#9-notifications)
+10. [Background Jobs](#10-background-jobs)
+11. [Console Commands & Scheduled Tasks](#11-console-commands--scheduled-tasks)
+12. [Services](#12-services)
+13. [Activity Log Entries](#13-activity-log-entries)
+14. [Data Flow Diagrams](#14-data-flow-diagrams)
+15. [Configuration](#15-configuration)
+16. [Test Coverage](#16-test-coverage)
+17. [File Map](#17-file-map)
+18. [Known Issues & Improvement Opportunities](#18-known-issues--improvement-opportunities)
+
+---
+
+## 1. Overview
+
+This PRD (#637) delivers three distinct sub-features that collectively enhance how staff interact with discipline reports, the public staff page, and the finance module.
+
+**Sub-feature 1: Staff Page Modal Replacement.** The public `/staff` page previously displayed position details in a sidebar panel. This was replaced with a Flux modal that shows full position details (description, responsibilities, requirements, assigned staff member's contact info) when a card is clicked. Board member cards also open a dedicated modal. The change improves the layout on all screen sizes and removes the sidebar's layout constraints.
+
+**Sub-feature 2: Discipline Report Evidence Images.** Staff writing discipline reports can now attach image evidence (screenshots, photos) to a report while it is in draft status. Images are uploaded via Livewire's `WithFileUploads` trait, stored on the public disk under `report-evidence/{report_id}/`, and displayed in both the edit and view modals as responsive thumbnail grids. Removing an image on the edit modal is staged (pending) until the update is saved. Deleting a report cascades to delete both the database records and the files on disk.
+
+**Sub-feature 3: Finance Staff Dashboard.** A new dashboard page accessible to any user with the `finance-view` gate provides at-a-glance financial health indicators: current cash position across all active bank accounts, current-month income/expense comparison with budget, a 6-month income/expense trend line chart, year-to-date summary figures, net assets (unrestricted vs. restricted), and a count of pending draft journal entries awaiting posting. All figures are computed from posted entries only; drafts are excluded until they are posted.
+
+**Users:** The staff page is public (no authentication required). Evidence image upload and management is available to users with the `Discipline Report - Manager` role or report creators (draft only). The finance dashboard requires the `Finance - View`, `Finance - Record`, or `Finance - Manage` role.
+
+---
+
+## 2. Database Schema
+
+### `discipline_report_images` table
+
+| Column | Type | Nullable | Default | Notes |
+|--------|------|----------|---------|-------|
+| `id` | bigint unsigned | No | auto | Primary key |
+| `discipline_report_id` | bigint unsigned | No | — | FK → `discipline_reports.id` |
+| `path` | varchar | No | — | Relative path on public disk |
+| `original_filename` | varchar | No | — | Client-provided filename for display |
+| `created_at` | timestamp | Yes | null | |
+| `updated_at` | timestamp | Yes | null | |
+
+**Indexes:** Primary key on `id`
+**Foreign Keys:** `discipline_report_id` → `discipline_reports(id)` CASCADE DELETE
+**Migration:** `database/migrations/2026_04_26_024008_create_discipline_report_images_table.php`
+
+---
+
+### Financial tables (existing, added `finance.dashboard` route for summary display)
+
+The finance dashboard reads from the existing financial tables created in `2026_04_05_000001_create_financial_tables.php`. Key tables used:
+
+#### `financial_accounts` table (excerpt)
+
+| Column | Type | Nullable | Notes |
+|--------|------|----------|-------|
+| `id` | bigint unsigned | No | Primary key |
+| `code` | varchar | No | Unique account code |
+| `name` | varchar | No | Human-readable name |
+| `type` | enum | No | `asset`, `liability`, `net_assets`, `revenue`, `expense` |
+| `normal_balance` | enum | No | `debit` or `credit` |
+| `is_bank_account` | boolean | No | Flags accounts shown in cash position |
+| `is_active` | boolean | No | Inactive accounts excluded |
+
+#### `financial_journal_entries` table (excerpt)
+
+| Column | Type | Nullable | Notes |
+|--------|------|----------|-------|
+| `id` | bigint unsigned | No | Primary key |
+| `period_id` | bigint unsigned | No | FK → `financial_periods.id` |
+| `date` | date | No | Transaction date |
+| `status` | enum | No | `draft` or `posted` — only `posted` entries affect dashboard |
+| `restricted_fund_id` | bigint unsigned | Yes | FK → `financial_restricted_funds.id` |
+
+#### `financial_journal_entry_lines` table (excerpt)
+
+| Column | Type | Nullable | Notes |
+|--------|------|----------|-------|
+| `id` | bigint unsigned | No | Primary key |
+| `journal_entry_id` | bigint unsigned | No | FK → `financial_journal_entries.id` |
+| `account_id` | bigint unsigned | No | FK → `financial_accounts.id` |
+| `debit` | decimal(15,2) | No | Debit amount (0 if credit side) |
+| `credit` | decimal(15,2) | No | Credit amount (0 if debit side) |
+
+#### `financial_budgets` table (excerpt)
+
+| Column | Type | Nullable | Notes |
+|--------|------|----------|-------|
+| `id` | bigint unsigned | No | Primary key |
+| `account_id` | bigint unsigned | No | FK → `financial_accounts.id` |
+| `period_id` | bigint unsigned | No | FK → `financial_periods.id` |
+| `amount` | decimal(15,2) | No | Budget amount for that period |
+
+**Unique constraint:** `[account_id, period_id]`
+
+#### `financial_periods` table (excerpt)
+
+| Column | Type | Nullable | Notes |
+|--------|------|----------|-------|
+| `id` | bigint unsigned | No | Primary key |
+| `fiscal_year` | integer | No | e.g., 2026 |
+| `month_number` | integer | No | 1–12 |
+| `start_date` | date | No | |
+| `end_date` | date | No | |
+| `status` | enum | No | `open`, `reconciling`, `closed` |
+
+**Unique constraint:** `[fiscal_year, month_number]`
+
+---
+
+## 3. Models & Relationships
+
+### DisciplineReportImage (`app/Models/DisciplineReportImage.php`)
+
+**Relationships:**
+| Method | Type | Related Model | Notes |
+|--------|------|---------------|-------|
+| `report()` | BelongsTo | DisciplineReport | FK: `discipline_report_id` |
+
+**Key Methods:**
+- `url(): string` — returns public URL via `StorageService::publicUrl($this->path)`
+
+**Booted observer:**
+- `deleting`: deletes the file from the public disk via `Storage::disk(...)->delete($this->path)`
+
+**Fillable:** `discipline_report_id`, `path`, `original_filename`
+
+---
+
+### DisciplineReport (`app/Models/DisciplineReport.php`)
+
+**Relationships:**
+| Method | Type | Related Model | Notes |
+|--------|------|---------------|-------|
+| `subject()` | BelongsTo | User | FK: `subject_user_id` |
+| `reporter()` | BelongsTo | User | FK: `reporter_user_id` |
+| `publisher()` | BelongsTo | User | FK: `publisher_user_id` |
+| `category()` | BelongsTo | ReportCategory | FK: `report_category_id` |
+| `images()` | HasMany | DisciplineReportImage | Eager-loaded as `$report->images` |
+| `violatedRules()` | BelongsToMany | Rule | Pivot: `discipline_report_rules` |
+| `topics()` | MorphMany | Thread | Polymorphic via `topicable` |
+
+**Scopes:** `scopePublished()`, `scopeDraft()`, `scopeForSubject(User $user)`
+
+**Key Methods:**
+- `isDraft(): bool` — true if `status === ReportStatus::Draft`
+- `isPublished(): bool` — true if `status === ReportStatus::Published`
+
+**Booted observer:**
+- `deleting`: iterates `$report->images` (collection) and calls `->delete()` on each, triggering `DisciplineReportImage::booted()` to clean up files
+
+**Casts:**
+- `location` → `ReportLocation`
+- `severity` → `ReportSeverity`
+- `status` → `ReportStatus`
+- `published_at` → `datetime`
+
+---
+
+### StaffPosition (`app/Models/StaffPosition.php`)
+
+**Relationships:**
+| Method | Type | Related Model | Notes |
+|--------|------|---------------|-------|
+| `user()` | BelongsTo | User | Nullable — null when position is vacant |
+| `applications()` | HasMany | StaffApplication | |
+| `credentials()` | BelongsToMany | Credential | |
+
+**Scopes:** `vacant()`, `filled()`, `inDepartment()`, `ordered()`, `acceptingApplications()`
+
+**Key Methods:**
+- `isVacant(): bool`, `isFilled(): bool`, `isAcceptingApplications(): bool`
+
+**Casts:** `department` → `StaffDepartment`, `rank` → `StaffRank`
+
+---
+
+### BoardMember (`app/Models/BoardMember.php`)
+
+**Relationships:**
+| Method | Type | Related Model | Notes |
+|--------|------|---------------|-------|
+| `user()` | BelongsTo | User | Nullable — unlinked board members have no account |
+
+**Scopes:** `ordered()`
+
+**Key Methods:**
+- `isLinked(): bool`, `isUnlinked(): bool`
+- `effectiveName(): string` — user's staff name if linked, else `display_name`
+- `effectiveBio(): string` — user's bio if linked, else `bio`
+- `effectivePhotoUrl(): ?string` — user avatar if linked, else stored `photo_path`
+
+---
+
+### FinancialAccount (`app/Models/FinancialAccount.php`)
+
+**Relationships:**
+| Method | Type | Related Model | Notes |
+|--------|------|---------------|-------|
+| `journalEntryLines()` | HasMany | FinancialJournalEntryLine | |
+| `budgets()` | HasMany | FinancialBudget | |
+| `reconciliations()` | HasMany | FinancialReconciliation | |
+
+---
+
+### FinancialJournalEntry (`app/Models/FinancialJournalEntry.php`)
+
+**Relationships:**
+| Method | Type | Related Model | Notes |
+|--------|------|---------------|-------|
+| `period()` | BelongsTo | FinancialPeriod | |
+| `postedBy()` | BelongsTo | User | |
+| `createdBy()` | BelongsTo | User | |
+| `reversesEntry()` | BelongsTo | FinancialJournalEntry | |
+| `reversedBy()` | HasOne | FinancialJournalEntry | |
+| `vendor()` | BelongsTo | FinancialVendor | |
+| `restrictedFund()` | BelongsTo | FinancialRestrictedFund | |
+| `lines()` | HasMany | FinancialJournalEntryLine | |
+| `tags()` | BelongsToMany | FinancialTag | |
+
+---
+
+### FinancialPeriod (`app/Models/FinancialPeriod.php`)
+
+**Relationships:**
+| Method | Type | Related Model | Notes |
+|--------|------|---------------|-------|
+| `journalEntries()` | HasMany | FinancialJournalEntry | |
+| `budgets()` | HasMany | FinancialBudget | |
+| `reconciliations()` | HasMany | FinancialReconciliation | |
+
+---
+
+### FinancialBudget (`app/Models/FinancialBudget.php`)
+
+**Relationships:**
+| Method | Type | Related Model | Notes |
+|--------|------|---------------|-------|
+| `account()` | BelongsTo | FinancialAccount | |
+| `period()` | BelongsTo | FinancialPeriod | |
+
+---
+
+## 4. Enums Reference
+
+### ReportStatus (`app/Enums/ReportStatus.php`)
+
+| Case | Value | Notes |
+|------|-------|-------|
+| `Draft` | `'draft'` | Editable; image upload allowed |
+| `Published` | `'published'` | Immutable; image upload/delete blocked |
+
+---
+
+### ReportSeverity (`app/Enums/ReportSeverity.php`)
+
+| Case | color() | label() |
+|------|---------|---------|
+| `Low` | `'green'` | `'Low'` |
+| `Medium` | `'yellow'` | `'Medium'` |
+| `High` | `'orange'` | `'High'` |
+| `Critical` | `'red'` | `'Critical'` |
+
+---
+
+### ReportLocation (`app/Enums/ReportLocation.php`)
+
+| Case | color() | label() |
+|------|---------|---------|
+| `InGame` | `'blue'` | `'In Game'` |
+| `Discord` | `'indigo'` | `'Discord'` |
+| `Forum` | `'purple'` | `'Forum'` |
+| `Other` | `'zinc'` | `'Other'` |
+
+---
+
+### StaffDepartment (`app/Enums/StaffDepartment.php`)
+
+| Case | Label |
+|------|-------|
+| `Command` | `'Command'` |
+| `Engineering` | `'Engineering'` |
+| `Chaplain` | `'Chaplain Corps'` |
+| `Quartermaster` | `'Quartermaster'` |
+| `Steward` | `'Steward'` |
+
+---
+
+### StaffRank (`app/Enums/StaffRank.php`)
+
+| Case | Value | Notes |
+|------|-------|-------|
+| `Officer` | `'officer'` | Command-level |
+| `CrewMember` | `'crew_member'` | Full staff |
+| `JrCrew` | `'jr_crew'` | Junior staff |
+| `None` | `'none'` | Not a staff member |
+
+---
+
+## 5. Authorization & Permissions
+
+### Gates (from `app/Providers/AuthServiceProvider.php`)
+
+| Gate Name | Who Can Pass | Logic Summary |
+|-----------|-------------|---------------|
+| `view-discipline-report-log` | Manager or log viewers | `hasRole('Discipline Report - Manager')` or specific log-viewer roles |
+| `manage-discipline-reports` | Managers | `hasRole('Discipline Report - Manager')` |
+| `publish-discipline-reports` | Publishers | `hasRole('Discipline Report - Publisher')` |
+| `view-user-discipline-reports` | Staff, self, or parent | `hasRole('Staff Access')` OR `$user->id === $targetUser->id` OR parent relationship |
+| `edit-staff-bio` | Staff or board members | `hasRole('Staff Access')` OR `is_board_member` |
+| `board-member` | Board members | `is_board_member` |
+| `finance-view` | Finance View/Record/Manage | Any finance role |
+| `finance-record` | Finance Record/Manage | `Finance - Record` or `Finance - Manage` |
+| `finance-manage` | Finance Manage only | `Finance - Manage` |
+| `finance-community-view` | Residents+ | Not in brig AND `isAtLeastLevel(Resident)` OR admin |
+
+---
+
+### Policies
+
+#### DisciplineReportPolicy (`app/Policies/DisciplineReportPolicy.php`)
+
+**`before()` hook:** Admins bypass all checks *except* `delete` and `publish` (those continue to policy evaluation).
+
+| Ability | Who Can | Conditions |
+|---------|---------|------------|
+| `viewAny` | Managers or Staff | `hasRole('Discipline Report - Manager')` OR `hasRole('Staff Access')` |
+| `view` | Manager, Staff, subject (published), parent of subject (published) | Published required for non-staff viewing |
+| `create` | Managers only | `hasRole('Discipline Report - Manager')` |
+| `update` | Manager or reporter | Report must be draft; manager always; reporter only if they created it |
+| `publish` | Publisher (with exclusion) | Must have Publisher role; if subject is active staff, reporter cannot publish their own report |
+| `delete` | Nobody | Always `false` |
+
+---
+
+### Permissions Matrix
+
+| User Type | View Report (staff) | View Report (own, published) | Create Report | Edit Draft | Publish | Add Images | Finance Dashboard |
+|-----------|--------------------|-----------------------------|---------------|------------|---------|-----------|------------------|
+| Admin | ✓ (bypass) | ✓ | ✓ (bypass) | ✓ (bypass) | ✗ (policy) | ✓ (bypass) | ✓ (role) |
+| Discipline Report - Manager | ✓ | ✓ | ✓ | ✓ | ✗ (needs Publisher) | ✓ | ✗ (needs Finance role) |
+| Discipline Report - Publisher | ✓ (Staff Access) | ✓ | ✗ | ✗ (unless also manager/creator) | ✓ | ✗ | ✗ |
+| Staff Access (general) | ✓ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ |
+| Finance - View | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✓ |
+| Regular user | ✗ | ✓ (published) | ✗ | ✗ | ✗ | ✗ | ✗ |
+| Parent of subject | ✗ | ✓ (published) | ✗ | ✗ | ✗ | ✗ | ✗ |
+
+---
+
+## 6. Routes
+
+| Method | URL | Middleware | Handler | Route Name |
+|--------|-----|-----------|---------|------------|
+| GET | `/staff` | — (public) | `staff.page` | `staff.index` |
+| GET | `/finance/dashboard` | `auth`, `can:finance-view` | `finance.dashboard` | `finance.dashboard.index` |
+| GET | `/finance` | — (public) | `finance.public-dashboard` | `finance.public.index` |
+| GET | `/finance/overview` | `auth`, `can:finance-community-view` | `finance.community-finance` | `finance.community.index` |
+
+*(All other finance routes exist but are part of the pre-existing Double-Entry Accounting Ledger System feature, not this PRD.)*
+
+---
+
+## 7. User Interface Components
+
+### Staff Page
+**File:** `resources/views/livewire/staff/page.blade.php`
+**Route:** `/staff` (route name: `staff.index`)
+
+**Purpose:** Publicly viewable team page listing all staff positions grouped by department and all board members. Cards open modals for detail view.
+
+**Authorization:** Public (no auth required). Apply button respects `auth` middleware internally.
+
+**PHP Class Properties:**
+- `$selectedPositionId: ?int` — ID of position whose modal is open
+- `$selectedBoardMemberId: ?int` — ID of board member whose modal is open
+
+**PHP Class Methods:**
+- `selectPosition(int $id)` — sets `$selectedPositionId`, clears board member, opens `position-detail-modal`
+- `selectBoardMember(int $id)` — sets `$selectedBoardMemberId`, clears position, opens `board-member-detail-modal`
+
+**Computed Properties:**
+- `departments` — `StaffPosition::with('user')->ordered()->get()` grouped by `department->label()`
+- `boardMembers` — `BoardMember::with('user')->ordered()->get()`
+- `selectedPosition` — `StaffPosition::with(['user.minecraftAccounts','user.discordAccounts'])->find($selectedPositionId)`
+- `selectedBoardMember` — `$this->boardMembers->firstWhere('id', $selectedBoardMemberId)`
+
+**Modals:**
+- `position-detail-modal` — shows title, department, rank badge, status badge, description, responsibilities (rendered as Markdown), requirements, assigned user avatar/name/contact links (Discord/Minecraft), apply button if accepting applications
+- `board-member-detail-modal` — shows effective name, title, effective photo, effective bio (rendered as Markdown), user contact links if linked
+
+---
+
+### Discipline Reports Card
+**File:** `resources/views/livewire/users/discipline-reports-card.blade.php`
+**Route:** Embedded on profile pages (not a standalone route)
+
+**Purpose:** Displays discipline reports for a user. Staff see all (draft + published); subject sees published only; parents see published for their child. Provides create/edit/view modals with image management.
+
+**Authorization:** `mount()` authorizes via `view-user-discipline-reports` gate.
+
+**Key PHP Class Properties:**
+- `$userId` (`#[Locked]`) — subject user ID
+- `$isStaffViewing` (`#[Locked]`) — whether viewer is staff
+- `$editingReportId` (`#[Locked]`) — ID of report being edited
+- `$viewingReportId` (`#[Locked]`) — ID of report being viewed
+- `$formImages` — array of `UploadedFile` objects (Livewire `WithFileUploads`)
+- `$removedImageIds` — `int[]` of image IDs staged for deletion
+
+**Key PHP Class Methods:**
+- `createReport()` — validates form + images, calls `AttachDisciplineReportImages::run()` if images
+- `updateReport()` — validates form + images, deletes staged removals (ownership-verified), calls `AttachDisciplineReportImages::run()` for new images
+- `removeImage(int $imageId)` — authorizes `update`, appends to `$removedImageIds`
+- `openEditModal(int $reportId)` — authorizes `update`, loads report, resets image state
+- `openCreateModal()` — authorizes `create`
+
+**Computed Properties:**
+- `editingReportImages` — existing images for `$editingReportId` minus pending `$removedImageIds`
+- `viewingReport` — `DisciplineReport::with(['subject','reporter','publisher','category','violatedRules','images'])->find($viewingReportId)`
+
+**User Actions Available:**
+- Create report via `create-report-modal` with multi-image upload and live previews
+- Edit draft report via `edit-report-modal` (image add/remove only available for drafts)
+- Publish draft report
+- View any report via `view-report-modal` (Evidence section shows thumbnail grid if images exist)
+
+---
+
+### View Report (standalone page component)
+**File:** `resources/views/livewire/reports/view-report.blade.php`
+**Route:** Embedded in staff report view pages
+
+**Purpose:** Full read-only view of a discipline report, including Evidence section with image grid.
+
+**Authorization:** `mount()` calls `$this->authorize('view', $report)` via `DisciplineReportPolicy@view`.
+
+**`mount()` eager-loads:** `['subject', 'reporter', 'publisher', 'category', 'violatedRules', 'images']`
+
+**Evidence section:** Rendered only when `$report->images->isNotEmpty()`. Shows a responsive 2–4 column grid of `<img>` thumbnails, each wrapped in a `<a target="_blank">` link to the full-size image.
+
+---
+
+### Finance Dashboard
+**File:** `resources/views/livewire/finance/dashboard.blade.php`
+**Route:** `/finance/dashboard` (route name: `finance.dashboard.index`)
+
+**Purpose:** At-a-glance financial health dashboard for finance staff. All figures from posted entries only.
+
+**Authorization:** `mount()` calls `$this->authorize('finance-view')`.
+
+**Computed Properties:**
+| Property | Description |
+|----------|-------------|
+| `cashPosition` | Array of bank account name/balance plus total; queries posted entry lines joined to accounts where `is_bank_account = true` |
+| `currentMonth` | Income, expenses, net, budgeted income/expenses for current calendar month; finds covering `FinancialPeriod` for budget data |
+| `sixMonthTrend` | Array of 6 months (labels + income/expense arrays) for line chart |
+| `ytdSummary` | Fiscal-year income, expenses, net; finds all periods sharing the same `fiscal_year` as today's period |
+| `netAssets` | Total, unrestricted, restricted net assets using CASE WHEN SQL to separate restricted fund entries |
+| `pendingDrafts` | `FinancialJournalEntry::where('status', 'draft')->count()` |
+
+**All DB queries use raw `DB::table()` joins** — not Eloquent eager-loading — to produce aggregate SQL for balance calculations.
+
+**UI Elements:**
+- Cash Position grid (one card per bank account + total card)
+- Current Month: stat cards for Income, Expenses, Net; budget variance indicators; `flux:chart` bar/line
+- 6-Month Trend: `flux:chart` multi-series line (income vs. expenses)
+- YTD Summary: Income, Expenses, Net stat cards
+- Net Assets: Total, Unrestricted, Restricted stat cards
+- Pending Drafts: Count badge with link to `/finance/journal`
+
+---
+
+## 8. Actions (Business Logic)
+
+### AttachDisciplineReportImages (`app/Actions/AttachDisciplineReportImages.php`)
+
+**Signature:** `handle(DisciplineReport $report, array $files): void`
+
+**Step-by-step logic:**
+1. Checks `$report->isPublished()` — throws `RuntimeException` if true (cannot attach images to published reports)
+2. Reads `SiteConfig::getValue('max_image_size_kb', '2048')` for max file size
+3. For each `UploadedFile $file`:
+   a. Runs `Validator::make(['file' => $file], ['file' => "mimes:jpg,jpeg,png,gif,webp|max:{$maxKb}"])->validate()`
+   b. Stores file to public disk: `$file->store("report-evidence/{$report->id}", config('filesystems.public_disk'))`
+   c. Creates `DisciplineReportImage` with `discipline_report_id`, `path`, `original_filename`
+4. No activity logging, no notifications, no jobs dispatched
+
+**Called by:**
+- `discipline-reports-card` Volt component — `createReport()` and `updateReport()` methods
+
+---
+
+## 9. Notifications
+
+Not applicable for this feature. No notifications are sent when images are attached, edited, or when the finance dashboard is viewed.
+
+---
+
+## 10. Background Jobs
+
+Not applicable for this feature.
+
+---
+
+## 11. Console Commands & Scheduled Tasks
+
+Not applicable for this feature.
+
+---
+
+## 12. Services
+
+### StorageService (`app/Services/StorageService.php`)
+
+**Purpose:** Abstracts public file URL generation. Returns a permanent public URL for local storage or a signed S3 URL for cloud storage.
+
+**Used by:** `DisciplineReportImage::url()` to generate thumbnail and full-size image URLs.
+
+**Key method:**
+- `publicUrl(string $path): string` — returns `Storage::disk(...)->url($path)` or signed URL depending on environment
+
+---
+
+## 13. Activity Log Entries
+
+Not applicable for this feature. `AttachDisciplineReportImages` does not call `RecordActivity::run()`. Image management does not produce activity log entries.
+
+---
+
+## 14. Data Flow Diagrams
+
+### Attaching Images on Report Creation
+
+```
+User selects files in create-report-modal
+  -> wire:model="formImages" (WithFileUploads handles temp storage)
+  -> User previews via $image->temporaryUrl()
+  -> User clicks "Create Report" (wire:submit="createReport")
+    -> discipline-reports-card::createReport()
+      -> $this->authorize('create', DisciplineReport::class)  [DisciplineReportPolicy@create]
+      -> $this->validate([..., 'formImages.*' => 'nullable|mimes:...|max:{$maxKb}'])
+      -> DisciplineReport::create([...]) → $report
+      -> if $this->formImages → AttachDisciplineReportImages::run($report, $this->formImages)
+           -> foreach file: validate → store → DisciplineReportImage::create([...])
+      -> $this->resetForm()
+      -> Flux::modal('create-report-modal')->close()
+      -> Flux::toast('Report created', variant: 'success')
+```
+
+### Editing Images on a Draft Report
+
+```
+User opens edit modal (clicks Edit button)
+  -> discipline-reports-card::openEditModal($reportId)
+    -> $this->authorize('update', $report)  [DisciplineReportPolicy@update]
+    -> loads form fields, resets $formImages, $removedImageIds
+    -> Flux::modal('edit-report-modal')->show()
+
+User clicks × on existing image
+  -> discipline-reports-card::removeImage($imageId)
+    -> $this->authorize('update', $editingReport)
+    -> $this->removedImageIds[] = $imageId  (staged, NOT deleted yet)
+    -> editingReportImages computed property re-evaluates (filters out staged IDs)
+
+User clicks "Update Report"
+  -> discipline-reports-card::updateReport()
+    -> $this->authorize('update', $editingReport)
+    -> validate form + new formImages
+    -> foreach $removedImageIds: DisciplineReportImage::where(id, discipline_report_id)->first()->delete()
+         -> DisciplineReportImage::booted() deleting: Storage::disk->delete($path)
+    -> if $this->formImages → AttachDisciplineReportImages::run($report, $this->formImages)
+    -> Flux::toast('Report updated', variant: 'success')
+```
+
+### Viewing Evidence on a Report
+
+```
+User clicks View on a report
+  -> discipline-reports-card::openViewModal($reportId)
+    -> loads viewingReport with ['images'] eager-loaded
+    -> Flux::modal('view-report-modal')->show()
+  -> Blade: @if($viewingReport->images->isNotEmpty())
+       renders Evidence section with thumbnail grid
+    @endif
+
+OR via standalone view-report component:
+  -> mount(DisciplineReport $report)
+    -> $this->authorize('view', $report)
+    -> $this->report = $report->load([..., 'images'])
+  -> @if($report->images->isNotEmpty()) renders Evidence flux:card @endif
+```
+
+### Cascade Delete
+
+```
+Admin deletes a DisciplineReport
+  -> DisciplineReport::booted() deleting: $report->images->each->delete()
+       -> for each DisciplineReportImage:
+            -> DisciplineReportImage::booted() deleting: Storage::disk->delete($path)
+            -> DB record deleted
+  -> DisciplineReport record deleted
+```
+
+### Finance Dashboard Load
+
+```
+User navigates to /finance/dashboard
+  -> Route: finance.dashboard.index (middleware: auth, can:finance-view)
+    -> finance.dashboard Volt component
+      -> mount(): $this->authorize('finance-view')
+      -> Page renders, Livewire calls computed properties on demand:
+           cashPosition: DB::table join → SUM(debit)/SUM(credit) per bank account
+           currentMonth: DB::table join filtered by current calendar month dates
+           sixMonthTrend: loop 6 months, DB::table per month
+           ytdSummary: find fiscal year from today, sum all periods in that year
+           netAssets: DB::table with CASE WHEN for restricted_fund_id IS NOT NULL
+           pendingDrafts: FinancialJournalEntry::where('status','draft')->count()
+      -> flux:chart components render using returned data arrays
+```
+
+### Staff Page Modal Interaction
+
+```
+User visits /staff (public, no auth required)
+  -> staff.page Volt component loads
+  -> getDepartmentsProperty(): StaffPosition::with('user')->ordered()->get() grouped by dept
+  -> getBoardMembersProperty(): BoardMember::with('user')->ordered()->get()
+  -> Page renders position cards and board member cards
+
+User clicks a position card
+  -> wire:click="selectPosition({{ $position->id }})"
+    -> selectPosition(int $id):
+         $this->selectedPositionId = $id
+         $this->selectedBoardMemberId = null
+         Flux::modal('position-detail-modal')->show()
+    -> selectedPosition computed: StaffPosition::with([user.minecraftAccounts,user.discordAccounts])->find($id)
+    -> position-detail-modal renders with position details + user contact info
+
+User clicks a board member card
+  -> wire:click="selectBoardMember({{ $bm->id }})"
+    -> selectBoardMember(int $id):
+         $this->selectedBoardMemberId = $id
+         $this->selectedPositionId = null
+         Flux::modal('board-member-detail-modal')->show()
+    -> selectedBoardMember: $this->boardMembers->firstWhere('id', $id)
+    -> board-member-detail-modal renders
+```
+
+---
+
+## 15. Configuration
+
+| Key | Default | Purpose |
+|-----|---------|---------|
+| `max_image_size_kb` | `'2048'` | Maximum upload size per evidence image (KB); read via `SiteConfig::getValue()` |
+| `filesystems.public_disk` | `'public'` | Laravel filesystem disk name used for storing and reading evidence images |
+
+---
+
+## 16. Test Coverage
+
+### Test Files
+
+| File | Tests | What It Covers |
+|------|-------|----------------|
+| `tests/Feature/StaffPageTest.php` | 12 | Staff page rendering, modal state, position/board-member display |
+| `tests/Feature/Livewire/ReportEvidenceUITest.php` | 7 | Evidence section visibility, image upload/delete, cascade delete |
+| `tests/Feature/Livewire/DisciplineReportsCardTest.php` | 12+ | Reports card access, CRUD, publish, risk score |
+| `tests/Feature/Finance/FinanceDashboardTest.php` | 9 | Finance dashboard access, cash position, monthly totals, pending drafts |
+
+---
+
+### Test Case Inventory
+
+**`tests/Feature/StaffPageTest.php`**
+- loads the public staff page without authentication
+- displays filled positions with user names
+- displays vacant positions as open
+- groups positions by department
+- does not display departments with no positions
+- displays board members section on the public page
+- does not display board members section when no board members exist
+- shows linked board member with user staff name
+- shows unlinked board member with display name
+- does not render the old sidebar panel markup
+- selectPosition sets selectedPositionId and selectedPosition returns the correct model
+- renders markdown responsibilities as HTML in the modal content
+
+**`tests/Feature/Livewire/ReportEvidenceUITest.php`**
+- view-report shows Evidence section with img elements when report has images
+- view-report does not render Evidence section when report has no images
+- opening edit modal for a published report is forbidden
+- edit modal image UI is rendered for a draft report
+- images attached via AttachDisciplineReportImages are retrievable from the report
+- deleting a report also removes its image files from disk
+- removeImage marks an image ID for pending removal without immediately deleting
+
+**`tests/Feature/Livewire/DisciplineReportsCardTest.php`**
+- shows discipline reports card to staff on profile page
+- shows discipline reports card to the subject user
+- shows discipline reports card to parent of subject
+- hides discipline reports card from unrelated users
+- shows only published reports to non-staff users
+- shows all reports including drafts to staff
+- allows staff to create a report via modal
+- allows user with Discipline Report - Publisher role to publish a draft report
+- prevents non-officer from publishing
+- allows creator to edit their draft report
+- prevents editing of published reports
+- shows risk score badge with correct color
+
+**`tests/Feature/Finance/FinanceDashboardTest.php`**
+- finance-view user can access finance dashboard
+- user without finance role cannot access finance dashboard
+- unauthenticated user cannot access finance dashboard
+- cash position shows correct balance for a posted journal entry
+- draft entries are excluded from cash position
+- current month income total reflects posted entries in current calendar month
+- current month expenses reflect posted entries in current calendar month
+- draft entries are excluded from current month totals
+- pending drafts count matches draft journal entries
+
+---
+
+### Coverage Gaps
+
+- No test for `removeImage` followed by `updateReport` verifying that the image is actually deleted from disk after the full update flow (only the pending state is tested)
+- No test for `sixMonthTrend` computed property on the finance dashboard
+- No test for `ytdSummary` or `netAssets` computed properties on the finance dashboard
+- No test for the board member modal rendering (staff page tests cover position modal but not board member modal detail content)
+- No test for `AttachDisciplineReportImages` throwing `RuntimeException` on a published report via the Livewire component (the action's guard is tested at the action level but not exercised through the UI path)
+- No test for `SiteConfig::getValue('max_image_size_kb')` affecting validation (always uses the 2048 default in tests)
+
+---
+
+## 17. File Map
+
+**Models:**
+- `app/Models/DisciplineReport.php`
+- `app/Models/DisciplineReportImage.php`
+- `app/Models/StaffPosition.php`
+- `app/Models/BoardMember.php`
+- `app/Models/FinancialAccount.php`
+- `app/Models/FinancialJournalEntry.php`
+- `app/Models/FinancialJournalEntryLine.php`
+- `app/Models/FinancialPeriod.php`
+- `app/Models/FinancialBudget.php`
+- `app/Models/FinancialBudgetLine.php`
+- `app/Models/FinancialRestrictedFund.php`
+
+**Actions:**
+- `app/Actions/AttachDisciplineReportImages.php`
+
+**Policies:**
+- `app/Policies/DisciplineReportPolicy.php`
+
+**Gates:** `app/Providers/AuthServiceProvider.php` — gates: `view-discipline-report-log`, `view-user-discipline-reports`, `manage-discipline-reports`, `publish-discipline-reports`, `edit-staff-bio`, `board-member`, `finance-view`, `finance-record`, `finance-manage`, `finance-community-view`
+
+**Notifications:** None
+
+**Jobs:** None
+
+**Services:**
+- `app/Services/StorageService.php` (used for image URL generation)
+
+**Controllers:** None (all Volt components)
+
+**Volt Components:**
+- `resources/views/livewire/staff/page.blade.php`
+- `resources/views/livewire/users/discipline-reports-card.blade.php`
+- `resources/views/livewire/reports/view-report.blade.php`
+- `resources/views/livewire/finance/dashboard.blade.php`
+
+**Routes:**
+- `staff.index` → `/staff`
+- `finance.dashboard.index` → `/finance/dashboard`
+
+**Migrations:**
+- `database/migrations/2026_04_26_024008_create_discipline_report_images_table.php`
+- `database/migrations/2026_04_05_000001_create_financial_tables.php` (pre-existing; finance dashboard reads these tables)
+
+**Console Commands:** None
+
+**Tests:**
+- `tests/Feature/StaffPageTest.php`
+- `tests/Feature/Livewire/ReportEvidenceUITest.php`
+- `tests/Feature/Livewire/DisciplineReportsCardTest.php`
+- `tests/Feature/Finance/FinanceDashboardTest.php`
+
+**Config:**
+- `SiteConfig` key: `max_image_size_kb`
+- Config key: `filesystems.public_disk`
+
+**Other:**
+- `resources/views/dashboard/ready-room.blade.php` — Finance button updated to link to `finance.dashboard.index`
+- `resources/views/livewire/finance/partials/nav.blade.php` — Dashboard nav link added as first item
+
+---
+
+## 18. Known Issues & Improvement Opportunities
+
+1. **Missing full-flow image deletion test.** `removeImage` is tested to only stage the deletion without immediately deleting, but there is no test that completes the round-trip through `updateReport()` and verifies the file is gone from disk. A bug in `updateReport()`'s deletion loop would not be caught.
+
+2. **Finance dashboard coverage gaps.** `sixMonthTrend`, `ytdSummary`, and `netAssets` have no test coverage. These involve complex raw SQL with fiscal year detection and CASE WHEN expressions — exactly the kind of logic that benefits most from regression tests.
+
+3. **N+1 risk in `selectedPosition` computed property.** `StaffPosition::with(['user.minecraftAccounts','user.discordAccounts'])` is called once per click, which is fine, but if the board member section were to also eager-load user relations at mount time, a large staff list would cause multiple queries. Currently `boardMembers` loads `with('user')` in bulk, which is correct.
+
+4. **`removeImage` authorization re-fetches report.** The `removeImage` method re-fetches the editing report from the database to call `authorize('update', $report)`. This is correct for security but adds a query per removal click. Since removal is staging-only (no immediate DB write), a lighter check using the `$editingReportId` already held in the locked property would be equivalent.
+
+5. **`SiteConfig::getValue('max_image_size_kb')` not cached.** Called on every `createReport()` and `updateReport()` invocation. If SiteConfig reads from the database (rather than a cached value), this is an extra query per upload. Depends on SiteConfig implementation.
+
+6. **Image uploads allowed only on drafts, but the check is in the Action, not the Policy.** `AttachDisciplineReportImages::run()` throws `RuntimeException` if the report is published. This guard is not in `DisciplineReportPolicy@update`, which means a crafted request could reach the action with a published report and receive an uncaught exception rather than a proper 403 response.
+
+7. **No soft deletes on `DisciplineReportImage`.** Images are hard-deleted (DB row + file) when removed. There is no audit trail of what images were ever attached to a report. This may be intentional but is worth noting for compliance/audit use cases.
+
+8. **Finance dashboard YTD uses `fiscal_year` from `FinancialPeriod`** — if the current date falls between fiscal years (e.g., no period covering today), the YTD query returns empty results silently. Consider adding a user-visible indicator when no active period is found.

--- a/resources/library/books/staff-handbook/03-support-and-moderation/02-discipline-reports/01-creating-reports.md
+++ b/resources/library/books/staff-handbook/03-support-and-moderation/02-discipline-reports/01-creating-reports.md
@@ -48,8 +48,32 @@ Severity points feed into the member's **risk score**, which helps staff identif
 
 Categories are tags that help classify what type of incident occurred. Common categories include Language, Harassment, Griefing, Cheating, Disrespect, Spam, and Inappropriate Content. Officers can manage categories from the Admin Control Panel.
 
+## Attaching Evidence Images
+
+You can attach screenshots or photos to a report while it's in draft. Images are a permanent part of the report once the report is published.
+
+**To attach images when creating a report:**
+
+1. In the **New Report** form, scroll to the **Evidence Images** section
+2. Click **Choose Files** (or drag and drop) to select one or more image files
+3. Preview thumbnails appear immediately -- verify you've selected the right files
+4. Click **Save** -- images are uploaded and attached to the draft
+
+**To add or remove images on an existing draft:**
+
+1. Open the report in **edit mode**
+2. Existing images are shown in the **Evidence Images** section
+3. Click the **×** on an image to remove it (this takes effect when you click **Update**)
+4. Use the file input below to add new images
+5. Click **Update Report** to save your changes
+
+Accepted formats: JPG, PNG, GIF, WEBP. Images are rejected if they exceed the configured maximum size.
+
+Once a report is published, the evidence section is locked -- you can't add or remove images from a published report.
+
 ## Important Notes
 
 - Reports are **not** discipline actions themselves -- they're documentation. Use the [[books/staff-handbook/user-management/the-brig/putting-users-in-the-brig|Brig]] for restricting access.
 - Write factual, specific descriptions. Avoid emotional language -- these reports may be seen by the member and their parents.
 - You can edit your own draft reports until they're published. After publication, reports cannot be edited.
+- Evidence images are visible to the report subject and their parents on published reports. Only attach images that are appropriate for the subject to see.

--- a/resources/library/books/staff-handbook/10-finance/01-overview/02-finance-dashboard.md
+++ b/resources/library/books/staff-handbook/10-finance/01-overview/02-finance-dashboard.md
@@ -1,0 +1,63 @@
+---
+title: "Finance Dashboard"
+visibility: staff
+order: 2
+summary: "How to use the Finance Dashboard to get an at-a-glance picture of financial health."
+---
+
+## Overview
+
+The **Finance Dashboard** is the landing page for the Finance System. It gives you a quick summary of Lighthouse's financial position without having to dig through the journal or run reports manually. All figures shown are based on **posted** journal entries only -- drafts aren't counted until they're posted.
+
+## Who Can Do This
+
+Any staff member with the **Finance - View**, **Finance - Record**, or **Finance - Manage** role can access the dashboard. See [[books/staff-handbook/finance/overview/finance-roles|Finance Roles and Access]] for details.
+
+## Getting There
+
+From the Ready Room, click **Finance**. The dashboard is the first page you land on. You can also reach it by clicking **Dashboard** in the Finance navigation bar.
+
+## What's on the Dashboard
+
+### Cash Position
+
+The top section shows your current balance across each active bank account, plus a total. These figures are calculated from all posted entries to date -- not just the current period.
+
+### Current Month
+
+The current month section shows:
+- **Income** -- total revenue earned so far this calendar month
+- **Expenses** -- total expenses recorded so far this calendar month
+- **Net** -- income minus expenses for the month
+- **Budgeted** amounts for income and expenses if budgets have been set for the current fiscal period
+
+Use this section to see whether the month is tracking to budget.
+
+### 6-Month Trend
+
+The trend chart shows income and expenses for each of the past six months as a line chart. Use it to spot patterns -- rising expenses, seasonal income dips, or unusual spikes -- at a glance.
+
+### Year-to-Date Summary
+
+The YTD section shows cumulative income, expenses, and net for the current fiscal year. The fiscal year is determined by the open fiscal periods in the system.
+
+If no fiscal period covers today's date, this section will appear empty.
+
+### Net Assets
+
+This section breaks down the organization's net worth:
+- **Total** -- assets minus liabilities
+- **Unrestricted** -- funds available for general use
+- **Restricted** -- funds designated for a specific purpose
+
+### Pending Drafts
+
+The bottom of the dashboard shows a count of journal entries that have been created but not yet posted. Click the link to go directly to the journal, filtered to drafts.
+
+Pending drafts won't appear in any of the financial figures until they're posted. If the draft count is growing, it's worth checking whether entries need to be reviewed and posted.
+
+## Important Notes
+
+- All figures are read-only on the dashboard -- no edits happen here.
+- The dashboard doesn't auto-refresh. Reload the page to see the latest figures after posting new entries.
+- If bank account balances look unexpected, check whether any recent entries are still in draft status.

--- a/resources/library/books/user-handbook/03-website/03-parent-portal/02-managing-your-childs-account.md
+++ b/resources/library/books/user-handbook/03-website/03-parent-portal/02-managing-your-childs-account.md
@@ -41,7 +41,7 @@ When a child account is first created, the default permission settings depend on
 Each child's card also shows:
 
 - **Recent Tickets** -- The most recent support tickets involving your child, so you can see if they've reached out for help or been contacted by staff
-- **Discipline Reports** -- Any published reports related to your child's behavior in the community. You can click on a report to see the full details, including what happened and what actions were taken
+- **Discipline Reports** -- Any published reports related to your child's behavior in the community. You can click on a report to see the full details, including what happened, what actions were taken, and any evidence images staff attached to the report
 
 ## Releasing to an Independent Account
 

--- a/resources/library/books/user-handbook/03-website/08-staff-team/02-browsing-the-staff-page.md
+++ b/resources/library/books/user-handbook/03-website/08-staff-team/02-browsing-the-staff-page.md
@@ -1,0 +1,39 @@
+---
+title: "Browsing the Staff Team"
+visibility: public
+order: 2
+summary: "How to explore staff positions and board member profiles on the staff page."
+---
+
+## Overview
+
+The [Staff Page]({{url:/staff}}) shows everyone who keeps Lighthouse running -- staff members in each department, plus the Board of Directors. It's the best place to put a name to a face, learn what each role involves, or find out who to contact.
+
+## Viewing a Staff Position
+
+Each department shows a grid of positions. Filled positions display the staff member's name and rank; vacant positions show as **Open**.
+
+Click any position card to open a panel with full details:
+
+- **Title and department** -- What the role is called and which team it belongs to
+- **Rank badge** -- Whether this is a Junior Crew, Crew Member, or Officer role
+- **Description** -- What this person does as part of the team
+- **Responsibilities** -- A detailed list of their day-to-day duties
+- **Requirements** -- What's expected of someone in this position
+- **Staff member info** -- For filled positions, the assigned staff member's photo, name, and links to reach them on Discord or Minecraft
+
+Close the panel by clicking the X or clicking anywhere outside it.
+
+## Applying for an Open Position
+
+If a vacant position is currently accepting applications, you'll see an **Apply for this Position** button inside the position panel. Clicking it takes you directly to the application form for that role.
+
+Not all open positions accept applications at all times -- if you don't see the Apply button, that role isn't currently recruiting. Check back later or keep an eye on community announcements.
+
+For a full walkthrough of the application process, see [[books/user-handbook/website/staff-applications/applying-for-a-position|Applying for a Position]].
+
+## Viewing Board Members
+
+The lower section of the staff page shows the **Board of Directors**. Click any board member card to see their profile, including their photo, title, bio, and any contact links.
+
+Board member positions are appointed rather than applied for. They aren't shown in the department grid above.

--- a/resources/views/dashboard/ready-room.blade.php
+++ b/resources/views/dashboard/ready-room.blade.php
@@ -11,7 +11,7 @@
                 View Tickets
             </flux:button>
             @can('finance-view')
-                <flux:button href="{{ route('finance.journal.index') }}" wire:navigate icon="banknotes">
+                <flux:button href="{{ route('finance.dashboard.index') }}" wire:navigate icon="banknotes">
                     Finance
                 </flux:button>
             @endcan

--- a/resources/views/livewire/finance/dashboard.blade.php
+++ b/resources/views/livewire/finance/dashboard.blade.php
@@ -1,0 +1,437 @@
+<?php
+
+use App\Models\FinancialAccount;
+use App\Models\FinancialBudget;
+use App\Models\FinancialJournalEntry;
+use App\Models\FinancialPeriod;
+use Illuminate\Support\Facades\DB;
+use Livewire\Volt\Component;
+
+new class extends Component
+{
+    public function mount(): void
+    {
+        $this->authorize('finance-view');
+    }
+
+    public function getCashPositionProperty(): array
+    {
+        $accounts = FinancialAccount::where('is_bank_account', true)
+            ->where('is_active', true)
+            ->orderBy('code')
+            ->get();
+
+        $items = [];
+        $total = 0;
+
+        foreach ($accounts as $account) {
+            $balance = (int) DB::table('financial_journal_entry_lines as jel')
+                ->join('financial_journal_entries as je', 'je.id', '=', 'jel.journal_entry_id')
+                ->where('jel.account_id', $account->id)
+                ->where('je.status', 'posted')
+                ->selectRaw('COALESCE(SUM(jel.debit) - SUM(jel.credit), 0) as balance')
+                ->value('balance');
+
+            $items[] = ['name' => $account->name, 'balance' => $balance];
+            $total += $balance;
+        }
+
+        return ['accounts' => $items, 'total' => $total];
+    }
+
+    public function getCurrentMonthProperty(): array
+    {
+        $start = now()->startOfMonth()->toDateString();
+        $end = now()->endOfMonth()->toDateString();
+
+        $income = (int) DB::table('financial_journal_entry_lines as jel')
+            ->join('financial_journal_entries as je', 'je.id', '=', 'jel.journal_entry_id')
+            ->join('financial_accounts as fa', 'fa.id', '=', 'jel.account_id')
+            ->where('je.status', 'posted')
+            ->where('fa.type', 'revenue')
+            ->whereBetween('je.date', [$start, $end])
+            ->selectRaw('COALESCE(SUM(jel.credit) - SUM(jel.debit), 0) as total')
+            ->value('total');
+
+        $expenses = (int) DB::table('financial_journal_entry_lines as jel')
+            ->join('financial_journal_entries as je', 'je.id', '=', 'jel.journal_entry_id')
+            ->join('financial_accounts as fa', 'fa.id', '=', 'jel.account_id')
+            ->where('je.status', 'posted')
+            ->where('fa.type', 'expense')
+            ->whereBetween('je.date', [$start, $end])
+            ->selectRaw('COALESCE(SUM(jel.debit) - SUM(jel.credit), 0) as total')
+            ->value('total');
+
+        $period = FinancialPeriod::where('start_date', '<=', today())
+            ->where('end_date', '>=', today())
+            ->first();
+
+        $incomeBudget = 0;
+        $expenseBudget = 0;
+
+        if ($period) {
+            $incomeBudget = (int) FinancialBudget::where('period_id', $period->id)
+                ->whereHas('account', fn ($q) => $q->where('type', 'revenue'))
+                ->sum('amount');
+
+            $expenseBudget = (int) FinancialBudget::where('period_id', $period->id)
+                ->whereHas('account', fn ($q) => $q->where('type', 'expense'))
+                ->sum('amount');
+        }
+
+        return [
+            'income' => $income,
+            'expenses' => $expenses,
+            'income_budget' => $incomeBudget,
+            'expense_budget' => $expenseBudget,
+            'chart_data' => [
+                ['category' => 'Income', 'actual' => round($income / 100, 2), 'budget' => round($incomeBudget / 100, 2)],
+                ['category' => 'Expenses', 'actual' => round($expenses / 100, 2), 'budget' => round($expenseBudget / 100, 2)],
+            ],
+        ];
+    }
+
+    public function getSixMonthTrendProperty(): array
+    {
+        $data = [];
+
+        for ($i = 5; $i >= 0; $i--) {
+            $month = now()->startOfMonth()->subMonths($i);
+            $start = $month->copy()->startOfMonth()->toDateString();
+            $end = $month->copy()->endOfMonth()->toDateString();
+
+            $income = (int) DB::table('financial_journal_entry_lines as jel')
+                ->join('financial_journal_entries as je', 'je.id', '=', 'jel.journal_entry_id')
+                ->join('financial_accounts as fa', 'fa.id', '=', 'jel.account_id')
+                ->where('je.status', 'posted')
+                ->where('fa.type', 'revenue')
+                ->whereBetween('je.date', [$start, $end])
+                ->selectRaw('COALESCE(SUM(jel.credit) - SUM(jel.debit), 0) as total')
+                ->value('total');
+
+            $expense = (int) DB::table('financial_journal_entry_lines as jel')
+                ->join('financial_journal_entries as je', 'je.id', '=', 'jel.journal_entry_id')
+                ->join('financial_accounts as fa', 'fa.id', '=', 'jel.account_id')
+                ->where('je.status', 'posted')
+                ->where('fa.type', 'expense')
+                ->whereBetween('je.date', [$start, $end])
+                ->selectRaw('COALESCE(SUM(jel.debit) - SUM(jel.credit), 0) as total')
+                ->value('total');
+
+            $data[] = [
+                'month' => $month->format('M Y'),
+                'income' => round($income / 100, 2),
+                'expense' => round($expense / 100, 2),
+            ];
+        }
+
+        return $data;
+    }
+
+    public function getYtdSummaryProperty(): array
+    {
+        $todaysPeriod = FinancialPeriod::where('start_date', '<=', today())
+            ->where('end_date', '>=', today())
+            ->first();
+
+        if (! $todaysPeriod) {
+            return ['income' => 0, 'expenses' => 0, 'income_budget' => 0, 'expense_budget' => 0, 'fiscal_year' => null];
+        }
+
+        $fiscalYear = $todaysPeriod->fiscal_year;
+        $periodIds = FinancialPeriod::where('fiscal_year', $fiscalYear)->pluck('id');
+
+        $income = (int) DB::table('financial_journal_entry_lines as jel')
+            ->join('financial_journal_entries as je', 'je.id', '=', 'jel.journal_entry_id')
+            ->join('financial_accounts as fa', 'fa.id', '=', 'jel.account_id')
+            ->where('je.status', 'posted')
+            ->where('fa.type', 'revenue')
+            ->whereIn('je.period_id', $periodIds)
+            ->selectRaw('COALESCE(SUM(jel.credit) - SUM(jel.debit), 0) as total')
+            ->value('total');
+
+        $expenses = (int) DB::table('financial_journal_entry_lines as jel')
+            ->join('financial_journal_entries as je', 'je.id', '=', 'jel.journal_entry_id')
+            ->join('financial_accounts as fa', 'fa.id', '=', 'jel.account_id')
+            ->where('je.status', 'posted')
+            ->where('fa.type', 'expense')
+            ->whereIn('je.period_id', $periodIds)
+            ->selectRaw('COALESCE(SUM(jel.debit) - SUM(jel.credit), 0) as total')
+            ->value('total');
+
+        $incomeBudget = (int) FinancialBudget::whereIn('period_id', $periodIds)
+            ->whereHas('account', fn ($q) => $q->where('type', 'revenue'))
+            ->sum('amount');
+
+        $expenseBudget = (int) FinancialBudget::whereIn('period_id', $periodIds)
+            ->whereHas('account', fn ($q) => $q->where('type', 'expense'))
+            ->sum('amount');
+
+        return [
+            'income' => $income,
+            'expenses' => $expenses,
+            'income_budget' => $incomeBudget,
+            'expense_budget' => $expenseBudget,
+            'fiscal_year' => $fiscalYear,
+        ];
+    }
+
+    public function getNetAssetsProperty(): array
+    {
+        $totalAssets = (int) DB::table('financial_journal_entry_lines as jel')
+            ->join('financial_journal_entries as je', 'je.id', '=', 'jel.journal_entry_id')
+            ->join('financial_accounts as fa', 'fa.id', '=', 'jel.account_id')
+            ->where('je.status', 'posted')
+            ->where('fa.type', 'asset')
+            ->selectRaw('COALESCE(SUM(jel.debit) - SUM(jel.credit), 0) as total')
+            ->value('total');
+
+        $totalLiabilities = (int) DB::table('financial_journal_entry_lines as jel')
+            ->join('financial_journal_entries as je', 'je.id', '=', 'jel.journal_entry_id')
+            ->join('financial_accounts as fa', 'fa.id', '=', 'jel.account_id')
+            ->where('je.status', 'posted')
+            ->where('fa.type', 'liability')
+            ->selectRaw('COALESCE(SUM(jel.credit) - SUM(jel.debit), 0) as total')
+            ->value('total');
+
+        $total = $totalAssets - $totalLiabilities;
+
+        $restricted = (int) DB::table('financial_journal_entry_lines as jel')
+            ->join('financial_journal_entries as je', 'je.id', '=', 'jel.journal_entry_id')
+            ->join('financial_accounts as fa', 'fa.id', '=', 'jel.account_id')
+            ->where('je.status', 'posted')
+            ->whereNotNull('je.restricted_fund_id')
+            ->selectRaw("COALESCE(SUM(CASE WHEN fa.type = 'revenue' THEN jel.credit - jel.debit ELSE 0 END) - SUM(CASE WHEN fa.type = 'expense' THEN jel.debit - jel.credit ELSE 0 END), 0) as total")
+            ->value('total');
+
+        return [
+            'total' => $total,
+            'restricted' => $restricted,
+            'unrestricted' => $total - $restricted,
+        ];
+    }
+
+    public function getPendingDraftsProperty(): int
+    {
+        return FinancialJournalEntry::where('status', 'draft')->count();
+    }
+}; ?>
+
+<div class="space-y-6">
+    <div class="flex items-center justify-between">
+        <div>
+            <flux:heading size="xl">Finance Dashboard</flux:heading>
+            <flux:text variant="subtle">Financial overview — posted entries only.</flux:text>
+        </div>
+    </div>
+
+    @include('livewire.finance.partials.nav')
+
+    {{-- Cash Position --}}
+    <div>
+        <flux:heading size="md" class="mb-3">Cash Position</flux:heading>
+        <div class="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 gap-4">
+            @foreach ($this->cashPosition['accounts'] as $account)
+                <flux:card class="p-4">
+                    <flux:text variant="subtle" class="text-xs">{{ $account['name'] }}</flux:text>
+                    <p class="text-2xl font-mono font-semibold mt-1 {{ $account['balance'] >= 0 ? '' : 'text-red-600 dark:text-red-400' }}">
+                        {{ $account['balance'] < 0 ? '-' : '' }}${{ number_format(abs($account['balance']) / 100, 2) }}
+                    </p>
+                </flux:card>
+            @endforeach
+
+            <flux:card class="p-4 border-2 border-zinc-300 dark:border-zinc-600">
+                <flux:text variant="subtle" class="text-xs font-semibold">Total Cash</flux:text>
+                <p class="text-2xl font-mono font-semibold mt-1 {{ $this->cashPosition['total'] >= 0 ? 'text-green-600 dark:text-green-400' : 'text-red-600 dark:text-red-400' }}">
+                    {{ $this->cashPosition['total'] < 0 ? '-' : '' }}${{ number_format(abs($this->cashPosition['total']) / 100, 2) }}
+                </p>
+            </flux:card>
+        </div>
+    </div>
+
+    {{-- Current Month --}}
+    @php $currentMonth = $this->currentMonth; @endphp
+    <flux:card>
+        <flux:heading size="md" class="mb-4">Current Month — {{ now()->format('F Y') }}</flux:heading>
+
+        <div class="grid grid-cols-1 sm:grid-cols-2 gap-6 mb-6">
+            <div>
+                <flux:text variant="subtle" class="text-xs">Income</flux:text>
+                <p class="text-3xl font-mono font-semibold text-green-600 dark:text-green-400 mt-1">
+                    ${{ number_format($currentMonth['income'] / 100, 2) }}
+                </p>
+                @if ($currentMonth['income_budget'] > 0)
+                    <flux:text variant="subtle" class="text-xs mt-1">
+                        Budget: ${{ number_format($currentMonth['income_budget'] / 100, 2) }}
+                    </flux:text>
+                @endif
+            </div>
+            <div>
+                <flux:text variant="subtle" class="text-xs">Expenses</flux:text>
+                <p class="text-3xl font-mono font-semibold text-red-600 dark:text-red-400 mt-1">
+                    ${{ number_format($currentMonth['expenses'] / 100, 2) }}
+                </p>
+                @if ($currentMonth['expense_budget'] > 0)
+                    <flux:text variant="subtle" class="text-xs mt-1">
+                        Budget: ${{ number_format($currentMonth['expense_budget'] / 100, 2) }}
+                    </flux:text>
+                @endif
+            </div>
+        </div>
+
+        @if ($currentMonth['income_budget'] > 0 || $currentMonth['expense_budget'] > 0)
+            <flux:chart :value="$currentMonth['chart_data']" class="aspect-[4/1]">
+                <flux:chart.svg gutter="8 8 28 8">
+                    <flux:chart.axis axis="x" field="category">
+                        <flux:chart.axis.tick class="text-zinc-400 text-xs" />
+                        <flux:chart.axis.line class="text-zinc-600" />
+                    </flux:chart.axis>
+                    <flux:chart.axis axis="y">
+                        <flux:chart.axis.grid class="text-zinc-700" />
+                        <flux:chart.axis.tick class="text-zinc-400 text-xs" />
+                    </flux:chart.axis>
+                    <flux:chart.line field="actual" class="text-blue-500" />
+                    <flux:chart.point field="actual" class="text-blue-400" />
+                    <flux:chart.line field="budget" class="text-zinc-500" />
+                    <flux:chart.point field="budget" class="text-zinc-400" />
+                    <flux:chart.cursor />
+                </flux:chart.svg>
+                <flux:chart.tooltip>
+                    <flux:chart.tooltip.heading field="category" />
+                    <flux:chart.tooltip.value field="actual" label="Actual" />
+                    <flux:chart.tooltip.value field="budget" label="Budget" />
+                </flux:chart.tooltip>
+            </flux:chart>
+        @endif
+    </flux:card>
+
+    {{-- 6-Month Trend --}}
+    <flux:card>
+        <flux:heading size="md" class="mb-4">6-Month Trend</flux:heading>
+        <flux:chart :value="$this->sixMonthTrend" class="aspect-[3/1]">
+            <flux:chart.svg gutter="8 8 28 8">
+                <flux:chart.axis axis="x" field="month">
+                    <flux:chart.axis.tick class="text-zinc-400 text-xs" />
+                    <flux:chart.axis.line class="text-zinc-600" />
+                </flux:chart.axis>
+                <flux:chart.axis axis="y">
+                    <flux:chart.axis.grid class="text-zinc-700" />
+                    <flux:chart.axis.tick class="text-zinc-400 text-xs" />
+                </flux:chart.axis>
+                <flux:chart.line field="income" class="text-green-500" />
+                <flux:chart.point field="income" class="text-green-400" />
+                <flux:chart.line field="expense" class="text-red-500" />
+                <flux:chart.point field="expense" class="text-red-400" />
+                <flux:chart.cursor />
+            </flux:chart.svg>
+            <flux:chart.tooltip>
+                <flux:chart.tooltip.heading field="month" />
+                <flux:chart.tooltip.value field="income" label="Income" />
+                <flux:chart.tooltip.value field="expense" label="Expenses" />
+            </flux:chart.tooltip>
+        </flux:chart>
+    </flux:card>
+
+    {{-- YTD Summary + Net Assets side by side --}}
+    @php $ytd = $this->ytdSummary; $netAssets = $this->netAssets; @endphp
+    <div class="grid grid-cols-1 lg:grid-cols-2 gap-6">
+        {{-- YTD Summary --}}
+        <flux:card>
+            <flux:heading size="md" class="mb-4">
+                YTD Summary
+                @if ($ytd['fiscal_year'])
+                    <span class="text-sm font-normal text-zinc-400">FY{{ $ytd['fiscal_year'] }}</span>
+                @endif
+            </flux:heading>
+            <div class="space-y-4">
+                <div>
+                    <div class="flex items-center justify-between">
+                        <flux:text variant="subtle" class="text-sm">Income</flux:text>
+                        <span class="font-mono font-semibold text-green-600 dark:text-green-400">
+                            ${{ number_format($ytd['income'] / 100, 2) }}
+                        </span>
+                    </div>
+                    @if ($ytd['income_budget'] > 0)
+                        <div class="flex items-center justify-between">
+                            <flux:text variant="subtle" class="text-xs">Budget</flux:text>
+                            <flux:text variant="subtle" class="text-xs font-mono">
+                                ${{ number_format($ytd['income_budget'] / 100, 2) }}
+                            </flux:text>
+                        </div>
+                    @endif
+                </div>
+                <flux:separator variant="subtle" />
+                <div>
+                    <div class="flex items-center justify-between">
+                        <flux:text variant="subtle" class="text-sm">Expenses</flux:text>
+                        <span class="font-mono font-semibold text-red-600 dark:text-red-400">
+                            ${{ number_format($ytd['expenses'] / 100, 2) }}
+                        </span>
+                    </div>
+                    @if ($ytd['expense_budget'] > 0)
+                        <div class="flex items-center justify-between">
+                            <flux:text variant="subtle" class="text-xs">Budget</flux:text>
+                            <flux:text variant="subtle" class="text-xs font-mono">
+                                ${{ number_format($ytd['expense_budget'] / 100, 2) }}
+                            </flux:text>
+                        </div>
+                    @endif
+                </div>
+                <flux:separator variant="subtle" />
+                <div class="flex items-center justify-between">
+                    <flux:text class="text-sm font-semibold">Net</flux:text>
+                    @php $ytdNet = $ytd['income'] - $ytd['expenses']; @endphp
+                    <span class="font-mono font-semibold {{ $ytdNet >= 0 ? 'text-green-600 dark:text-green-400' : 'text-red-600 dark:text-red-400' }}">
+                        {{ $ytdNet < 0 ? '-' : '' }}${{ number_format(abs($ytdNet) / 100, 2) }}
+                    </span>
+                </div>
+            </div>
+        </flux:card>
+
+        {{-- Net Assets --}}
+        <flux:card>
+            <flux:heading size="md" class="mb-4">Net Assets</flux:heading>
+            <div class="space-y-4">
+                <div class="flex items-center justify-between">
+                    <flux:text variant="subtle" class="text-sm">Total Net Assets</flux:text>
+                    <span class="font-mono font-semibold text-xl {{ $netAssets['total'] >= 0 ? '' : 'text-red-600 dark:text-red-400' }}">
+                        {{ $netAssets['total'] < 0 ? '-' : '' }}${{ number_format(abs($netAssets['total']) / 100, 2) }}
+                    </span>
+                </div>
+                <flux:separator variant="subtle" />
+                <div class="flex items-center justify-between">
+                    <flux:text variant="subtle" class="text-sm">Unrestricted</flux:text>
+                    <span class="font-mono">
+                        {{ $netAssets['unrestricted'] < 0 ? '-' : '' }}${{ number_format(abs($netAssets['unrestricted']) / 100, 2) }}
+                    </span>
+                </div>
+                <div class="flex items-center justify-between">
+                    <flux:text variant="subtle" class="text-sm">Restricted</flux:text>
+                    <span class="font-mono">
+                        ${{ number_format($netAssets['restricted'] / 100, 2) }}
+                    </span>
+                </div>
+            </div>
+        </flux:card>
+    </div>
+
+    {{-- Pending Drafts --}}
+    <flux:card>
+        <div class="flex items-center justify-between">
+            <div>
+                <flux:heading size="md">Pending Drafts</flux:heading>
+                <flux:text variant="subtle" class="text-sm mt-1">Journal entries awaiting review and posting.</flux:text>
+            </div>
+            <div class="flex items-center gap-4">
+                <span class="text-3xl font-bold {{ $this->pendingDrafts > 0 ? 'text-amber-500' : 'text-zinc-400' }}">
+                    {{ $this->pendingDrafts }}
+                </span>
+                @if ($this->pendingDrafts > 0)
+                    <flux:button href="{{ route('finance.journal.index') }}" wire:navigate variant="ghost" size="sm" icon="arrow-right">
+                        View Journal
+                    </flux:button>
+                @endif
+            </div>
+        </div>
+    </flux:card>
+</div>

--- a/resources/views/livewire/finance/partials/nav.blade.php
+++ b/resources/views/livewire/finance/partials/nav.blade.php
@@ -1,5 +1,12 @@
 <nav class="flex flex-wrap gap-2 pb-2 border-b border-zinc-200 dark:border-zinc-700">
     <flux:button
+        variant="{{ request()->routeIs('finance.dashboard.index') ? 'filled' : 'ghost' }}"
+        size="sm"
+        href="{{ route('finance.dashboard.index') }}"
+        wire:navigate
+    >Dashboard</flux:button>
+
+    <flux:button
         variant="{{ request()->routeIs('finance.journal.*') ? 'filled' : 'ghost' }}"
         size="sm"
         href="{{ route('finance.journal.index') }}"

--- a/resources/views/livewire/reports/view-report.blade.php
+++ b/resources/views/livewire/reports/view-report.blade.php
@@ -15,7 +15,7 @@ new class extends Component
     public function mount(DisciplineReport $report): void
     {
         $this->authorize('view', $report);
-        $this->report = $report->load(['subject', 'reporter', 'publisher', 'category', 'violatedRules']);
+        $this->report = $report->load(['subject', 'reporter', 'publisher', 'category', 'violatedRules', 'images']);
     }
 
     #[Computed]
@@ -161,6 +161,20 @@ new class extends Component
             <div>
                 <flux:text class="font-bold text-sm">Date</flux:text>
                 <flux:text>{{ ($report->published_at ?? $report->created_at)->format('M j, Y g:i A') }}</flux:text>
+            </div>
+        </flux:card>
+    @endif
+
+    {{-- Evidence --}}
+    @if($report->images->isNotEmpty())
+        <flux:card>
+            <flux:heading size="sm" class="mb-3">Evidence</flux:heading>
+            <div class="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-3">
+                @foreach($report->images as $image)
+                    <a href="{{ $image->url() }}" target="_blank" rel="noopener" wire:key="evidence-img-{{ $image->id }}">
+                        <img src="{{ $image->url() }}" alt="{{ $image->original_filename }}" class="rounded-lg object-cover aspect-square w-full hover:opacity-90 transition" />
+                    </a>
+                @endforeach
             </div>
         </flux:card>
     @endif

--- a/resources/views/livewire/staff-applications/apply.blade.php
+++ b/resources/views/livewire/staff-applications/apply.blade.php
@@ -144,18 +144,24 @@ new class extends Component {
                     <flux:badge size="sm" color="zinc">{{ $staffPosition->department->label() }}</flux:badge>
                 </div>
                 @if($staffPosition->description)
-                    <flux:text variant="subtle">{{ $staffPosition->description }}</flux:text>
+                    <div class="prose prose-sm dark:prose-invert max-w-none">
+                        {!! Str::markdown($staffPosition->description, ['html_input' => 'strip', 'allow_unsafe_links' => false]) !!}
+                    </div>
                 @endif
                 @if($staffPosition->responsibilities)
                     <div>
                         <flux:text class="font-medium">Responsibilities:</flux:text>
-                        <flux:text>{{ $staffPosition->responsibilities }}</flux:text>
+                        <div class="prose prose-sm dark:prose-invert max-w-none">
+                            {!! Str::markdown($staffPosition->responsibilities, ['html_input' => 'strip', 'allow_unsafe_links' => false]) !!}
+                        </div>
                     </div>
                 @endif
                 @if($staffPosition->requirements)
                     <div>
                         <flux:text class="font-medium">Requirements:</flux:text>
-                        <flux:text>{{ $staffPosition->requirements }}</flux:text>
+                        <div class="prose prose-sm dark:prose-invert max-w-none">
+                            {!! Str::markdown($staffPosition->requirements, ['html_input' => 'strip', 'allow_unsafe_links' => false]) !!}
+                        </div>
                     </div>
                 @endif
             </div>

--- a/resources/views/livewire/staff/page.blade.php
+++ b/resources/views/livewire/staff/page.blade.php
@@ -4,39 +4,26 @@ use App\Enums\StaffDepartment;
 use App\Enums\StaffRank;
 use App\Models\BoardMember;
 use App\Models\StaffPosition;
+use Flux\Flux;
+use Illuminate\Support\Str;
 use Livewire\Volt\Component;
 
 new class extends Component {
     public ?int $selectedPositionId = null;
     public ?int $selectedBoardMemberId = null;
 
-    public function mount(): void
-    {
-        // Default: select the first filled Command Officer position
-        $default = StaffPosition::filled()
-            ->inDepartment(StaffDepartment::Command)
-            ->where('rank', StaffRank::Officer)
-            ->ordered()
-            ->first();
-
-        // Fallback: first filled position of any department
-        if (! $default) {
-            $default = StaffPosition::filled()->ordered()->first();
-        }
-
-        $this->selectedPositionId = $default?->id;
-    }
-
     public function selectPosition(int $id): void
     {
         $this->selectedPositionId = $id;
         $this->selectedBoardMemberId = null;
+        Flux::modal('position-detail-modal')->show();
     }
 
     public function selectBoardMember(int $id): void
     {
         $this->selectedBoardMemberId = $id;
         $this->selectedPositionId = null;
+        Flux::modal('board-member-detail-modal')->show();
     }
 
     public function getDepartmentsProperty(): array
@@ -88,269 +75,268 @@ new class extends Component {
     }
 }; ?>
 
-<section>
+<div>
     <div class="w-full px-4 py-8 mx-auto sm:px-6 lg:px-8">
         <flux:heading size="2xl" class="mb-8">Our Team</flux:heading>
 
-        <div class="flex flex-col-reverse w-full gap-8 lg:flex-row">
-            {{-- Staff Directory --}}
-            <div class="space-y-8 lg:w-2/3">
-                @foreach($this->departments as $group)
-                    <div>
-                        <flux:heading size="lg" class="pb-2 mb-4 border-b border-zinc-200 dark:border-zinc-700">
-                            {{ $group['department']->label() }} Department
-                        </flux:heading>
+        <div class="space-y-8">
+            @foreach($this->departments as $group)
+                <div>
+                    <flux:heading size="lg" class="pb-2 mb-4 border-b border-zinc-200 dark:border-zinc-700">
+                        {{ $group['department']->label() }} Department
+                    </flux:heading>
 
-                        {{-- Officers --}}
-                        @if($group['officers']->isNotEmpty())
-                            <div class="grid grid-cols-2 gap-4 mb-4 sm:grid-cols-3 lg:grid-cols-4">
-                                @foreach($group['officers'] as $pos)
-                                    <div
-                                        wire:key="staff-{{ $pos->id }}"
-                                        wire:click="selectPosition({{ $pos->id }})"
-                                        wire:keydown.enter="selectPosition({{ $pos->id }})"
-                                        wire:keydown.space.prevent="selectPosition({{ $pos->id }})"
-                                        role="button"
-                                        tabindex="0"
-                                        aria-pressed="{{ $selectedPositionId === $pos->id ? 'true' : 'false' }}"
-                                        class="p-3 rounded-lg border transition-colors cursor-pointer {{ $selectedPositionId === $pos->id ? 'border-blue-500 bg-blue-50 dark:bg-blue-950' : 'border-zinc-200 dark:border-zinc-700 hover:border-blue-300 dark:hover:border-blue-600' }}"
-                                    >
-                                        @if($pos->isFilled())
-                                            <div class="flex flex-col items-center gap-2 text-center">
-                                                @if($pos->user->staffPhotoUrl())
-                                                    <img src="{{ $pos->user->staffPhotoUrl() }}" alt="{{ $pos->user->name }}" class="object-cover w-20 h-20 rounded-lg" />
-                                                @elseif($pos->user->avatarUrl())
-                                                    <img src="{{ $pos->user->avatarUrl() }}" alt="{{ $pos->user->name }}" class="w-20 h-20 rounded-lg" />
-                                                @endif
-                                                <div class="min-w-0">
-                                                    <div class="text-sm font-semibold truncate">{{ $pos->user->name }}</div>
-                                                    <div class="text-xs truncate text-zinc-500 dark:text-zinc-400">{{ $pos->title }}</div>
-                                                </div>
-                                            </div>
-                                        @else
-                                            <div class="flex flex-col items-center gap-2 py-4 text-center">
-                                                <div class="font-medium text-zinc-400 dark:text-zinc-500">Open Position</div>
-                                                <div class="text-sm text-zinc-400 dark:text-zinc-500">{{ $pos->title }}</div>
-                                            </div>
-                                        @endif
-                                    </div>
-                                @endforeach
-                            </div>
-                        @endif
-
-                        {{-- Crew Members (CrewMember + JrCrew together) --}}
-                        @if($group['crew']->isNotEmpty())
-                            <div class="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-4">
-                                @foreach($group['crew'] as $pos)
-                                    <div
-                                        wire:key="staff-{{ $pos->id }}"
-                                        wire:click="selectPosition({{ $pos->id }})"
-                                        wire:keydown.enter="selectPosition({{ $pos->id }})"
-                                        wire:keydown.space.prevent="selectPosition({{ $pos->id }})"
-                                        role="button"
-                                        tabindex="0"
-                                        aria-pressed="{{ $selectedPositionId === $pos->id ? 'true' : 'false' }}"
-                                        class="p-3 rounded-lg border transition-colors cursor-pointer {{ $selectedPositionId === $pos->id ? 'border-blue-500 bg-blue-50 dark:bg-blue-950' : 'border-zinc-200 dark:border-zinc-700 hover:border-blue-300 dark:hover:border-blue-600' }}"
-                                    >
-                                        @if($pos->isFilled())
-                                            <div class="flex flex-col items-center gap-2 text-center">
-                                                @php $isJrCrew = $pos->user->isJrCrew(); @endphp
-                                                @if(! $isJrCrew && $pos->user->staffPhotoUrl())
-                                                    <img src="{{ $pos->user->staffPhotoUrl() }}" alt="{{ $pos->user->name }}" class="object-cover w-16 h-16 rounded-lg" />
-                                                @elseif($pos->user->avatarUrl())
-                                                    <img src="{{ $pos->user->avatarUrl() }}" alt="{{ $pos->user->name }}" class="w-16 h-16 rounded-lg" />
-                                                @endif
-                                                <div class="w-full min-w-0">
-                                                    <div class="text-sm font-medium truncate">{{ $pos->user->name }}</div>
-                                                    <div class="text-xs truncate text-zinc-500 dark:text-zinc-400">{{ $pos->title }}</div>
-                                                </div>
-                                            </div>
-                                        @else
-                                            <div class="flex flex-col items-center gap-2 py-2 text-center">
-                                                <div class="text-sm text-zinc-400 dark:text-zinc-500">Open Position</div>
-                                                <div class="text-xs text-zinc-400 dark:text-zinc-500">{{ $pos->title }}</div>
-                                            </div>
-                                        @endif
-                                    </div>
-                                @endforeach
-                            </div>
-                        @endif
-                    </div>
-                @endforeach
-
-                @if(empty($this->departments) && $this->boardMembers->isEmpty())
-                    <flux:text variant="subtle" class="py-12 text-center">No staff positions have been configured yet.</flux:text>
-                @endif
-
-                {{-- Board of Directors --}}
-                @if($this->boardMembers->isNotEmpty())
-                    <div>
-                        <flux:heading size="lg" class="pb-2 mb-4 border-b border-zinc-200 dark:border-zinc-700">
-                            Board of Directors
-                        </flux:heading>
-
-                        <div class="grid grid-cols-2 gap-4 sm:grid-cols-3 lg:grid-cols-4">
-                            @foreach($this->boardMembers as $member)
+                    {{-- Officers --}}
+                    @if($group['officers']->isNotEmpty())
+                        <div class="grid grid-cols-2 gap-4 mb-4 sm:grid-cols-3 lg:grid-cols-4">
+                            @foreach($group['officers'] as $pos)
                                 <div
-                                    wire:key="board-{{ $member->id }}"
-                                    wire:click="selectBoardMember({{ $member->id }})"
-                                    wire:keydown.enter="selectBoardMember({{ $member->id }})"
-                                    wire:keydown.space.prevent="selectBoardMember({{ $member->id }})"
+                                    wire:key="staff-{{ $pos->id }}"
+                                    wire:click="selectPosition({{ $pos->id }})"
+                                    wire:keydown.enter="selectPosition({{ $pos->id }})"
+                                    wire:keydown.space.prevent="selectPosition({{ $pos->id }})"
                                     role="button"
                                     tabindex="0"
-                                    aria-pressed="{{ $selectedBoardMemberId === $member->id ? 'true' : 'false' }}"
-                                    class="p-3 rounded-lg border transition-colors cursor-pointer {{ $selectedBoardMemberId === $member->id ? 'border-blue-500 bg-blue-50 dark:bg-blue-950' : 'border-zinc-200 dark:border-zinc-700 hover:border-blue-300 dark:hover:border-blue-600' }}"
+                                    class="p-3 rounded-lg border transition-colors cursor-pointer border-zinc-200 dark:border-zinc-700 hover:border-blue-300 dark:hover:border-blue-600"
                                 >
-                                    <div class="flex flex-col items-center gap-2 text-center">
-                                        @if($member->effectivePhotoUrl())
-                                            <img src="{{ $member->effectivePhotoUrl() }}" alt="{{ $member->effectiveName() }}" class="object-cover w-20 h-20 rounded-lg" />
-                                        @endif
-                                        <div class="min-w-0">
-                                            <div class="block text-sm font-semibold truncate">{{ $member->effectiveName() }}</div>
-                                            <div class="text-xs truncate text-zinc-500 dark:text-zinc-400">{{ $member->title ?? 'Board Member' }}</div>
+                                    @if($pos->isFilled())
+                                        <div class="flex flex-col items-center gap-2 text-center">
+                                            @if($pos->user->staffPhotoUrl())
+                                                <img src="{{ $pos->user->staffPhotoUrl() }}" alt="{{ $pos->user->name }}" class="object-cover w-20 h-20 rounded-lg" />
+                                            @elseif($pos->user->avatarUrl())
+                                                <img src="{{ $pos->user->avatarUrl() }}" alt="{{ $pos->user->name }}" class="w-20 h-20 rounded-lg" />
+                                            @endif
+                                            <div class="min-w-0">
+                                                <div class="text-sm font-semibold truncate">{{ $pos->user->name }}</div>
+                                                <div class="text-xs truncate text-zinc-500 dark:text-zinc-400">{{ $pos->title }}</div>
+                                            </div>
                                         </div>
-                                    </div>
+                                    @else
+                                        <div class="flex flex-col items-center gap-2 py-4 text-center">
+                                            <div class="font-medium text-zinc-400 dark:text-zinc-500">Open Position</div>
+                                            <div class="text-sm text-zinc-400 dark:text-zinc-500">{{ $pos->title }}</div>
+                                        </div>
+                                    @endif
                                 </div>
                             @endforeach
                         </div>
-                    </div>
-                @endif
-            </div>
+                    @endif
 
-            {{-- Staff Details Panel --}}
-            <div class="lg:w-1/4 lg:sticky lg:top-4 lg:self-start">
-                @if($this->selectedBoardMemberId && $this->selectedBoardMember)
-                    @php $bm = $this->selectedBoardMember; @endphp
-                    <flux:card class="space-y-4">
-                        @if($bm->isLinked() && $bm->user && $bm->user->staffPhotoUrl())
-                            <img src="{{ $bm->user->staffPhotoUrl() }}" alt="{{ $bm->effectiveName() }}" class="object-cover w-full h-48 rounded-lg" />
-                        @elseif($bm->isLinked() && $bm->user && $bm->user->avatarUrl())
-                            <img src="{{ $bm->user->avatarUrl() }}" alt="{{ $bm->effectiveName() }}" class="w-24 h-24 mx-auto rounded-lg" />
-                        @elseif($bm->photo_path)
-                            <img src="{{ $bm->effectivePhotoUrl() }}" alt="{{ $bm->effectiveName() }}" class="object-cover w-full h-48 rounded-lg" />
-                        @endif
-
-                        <flux:heading size="lg">{{ $bm->effectiveName() }}</flux:heading>
-
-                        @if($bm->isLinked() && $bm->user)
-                            <flux:link href="{{ route('profile.show', $bm->user) }}" wire:navigate class="block text-sm text-zinc-500">{{ $bm->user->name }}</flux:link>
-                        @endif
-
-                        <div>
-                            <div class="flex gap-2 mt-1">
-                                <flux:badge size="sm" color="indigo">{{ $bm->title ?? 'Board Member' }}</flux:badge>
-                            </div>
-                        </div>
-
-                        @if($bm->effectiveBio())
-                            <div>
-                                <flux:heading size="sm" class="mb-1">About</flux:heading>
-                                <flux:text>{!! nl2br(e($bm->effectiveBio())) !!}</flux:text>
-                            </div>
-                        @endif
-
-                        @if($bm->isLinked() && $bm->user)
-                            @can('viewStaffPhone', $bm->user)
-                                @if($bm->user->staff_phone)
-                                    <div>
-                                        <flux:heading size="sm" class="mb-1">Contact</flux:heading>
-                                        <flux:text>{{ $bm->user->staff_phone }}</flux:text>
-                                    </div>
-                                @endif
-                            @endcan
-                        @endif
-                    </flux:card>
-                @elseif($this->selectedPosition)
-                    @php $selected = $this->selectedPosition; @endphp
-                    <flux:card class="space-y-4">
-                        @if($selected->isFilled())
-                            @php $isJrCrew = $selected->user->isJrCrew(); @endphp
-
-                            @if(! $isJrCrew && $selected->user->staffPhotoUrl())
-                                <img src="{{ $selected->user->staffPhotoUrl() }}" alt="{{ $selected->user->name }}" class="object-cover w-full h-48 rounded-lg" />
-                            @elseif($selected->user->avatarUrl())
-                                <img src="{{ $selected->user->avatarUrl() }}" alt="{{ $selected->user->name }}" class="w-24 h-24 mx-auto rounded-lg" />
-                            @endif
-
-                            @if(! $isJrCrew && $selected->user->staff_first_name)
-                                <flux:heading size="lg">{{ $selected->user->staff_first_name }} {{ $selected->user->staff_last_initial }}.</flux:heading>
-                            @endif
-
-                            <flux:link href="{{ route('profile.show', $selected->user) }}" wire:navigate class="block text-sm text-zinc-500">{{ $selected->user->name }}</flux:link>
-                        @endif
-
-                        <div>
-                            <flux:heading size="md">{{ $selected->title }}</flux:heading>
-                            <div class="flex gap-2 mt-1">
-                                @if($selected->isFilled())
-                                    <flux:badge size="sm" color="{{ $selected->user->staff_rank->color() }}">{{ $selected->user->staff_rank->label() }}</flux:badge>
-                                @else
-                                    <flux:badge size="sm" color="{{ $selected->rank->color() }}">{{ $selected->rank->label() }}</flux:badge>
-                                @endif
-                                <flux:badge size="sm" color="zinc">{{ $selected->department->label() }}</flux:badge>
-                            </div>
-                        </div>
-
-                        @if($selected->description)
-                            <flux:text variant="subtle">{{ $selected->description }}</flux:text>
-                        @endif
-
-                        @if($selected->isFilled() && ! $selected->user->isJrCrew() && $selected->user->staff_bio)
-                            <div>
-                                <flux:heading size="sm" class="mb-1">About</flux:heading>
-                                <flux:text>{!! nl2br(e($selected->user->staff_bio)) !!}</flux:text>
-                            </div>
-                        @endif
-
-                        @if($selected->responsibilities)
-                            <div>
-                                <flux:heading size="sm" class="mb-1">Responsibilities</flux:heading>
-                                <flux:text>{{ $selected->responsibilities }}</flux:text>
-                            </div>
-                        @endif
-
-                        @if($selected->isFilled())
-                            @can('viewStaffPhone', $selected->user)
-                                @if($selected->user->staff_phone)
-                                    <div>
-                                        <flux:heading size="sm" class="mb-1">Contact</flux:heading>
-                                        <flux:text>{{ $selected->user->staff_phone }}</flux:text>
-                                    </div>
-                                @endif
-                            @endcan
-                        @endif
-
-                        @if($selected->isVacant())
-                            @if($selected->requirements)
-                                <div>
-                                    <flux:heading size="sm" class="mb-1">Requirements</flux:heading>
-                                    <flux:text>{{ $selected->requirements }}</flux:text>
+                    {{-- Crew Members (CrewMember + JrCrew together) --}}
+                    @if($group['crew']->isNotEmpty())
+                        <div class="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-4">
+                            @foreach($group['crew'] as $pos)
+                                <div
+                                    wire:key="staff-{{ $pos->id }}"
+                                    wire:click="selectPosition({{ $pos->id }})"
+                                    wire:keydown.enter="selectPosition({{ $pos->id }})"
+                                    wire:keydown.space.prevent="selectPosition({{ $pos->id }})"
+                                    role="button"
+                                    tabindex="0"
+                                    class="p-3 rounded-lg border transition-colors cursor-pointer border-zinc-200 dark:border-zinc-700 hover:border-blue-300 dark:hover:border-blue-600"
+                                >
+                                    @if($pos->isFilled())
+                                        <div class="flex flex-col items-center gap-2 text-center">
+                                            @php $isJrCrew = $pos->user->isJrCrew(); @endphp
+                                            @if(! $isJrCrew && $pos->user->staffPhotoUrl())
+                                                <img src="{{ $pos->user->staffPhotoUrl() }}" alt="{{ $pos->user->name }}" class="object-cover w-16 h-16 rounded-lg" />
+                                            @elseif($pos->user->avatarUrl())
+                                                <img src="{{ $pos->user->avatarUrl() }}" alt="{{ $pos->user->name }}" class="w-16 h-16 rounded-lg" />
+                                            @endif
+                                            <div class="w-full min-w-0">
+                                                <div class="text-sm font-medium truncate">{{ $pos->user->name }}</div>
+                                                <div class="text-xs truncate text-zinc-500 dark:text-zinc-400">{{ $pos->title }}</div>
+                                            </div>
+                                        </div>
+                                    @else
+                                        <div class="flex flex-col items-center gap-2 py-2 text-center">
+                                            <div class="text-sm text-zinc-400 dark:text-zinc-500">Open Position</div>
+                                            <div class="text-xs text-zinc-400 dark:text-zinc-500">{{ $pos->title }}</div>
+                                        </div>
+                                    @endif
                                 </div>
-                            @endif
-                        @endif
+                            @endforeach
+                        </div>
+                    @endif
+                </div>
+            @endforeach
 
-                        @auth
-                            @if($selected->isAcceptingApplications())
-                                @can('create', \App\Models\StaffApplication::class)
-                                    <div>
-                                        <flux:button href="{{ route('applications.apply', $selected) }}" variant="primary" icon="paper-airplane" wire:navigate>
-                                            Apply for this Position
-                                        </flux:button>
+            @if(empty($this->departments) && $this->boardMembers->isEmpty())
+                <flux:text variant="subtle" class="py-12 text-center">No staff positions have been configured yet.</flux:text>
+            @endif
+
+            {{-- Board of Directors --}}
+            @if($this->boardMembers->isNotEmpty())
+                <div>
+                    <flux:heading size="lg" class="pb-2 mb-4 border-b border-zinc-200 dark:border-zinc-700">
+                        Board of Directors
+                    </flux:heading>
+
+                    <div class="grid grid-cols-2 gap-4 sm:grid-cols-3 lg:grid-cols-4">
+                        @foreach($this->boardMembers as $member)
+                            <div
+                                wire:key="board-{{ $member->id }}"
+                                wire:click="selectBoardMember({{ $member->id }})"
+                                wire:keydown.enter="selectBoardMember({{ $member->id }})"
+                                wire:keydown.space.prevent="selectBoardMember({{ $member->id }})"
+                                role="button"
+                                tabindex="0"
+                                class="p-3 rounded-lg border transition-colors cursor-pointer border-zinc-200 dark:border-zinc-700 hover:border-blue-300 dark:hover:border-blue-600"
+                            >
+                                <div class="flex flex-col items-center gap-2 text-center">
+                                    @if($member->effectivePhotoUrl())
+                                        <img src="{{ $member->effectivePhotoUrl() }}" alt="{{ $member->effectiveName() }}" class="object-cover w-20 h-20 rounded-lg" />
+                                    @endif
+                                    <div class="min-w-0">
+                                        <div class="block text-sm font-semibold truncate">{{ $member->effectiveName() }}</div>
+                                        <div class="text-xs truncate text-zinc-500 dark:text-zinc-400">{{ $member->title ?? 'Board Member' }}</div>
                                     </div>
-                                @else
-                                    <flux:text variant="subtle" class="text-sm italic">You are not eligible to apply at this time.</flux:text>
-                                @endcan
-                            @else
-                                <flux:text variant="subtle" class="text-sm italic">This position is not currently accepting applications.</flux:text>
-                            @endif
-                        @endauth
-                    </flux:card>
-                @else
-                    <flux:card>
-                        <flux:text variant="subtle" class="py-8 text-center">Select a staff member to view their details.</flux:text>
-                    </flux:card>
-                @endif
-            </div>
+                                </div>
+                            </div>
+                        @endforeach
+                    </div>
+                </div>
+            @endif
         </div>
     </div>
-</section>
+
+    {{-- Position Detail Modal --}}
+    <flux:modal name="position-detail-modal" class="w-full md:max-w-2xl">
+        @if($this->selectedPosition)
+            @php $selected = $this->selectedPosition; @endphp
+            <div class="space-y-4">
+                @if($selected->isFilled())
+                    @php $isJrCrew = $selected->user->isJrCrew(); @endphp
+
+                    @if(! $isJrCrew && $selected->user->staffPhotoUrl())
+                        <img src="{{ $selected->user->staffPhotoUrl() }}" alt="{{ $selected->user->name }}" class="object-cover w-full h-48 rounded-lg" />
+                    @elseif($selected->user->avatarUrl())
+                        <img src="{{ $selected->user->avatarUrl() }}" alt="{{ $selected->user->name }}" class="w-24 h-24 mx-auto rounded-lg" />
+                    @endif
+
+                    @if(! $isJrCrew && $selected->user->staff_first_name)
+                        <flux:heading size="lg">{{ $selected->user->staff_first_name }} {{ $selected->user->staff_last_initial }}.</flux:heading>
+                    @endif
+
+                    <flux:link href="{{ route('profile.show', $selected->user) }}" wire:navigate class="block text-sm text-zinc-500">{{ $selected->user->name }}</flux:link>
+                @endif
+
+                <div>
+                    <flux:heading size="md">{{ $selected->title }}</flux:heading>
+                    <div class="flex gap-2 mt-1">
+                        @if($selected->isFilled())
+                            <flux:badge size="sm" color="{{ $selected->user->staff_rank->color() }}">{{ $selected->user->staff_rank->label() }}</flux:badge>
+                        @else
+                            <flux:badge size="sm" color="{{ $selected->rank->color() }}">{{ $selected->rank->label() }}</flux:badge>
+                        @endif
+                        <flux:badge size="sm" color="zinc">{{ $selected->department->label() }}</flux:badge>
+                    </div>
+                </div>
+
+                @if($selected->description)
+                    <flux:text variant="subtle">{{ $selected->description }}</flux:text>
+                @endif
+
+                @if($selected->isFilled() && ! $selected->user->isJrCrew() && $selected->user->staff_bio)
+                    <div>
+                        <flux:heading size="sm" class="mb-1">About</flux:heading>
+                        <flux:text>{!! nl2br(e($selected->user->staff_bio)) !!}</flux:text>
+                    </div>
+                @endif
+
+                @if($selected->responsibilities)
+                    <div>
+                        <flux:heading size="sm" class="mb-1">Responsibilities</flux:heading>
+                        <div class="prose prose-sm dark:prose-invert">
+                            {!! Str::markdown($selected->responsibilities, ['html_input' => 'strip', 'allow_unsafe_links' => false]) !!}
+                        </div>
+                    </div>
+                @endif
+
+                @if($selected->isFilled())
+                    @can('viewStaffPhone', $selected->user)
+                        @if($selected->user->staff_phone)
+                            <div>
+                                <flux:heading size="sm" class="mb-1">Contact</flux:heading>
+                                <flux:text>{{ $selected->user->staff_phone }}</flux:text>
+                            </div>
+                        @endif
+                    @endcan
+                @endif
+
+                @if($selected->isVacant())
+                    @if($selected->requirements)
+                        <div>
+                            <flux:heading size="sm" class="mb-1">Requirements</flux:heading>
+                            <div class="prose prose-sm dark:prose-invert">
+                                {!! Str::markdown($selected->requirements, ['html_input' => 'strip', 'allow_unsafe_links' => false]) !!}
+                            </div>
+                        </div>
+                    @endif
+                @endif
+
+                @auth
+                    @if($selected->isAcceptingApplications())
+                        @can('create', \App\Models\StaffApplication::class)
+                            <div>
+                                <flux:button href="{{ route('applications.apply', $selected) }}" variant="primary" icon="paper-airplane" wire:navigate>
+                                    Apply for this Position
+                                </flux:button>
+                            </div>
+                        @else
+                            <flux:text variant="subtle" class="text-sm italic">You are not eligible to apply at this time.</flux:text>
+                        @endcan
+                    @else
+                        <flux:text variant="subtle" class="text-sm italic">This position is not currently accepting applications.</flux:text>
+                    @endif
+                @endauth
+            </div>
+        @endif
+    </flux:modal>
+
+    {{-- Board Member Detail Modal --}}
+    <flux:modal name="board-member-detail-modal" class="w-full md:max-w-2xl">
+        @if($this->selectedBoardMember)
+            @php $bm = $this->selectedBoardMember; @endphp
+            <div class="space-y-4">
+                @if($bm->isLinked() && $bm->user && $bm->user->staffPhotoUrl())
+                    <img src="{{ $bm->user->staffPhotoUrl() }}" alt="{{ $bm->effectiveName() }}" class="object-cover w-full h-48 rounded-lg" />
+                @elseif($bm->isLinked() && $bm->user && $bm->user->avatarUrl())
+                    <img src="{{ $bm->user->avatarUrl() }}" alt="{{ $bm->effectiveName() }}" class="w-24 h-24 mx-auto rounded-lg" />
+                @elseif($bm->photo_path)
+                    <img src="{{ $bm->effectivePhotoUrl() }}" alt="{{ $bm->effectiveName() }}" class="object-cover w-full h-48 rounded-lg" />
+                @endif
+
+                <flux:heading size="lg">{{ $bm->effectiveName() }}</flux:heading>
+
+                @if($bm->isLinked() && $bm->user)
+                    <flux:link href="{{ route('profile.show', $bm->user) }}" wire:navigate class="block text-sm text-zinc-500">{{ $bm->user->name }}</flux:link>
+                @endif
+
+                <div>
+                    <div class="flex gap-2 mt-1">
+                        <flux:badge size="sm" color="indigo">{{ $bm->title ?? 'Board Member' }}</flux:badge>
+                    </div>
+                </div>
+
+                @if($bm->effectiveBio())
+                    <div>
+                        <flux:heading size="sm" class="mb-1">About</flux:heading>
+                        <flux:text>{!! nl2br(e($bm->effectiveBio())) !!}</flux:text>
+                    </div>
+                @endif
+
+                @if($bm->isLinked() && $bm->user)
+                    @can('viewStaffPhone', $bm->user)
+                        @if($bm->user->staff_phone)
+                            <div>
+                                <flux:heading size="sm" class="mb-1">Contact</flux:heading>
+                                <flux:text>{{ $bm->user->staff_phone }}</flux:text>
+                            </div>
+                        @endif
+                    @endcan
+                @endif
+            </div>
+        @endif
+    </flux:modal>
+</div>

--- a/resources/views/livewire/users/discipline-reports-card.blade.php
+++ b/resources/views/livewire/users/discipline-reports-card.blade.php
@@ -40,6 +40,8 @@ new class extends Component {
     public array $formRuleIds = [];
 
     // Image upload state
+    public $pendingImage = null;
+
     public $formImages = [];
 
     public array $removedImageIds = [];
@@ -107,6 +109,31 @@ new class extends Component {
             ->groupBy(fn ($rule) => $rule->ruleCategory?->name ?? 'Uncategorized');
     }
 
+    public function addPendingImage(): void
+    {
+        if (! $this->pendingImage) {
+            return;
+        }
+
+        $maxKb = (int) (SiteConfig::getValue('max_image_size_kb', '2048') ?: 2048);
+        if ($maxKb <= 0) {
+            $maxKb = 2048;
+        }
+
+        $this->validate([
+            'pendingImage' => "mimes:jpg,jpeg,png,gif,webp|max:{$maxKb}",
+        ]);
+
+        $this->formImages[] = $this->pendingImage;
+        $this->pendingImage = null;
+    }
+
+    public function removeStagedImage(int $index): void
+    {
+        unset($this->formImages[$index]);
+        $this->formImages = array_values($this->formImages);
+    }
+
     public function openCreateModal(): void
     {
         $this->authorize('create', DisciplineReport::class);
@@ -130,6 +157,7 @@ new class extends Component {
             'formActionsTaken' => 'required|string|min:5',
             'formSeverity' => ['required', 'string', Rule::enum(ReportSeverity::class)],
             'formCategory' => 'nullable|string|exists:report_categories,id',
+            'pendingImage' => "nullable|mimes:jpg,jpeg,png,gif,webp|max:{$maxKb}",
             'formImages.*' => "nullable|mimes:jpg,jpeg,png,gif,webp|max:{$maxKb}",
         ]);
 
@@ -148,8 +176,13 @@ new class extends Component {
             array_map('intval', $this->formRuleIds),
         );
 
-        if (! empty($this->formImages)) {
-            AttachDisciplineReportImages::run($report, $this->formImages);
+        $allImages = $this->formImages;
+        if ($this->pendingImage) {
+            $allImages[] = $this->pendingImage;
+        }
+
+        if (! empty($allImages)) {
+            AttachDisciplineReportImages::run($report, $allImages);
         }
 
         $this->resetForm();
@@ -192,6 +225,7 @@ new class extends Component {
             'formActionsTaken' => 'required|string|min:5',
             'formSeverity' => ['required', 'string', Rule::enum(ReportSeverity::class)],
             'formCategory' => 'nullable|string|exists:report_categories,id',
+            'pendingImage' => "nullable|mimes:jpg,jpeg,png,gif,webp|max:{$maxKb}",
             'formImages.*' => "nullable|mimes:jpg,jpeg,png,gif,webp|max:{$maxKb}",
         ]);
 
@@ -224,9 +258,14 @@ new class extends Component {
                 ->each->delete();
         }
 
-        // Attach newly uploaded images
-        if (! empty($this->formImages)) {
-            AttachDisciplineReportImages::run($report, $this->formImages);
+        // Attach newly uploaded images (staged + any still-pending)
+        $allImages = $this->formImages;
+        if ($this->pendingImage) {
+            $allImages[] = $this->pendingImage;
+        }
+
+        if (! empty($allImages)) {
+            AttachDisciplineReportImages::run($report, $allImages);
         }
 
         $this->resetForm();
@@ -345,6 +384,7 @@ new class extends Component {
         $this->formSeverity = '';
         $this->formCategory = '';
         $this->formRuleIds = [];
+        $this->pendingImage = null;
         $this->formImages = [];
         $this->removedImageIds = [];
     }
@@ -511,21 +551,38 @@ new class extends Component {
 
             <flux:field>
                 <flux:label>Evidence Images</flux:label>
-                <flux:description>Attach screenshots or photos as evidence (JPG, PNG, GIF, WEBP). Multiple files allowed.</flux:description>
-                <input
-                    type="file"
-                    wire:model="formImages"
-                    multiple
-                    accept="image/jpeg,image/png,image/gif,image/webp"
-                    class="block w-full text-sm text-zinc-500 dark:text-zinc-400 file:mr-3 file:py-1.5 file:px-3 file:rounded-md file:border-0 file:text-sm file:font-medium file:bg-zinc-100 file:text-zinc-700 hover:file:bg-zinc-200 dark:file:bg-zinc-700 dark:file:text-zinc-300 dark:hover:file:bg-zinc-600 cursor-pointer"
-                >
-                <flux:error name="formImages.*" />
+                <flux:file-upload wire:model="pendingImage">
+                    <flux:file-upload.dropzone
+                        icon="photo"
+                        heading="Upload image"
+                        description="PNG, JPG, GIF, WEBP"
+                    />
+                </flux:file-upload>
+                @if($pendingImage)
+                    <flux:file-item
+                        :heading="$pendingImage->getClientOriginalName()"
+                        :image="$pendingImage->temporaryUrl()"
+                        :size="$pendingImage->getSize()"
+                    >
+                        <flux:file-item.remove wire:click="$set('pendingImage', null)" />
+                    </flux:file-item>
+                    <flux:button size="sm" wire:click="addPendingImage">Add Image</flux:button>
+                @endif
+                <flux:error name="pendingImage" />
             </flux:field>
 
-            @if($formImages)
-                <div class="grid grid-cols-3 gap-2">
+            @if(!empty($formImages))
+                <div class="space-y-2">
+                    <flux:text class="text-sm font-medium">Images to attach ({{ count($formImages) }})</flux:text>
                     @foreach($formImages as $index => $image)
-                        <img wire:key="create-preview-{{ $index }}" src="{{ $image->temporaryUrl() }}" alt="Preview" class="rounded-lg object-cover aspect-square w-full" />
+                        <flux:file-item
+                            wire:key="create-staged-{{ $index }}"
+                            :heading="$image->getClientOriginalName()"
+                            :image="$image->temporaryUrl()"
+                            :size="$image->getSize()"
+                        >
+                            <flux:file-item.remove wire:click="removeStagedImage({{ $index }})" />
+                        </flux:file-item>
                     @endforeach
                 </div>
             @endif
@@ -629,21 +686,38 @@ new class extends Component {
                 {{-- New image uploads --}}
                 <flux:field>
                     <flux:label>Add More Evidence Images</flux:label>
-                    <flux:description>Attach additional screenshots or photos (JPG, PNG, GIF, WEBP).</flux:description>
-                    <input
-                        type="file"
-                        wire:model="formImages"
-                        multiple
-                        accept="image/jpeg,image/png,image/gif,image/webp"
-                        class="block w-full text-sm text-zinc-500 dark:text-zinc-400 file:mr-3 file:py-1.5 file:px-3 file:rounded-md file:border-0 file:text-sm file:font-medium file:bg-zinc-100 file:text-zinc-700 hover:file:bg-zinc-200 dark:file:bg-zinc-700 dark:file:text-zinc-300 dark:hover:file:bg-zinc-600 cursor-pointer"
-                    >
-                    <flux:error name="formImages.*" />
+                    <flux:file-upload wire:model="pendingImage">
+                        <flux:file-upload.dropzone
+                            icon="photo"
+                            heading="Upload image"
+                            description="PNG, JPG, GIF, WEBP"
+                        />
+                    </flux:file-upload>
+                    @if($pendingImage)
+                        <flux:file-item
+                            :heading="$pendingImage->getClientOriginalName()"
+                            :image="$pendingImage->temporaryUrl()"
+                            :size="$pendingImage->getSize()"
+                        >
+                            <flux:file-item.remove wire:click="$set('pendingImage', null)" />
+                        </flux:file-item>
+                        <flux:button size="sm" wire:click="addPendingImage">Add Image</flux:button>
+                    @endif
+                    <flux:error name="pendingImage" />
                 </flux:field>
 
-                @if($formImages)
-                    <div class="grid grid-cols-3 gap-2">
+                @if(!empty($formImages))
+                    <div class="space-y-2">
+                        <flux:text class="text-sm font-medium">Images to attach ({{ count($formImages) }})</flux:text>
                         @foreach($formImages as $index => $image)
-                            <img wire:key="edit-preview-{{ $index }}" src="{{ $image->temporaryUrl() }}" alt="Preview" class="rounded-lg object-cover aspect-square w-full" />
+                            <flux:file-item
+                                wire:key="edit-staged-{{ $index }}"
+                                :heading="$image->getClientOriginalName()"
+                                :image="$image->temporaryUrl()"
+                                :size="$image->getSize()"
+                            >
+                                <flux:file-item.remove wire:click="removeStagedImage({{ $index }})" />
+                            </flux:file-item>
                         @endforeach
                     </div>
                 @endif

--- a/resources/views/livewire/users/discipline-reports-card.blade.php
+++ b/resources/views/livewire/users/discipline-reports-card.blade.php
@@ -512,9 +512,13 @@ new class extends Component {
             <flux:field>
                 <flux:label>Evidence Images</flux:label>
                 <flux:description>Attach screenshots or photos as evidence (JPG, PNG, GIF, WEBP). Multiple files allowed.</flux:description>
-                <flux:file-upload wire:model="formImages" multiple accept="image/jpeg,image/png,image/gif,image/webp">
-                    <flux:file-upload.dropzone heading="Upload evidence images" text="PNG, JPG, GIF, WEBP" inline />
-                </flux:file-upload>
+                <input
+                    type="file"
+                    wire:model="formImages"
+                    multiple
+                    accept="image/jpeg,image/png,image/gif,image/webp"
+                    class="block w-full text-sm text-zinc-500 dark:text-zinc-400 file:mr-3 file:py-1.5 file:px-3 file:rounded-md file:border-0 file:text-sm file:font-medium file:bg-zinc-100 file:text-zinc-700 hover:file:bg-zinc-200 dark:file:bg-zinc-700 dark:file:text-zinc-300 dark:hover:file:bg-zinc-600 cursor-pointer"
+                >
                 <flux:error name="formImages.*" />
             </flux:field>
 
@@ -626,9 +630,13 @@ new class extends Component {
                 <flux:field>
                     <flux:label>Add More Evidence Images</flux:label>
                     <flux:description>Attach additional screenshots or photos (JPG, PNG, GIF, WEBP).</flux:description>
-                    <flux:file-upload wire:model="formImages" multiple accept="image/jpeg,image/png,image/gif,image/webp">
-                        <flux:file-upload.dropzone heading="Upload evidence images" text="PNG, JPG, GIF, WEBP" inline />
-                    </flux:file-upload>
+                    <input
+                        type="file"
+                        wire:model="formImages"
+                        multiple
+                        accept="image/jpeg,image/png,image/gif,image/webp"
+                        class="block w-full text-sm text-zinc-500 dark:text-zinc-400 file:mr-3 file:py-1.5 file:px-3 file:rounded-md file:border-0 file:text-sm file:font-medium file:bg-zinc-100 file:text-zinc-700 hover:file:bg-zinc-200 dark:file:bg-zinc-700 dark:file:text-zinc-300 dark:hover:file:bg-zinc-600 cursor-pointer"
+                    >
                     <flux:error name="formImages.*" />
                 </flux:field>
 

--- a/resources/views/livewire/users/discipline-reports-card.blade.php
+++ b/resources/views/livewire/users/discipline-reports-card.blade.php
@@ -508,7 +508,9 @@ new class extends Component {
             <flux:field>
                 <flux:label>Evidence Images</flux:label>
                 <flux:description>Attach screenshots or photos as evidence (JPG, PNG, GIF, WEBP). Multiple files allowed.</flux:description>
-                <flux:input type="file" wire:model="formImages" multiple accept="image/jpeg,image/png,image/gif,image/webp" />
+                <flux:file-upload wire:model="formImages" multiple accept="image/jpeg,image/png,image/gif,image/webp">
+                    <flux:file-upload.dropzone heading="Upload evidence images" text="PNG, JPG, GIF, WEBP" inline />
+                </flux:file-upload>
                 <flux:error name="formImages.*" />
             </flux:field>
 
@@ -620,7 +622,9 @@ new class extends Component {
                 <flux:field>
                     <flux:label>Add More Evidence Images</flux:label>
                     <flux:description>Attach additional screenshots or photos (JPG, PNG, GIF, WEBP).</flux:description>
-                    <flux:input type="file" wire:model="formImages" multiple accept="image/jpeg,image/png,image/gif,image/webp" />
+                    <flux:file-upload wire:model="formImages" multiple accept="image/jpeg,image/png,image/gif,image/webp">
+                        <flux:file-upload.dropzone heading="Upload evidence images" text="PNG, JPG, GIF, WEBP" inline />
+                    </flux:file-upload>
                     <flux:error name="formImages.*" />
                 </flux:field>
 

--- a/resources/views/livewire/users/discipline-reports-card.blade.php
+++ b/resources/views/livewire/users/discipline-reports-card.blade.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Actions\AttachDisciplineReportImages;
 use App\Actions\CreateDisciplineReport;
 use App\Actions\CreateTopic;
 use App\Actions\PublishDisciplineReport;
@@ -8,8 +9,10 @@ use App\Enums\ReportLocation;
 use App\Enums\ReportSeverity;
 use App\Enums\StaffRank;
 use App\Models\DisciplineReport;
+use App\Models\DisciplineReportImage;
 use App\Models\ReportCategory;
 use App\Models\Rule as RuleModel;
+use App\Models\SiteConfig;
 use App\Models\Thread;
 use App\Models\User;
 use Flux\Flux;
@@ -17,8 +20,10 @@ use Illuminate\Support\Facades\Auth;
 use Illuminate\Validation\Rule;
 use Livewire\Attributes\Locked;
 use Livewire\Volt\Component;
+use Livewire\WithFileUploads;
 
 new class extends Component {
+    use WithFileUploads;
     #[Locked]
     public int $userId;
 
@@ -33,6 +38,11 @@ new class extends Component {
     public string $formSeverity = '';
     public string $formCategory = '';
     public array $formRuleIds = [];
+
+    // Image upload state
+    public $formImages = [];
+
+    public array $removedImageIds = [];
 
     // Editing state
     #[Locked]
@@ -109,18 +119,21 @@ new class extends Component {
     {
         $this->authorize('create', DisciplineReport::class);
 
+        $maxKb = SiteConfig::getValue('max_image_size_kb', '2048');
+
         $this->validate([
             'formDescription' => 'required|string|min:10',
             'formLocation' => ['required', 'string', Rule::enum(ReportLocation::class)],
             'formActionsTaken' => 'required|string|min:5',
             'formSeverity' => ['required', 'string', Rule::enum(ReportSeverity::class)],
             'formCategory' => 'nullable|string|exists:report_categories,id',
+            'formImages.*' => "nullable|mimes:jpg,jpeg,png,gif,webp|max:{$maxKb}",
         ]);
 
         $subject = $this->user;
         $category = $this->formCategory ? ReportCategory::find($this->formCategory) : null;
 
-        CreateDisciplineReport::run(
+        $report = CreateDisciplineReport::run(
             $subject,
             Auth::user(),
             $this->formDescription,
@@ -131,6 +144,10 @@ new class extends Component {
             $category,
             array_map('intval', $this->formRuleIds),
         );
+
+        if (! empty($this->formImages)) {
+            AttachDisciplineReportImages::run($report, $this->formImages);
+        }
 
         $this->resetForm();
         Flux::modal('create-report-modal')->close();
@@ -150,6 +167,8 @@ new class extends Component {
         $this->formSeverity = $report->severity->value;
         $this->formCategory = (string) ($report->report_category_id ?? '');
         $this->formRuleIds = $report->violatedRules()->pluck('rules.id')->map(fn ($id) => (string) $id)->all();
+        $this->formImages = [];
+        $this->removedImageIds = [];
 
         Flux::modal('edit-report-modal')->show();
     }
@@ -159,12 +178,15 @@ new class extends Component {
         $report = DisciplineReport::findOrFail($this->editingReportId);
         $this->authorize('update', $report);
 
+        $maxKb = SiteConfig::getValue('max_image_size_kb', '2048');
+
         $this->validate([
             'formDescription' => 'required|string|min:10',
             'formLocation' => ['required', 'string', Rule::enum(ReportLocation::class)],
             'formActionsTaken' => 'required|string|min:5',
             'formSeverity' => ['required', 'string', Rule::enum(ReportSeverity::class)],
             'formCategory' => 'nullable|string|exists:report_categories,id',
+            'formImages.*' => "nullable|mimes:jpg,jpeg,png,gif,webp|max:{$maxKb}",
         ]);
 
         $category = $this->formCategory ? ReportCategory::find($this->formCategory) : null;
@@ -180,6 +202,19 @@ new class extends Component {
             $category,
             array_map('intval', $this->formRuleIds),
         );
+
+        // Delete images marked for removal (verify they belong to this report)
+        if (! empty($this->removedImageIds)) {
+            DisciplineReportImage::where('discipline_report_id', $report->id)
+                ->whereIn('id', $this->removedImageIds)
+                ->get()
+                ->each->delete();
+        }
+
+        // Attach newly uploaded images
+        if (! empty($this->formImages)) {
+            AttachDisciplineReportImages::run($report, $this->formImages);
+        }
 
         $this->resetForm();
         $this->editingReportId = null;
@@ -197,13 +232,36 @@ new class extends Component {
         Flux::toast('Staff report published.', 'Report Published', variant: 'success');
     }
 
+    public function removeImage(int $imageId): void
+    {
+        $report = DisciplineReport::findOrFail($this->editingReportId);
+        $this->authorize('update', $report);
+
+        if (! in_array($imageId, $this->removedImageIds)) {
+            $this->removedImageIds[] = $imageId;
+        }
+    }
+
+    public function getEditingReportImagesProperty()
+    {
+        if (! $this->editingReportId) {
+            return collect();
+        }
+
+        return DisciplineReport::find($this->editingReportId)
+            ?->images()
+            ->whereNotIn('id', $this->removedImageIds)
+            ->get()
+            ?? collect();
+    }
+
     public function getViewingReportProperty()
     {
         if (! $this->viewingReportId) {
             return null;
         }
 
-        return DisciplineReport::with(['subject', 'reporter', 'publisher', 'category', 'violatedRules'])
+        return DisciplineReport::with(['subject', 'reporter', 'publisher', 'category', 'violatedRules', 'images'])
             ->find($this->viewingReportId);
     }
 
@@ -270,6 +328,8 @@ new class extends Component {
         $this->formSeverity = '';
         $this->formCategory = '';
         $this->formRuleIds = [];
+        $this->formImages = [];
+        $this->removedImageIds = [];
     }
 }; ?>
 
@@ -432,6 +492,21 @@ new class extends Component {
                 </flux:field>
             @endif
 
+            <flux:field>
+                <flux:label>Evidence Images</flux:label>
+                <flux:description>Attach screenshots or photos as evidence (JPG, PNG, GIF, WEBP). Multiple files allowed.</flux:description>
+                <input type="file" wire:model="formImages" multiple accept="image/jpeg,image/png,image/gif,image/webp" class="block w-full text-sm text-zinc-700 dark:text-zinc-300" />
+                <flux:error name="formImages.*" />
+            </flux:field>
+
+            @if($formImages)
+                <div class="grid grid-cols-3 gap-2">
+                    @foreach($formImages as $image)
+                        <img src="{{ $image->temporaryUrl() }}" alt="Preview" class="rounded-lg object-cover aspect-square w-full" />
+                    @endforeach
+                </div>
+            @endif
+
             <div class="flex gap-2 justify-end">
                 <flux:button variant="ghost" x-on:click="$flux.modal('create-report-modal').close()">Cancel</flux:button>
                 <flux:button wire:click="createReport" variant="primary">Create Report</flux:button>
@@ -510,6 +585,39 @@ new class extends Component {
                     </div>
                     <flux:description>Select any rules this incident violated (optional).</flux:description>
                 </flux:field>
+            @endif
+
+            @if($editingReportId && \App\Models\DisciplineReport::find($editingReportId)?->isDraft())
+                {{-- Existing images --}}
+                @if($this->editingReportImages->isNotEmpty())
+                    <div>
+                        <flux:text class="font-bold text-sm mb-2">Current Evidence Images</flux:text>
+                        <div class="grid grid-cols-3 gap-2">
+                            @foreach($this->editingReportImages as $image)
+                                <div wire:key="edit-img-{{ $image->id }}" class="relative group">
+                                    <img src="{{ $image->url() }}" alt="{{ $image->original_filename }}" class="rounded-lg object-cover aspect-square w-full" />
+                                    <button wire:click="removeImage({{ $image->id }})" class="absolute top-1 right-1 bg-red-500 text-white rounded-full w-5 h-5 text-xs flex items-center justify-center opacity-0 group-hover:opacity-100 transition">×</button>
+                                </div>
+                            @endforeach
+                        </div>
+                    </div>
+                @endif
+
+                {{-- New image uploads --}}
+                <flux:field>
+                    <flux:label>Add More Evidence Images</flux:label>
+                    <flux:description>Attach additional screenshots or photos (JPG, PNG, GIF, WEBP).</flux:description>
+                    <input type="file" wire:model="formImages" multiple accept="image/jpeg,image/png,image/gif,image/webp" class="block w-full text-sm text-zinc-700 dark:text-zinc-300" />
+                    <flux:error name="formImages.*" />
+                </flux:field>
+
+                @if($formImages)
+                    <div class="grid grid-cols-3 gap-2">
+                        @foreach($formImages as $image)
+                            <img src="{{ $image->temporaryUrl() }}" alt="Preview" class="rounded-lg object-cover aspect-square w-full" />
+                        @endforeach
+                    </div>
+                @endif
             @endif
 
             <div class="flex gap-2 justify-end">
@@ -612,6 +720,21 @@ new class extends Component {
                     <div>
                         <flux:text class="font-bold text-sm">Date</flux:text>
                         <flux:text>{{ ($viewReport->published_at ?? $viewReport->created_at)->format('M j, Y g:i A') }}</flux:text>
+                    </div>
+                @endif
+
+                {{-- Evidence Section --}}
+                @if($viewReport->images->isNotEmpty())
+                    <flux:separator variant="subtle" />
+                    <div>
+                        <flux:text class="font-bold text-sm mb-2">Evidence</flux:text>
+                        <div class="grid grid-cols-3 gap-2">
+                            @foreach($viewReport->images as $image)
+                                <a wire:key="view-img-{{ $image->id }}" href="{{ $image->url() }}" target="_blank" rel="noopener">
+                                    <img src="{{ $image->url() }}" alt="{{ $image->original_filename }}" class="rounded-lg object-cover aspect-square w-full hover:opacity-90 transition" />
+                                </a>
+                            @endforeach
+                        </div>
                     </div>
                 @endif
 

--- a/resources/views/livewire/users/discipline-reports-card.blade.php
+++ b/resources/views/livewire/users/discipline-reports-card.blade.php
@@ -119,7 +119,10 @@ new class extends Component {
     {
         $this->authorize('create', DisciplineReport::class);
 
-        $maxKb = SiteConfig::getValue('max_image_size_kb', '2048');
+        $maxKb = (int) (SiteConfig::getValue('max_image_size_kb', '2048') ?: 2048);
+        if ($maxKb <= 0) {
+            $maxKb = 2048;
+        }
 
         $this->validate([
             'formDescription' => 'required|string|min:10',
@@ -178,7 +181,10 @@ new class extends Component {
         $report = DisciplineReport::findOrFail($this->editingReportId);
         $this->authorize('update', $report);
 
-        $maxKb = SiteConfig::getValue('max_image_size_kb', '2048');
+        $maxKb = (int) (SiteConfig::getValue('max_image_size_kb', '2048') ?: 2048);
+        if ($maxKb <= 0) {
+            $maxKb = 2048;
+        }
 
         $this->validate([
             'formDescription' => 'required|string|min:10',
@@ -202,6 +208,13 @@ new class extends Component {
             $category,
             array_map('intval', $this->formRuleIds),
         );
+
+        $report->refresh();
+        if (! $report->isDraft()) {
+            Flux::modal('edit-report-modal')->close();
+            Flux::toast('This report is no longer editable.', 'Report Locked', variant: 'danger');
+            return;
+        }
 
         // Delete images marked for removal (verify they belong to this report)
         if (! empty($this->removedImageIds)) {
@@ -501,8 +514,8 @@ new class extends Component {
 
             @if($formImages)
                 <div class="grid grid-cols-3 gap-2">
-                    @foreach($formImages as $image)
-                        <img src="{{ $image->temporaryUrl() }}" alt="Preview" class="rounded-lg object-cover aspect-square w-full" />
+                    @foreach($formImages as $index => $image)
+                        <img wire:key="create-preview-{{ $index }}" src="{{ $image->temporaryUrl() }}" alt="Preview" class="rounded-lg object-cover aspect-square w-full" />
                     @endforeach
                 </div>
             @endif
@@ -613,8 +626,8 @@ new class extends Component {
 
                 @if($formImages)
                     <div class="grid grid-cols-3 gap-2">
-                        @foreach($formImages as $image)
-                            <img src="{{ $image->temporaryUrl() }}" alt="Preview" class="rounded-lg object-cover aspect-square w-full" />
+                        @foreach($formImages as $index => $image)
+                            <img wire:key="edit-preview-{{ $index }}" src="{{ $image->temporaryUrl() }}" alt="Preview" class="rounded-lg object-cover aspect-square w-full" />
                         @endforeach
                     </div>
                 @endif
@@ -730,7 +743,7 @@ new class extends Component {
                         <flux:text class="font-bold text-sm mb-2">Evidence</flux:text>
                         <div class="grid grid-cols-3 gap-2">
                             @foreach($viewReport->images as $image)
-                                <a wire:key="view-img-{{ $image->id }}" href="{{ $image->url() }}" target="_blank" rel="noopener">
+                                <a wire:key="view-img-{{ $image->id }}" href="{{ $image->url() }}" target="_blank" rel="noopener noreferrer">
                                     <img src="{{ $image->url() }}" alt="{{ $image->original_filename }}" class="rounded-lg object-cover aspect-square w-full hover:opacity-90 transition" />
                                 </a>
                             @endforeach

--- a/resources/views/livewire/users/discipline-reports-card.blade.php
+++ b/resources/views/livewire/users/discipline-reports-card.blade.php
@@ -250,6 +250,10 @@ new class extends Component {
         $report = DisciplineReport::findOrFail($this->editingReportId);
         $this->authorize('update', $report);
 
+        if (! $report->images()->whereKey($imageId)->exists()) {
+            return;
+        }
+
         if (! in_array($imageId, $this->removedImageIds)) {
             $this->removedImageIds[] = $imageId;
         }

--- a/resources/views/livewire/users/discipline-reports-card.blade.php
+++ b/resources/views/livewire/users/discipline-reports-card.blade.php
@@ -495,7 +495,7 @@ new class extends Component {
             <flux:field>
                 <flux:label>Evidence Images</flux:label>
                 <flux:description>Attach screenshots or photos as evidence (JPG, PNG, GIF, WEBP). Multiple files allowed.</flux:description>
-                <input type="file" wire:model="formImages" multiple accept="image/jpeg,image/png,image/gif,image/webp" class="block w-full text-sm text-zinc-700 dark:text-zinc-300" />
+                <flux:input type="file" wire:model="formImages" multiple accept="image/jpeg,image/png,image/gif,image/webp" />
                 <flux:error name="formImages.*" />
             </flux:field>
 
@@ -607,7 +607,7 @@ new class extends Component {
                 <flux:field>
                     <flux:label>Add More Evidence Images</flux:label>
                     <flux:description>Attach additional screenshots or photos (JPG, PNG, GIF, WEBP).</flux:description>
-                    <input type="file" wire:model="formImages" multiple accept="image/jpeg,image/png,image/gif,image/webp" class="block w-full text-sm text-zinc-700 dark:text-zinc-300" />
+                    <flux:input type="file" wire:model="formImages" multiple accept="image/jpeg,image/png,image/gif,image/webp" />
                     <flux:error name="formImages.*" />
                 </flux:field>
 

--- a/resources/views/livewire/users/display-basic-details.blade.php
+++ b/resources/views/livewire/users/display-basic-details.blade.php
@@ -927,7 +927,7 @@ new class extends Component {
             {{-- Staff Reports Card --}}
             @can('view-user-discipline-reports', $user)
                 <div class="w-full lg:w-1/2">
-                    <livewire:users.discipline-reports-card :user="$user" lazy />
+                    <livewire:users.discipline-reports-card :user="$user" />
                 </div>
             @endcan
         </div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -242,6 +242,7 @@ Route::prefix('finance')
     ->name('finance.')
     ->middleware(['auth', 'can:finance-view'])
     ->group(function () {
+        Volt::route('/dashboard', 'finance.dashboard')->name('dashboard.index');
         Volt::route('/accounts', 'finance.chart-of-accounts')->name('accounts.index');
         Volt::route('/periods', 'finance.fiscal-periods')->name('periods.index');
         Volt::route('/vendors', 'finance.vendors')->name('vendors.index');

--- a/tests/Feature/Actions/DisciplineReports/AttachDisciplineReportImagesTest.php
+++ b/tests/Feature/Actions/DisciplineReports/AttachDisciplineReportImagesTest.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Actions\AttachDisciplineReportImages;
+use App\Models\DisciplineReport;
+use App\Models\DisciplineReportImage;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Storage;
+
+uses()->group('discipline-reports', 'actions');
+
+beforeEach(function () {
+    Storage::fake(config('filesystems.public_disk'));
+});
+
+it('stores files and creates DisciplineReportImage records for a draft report', function () {
+    $report = DisciplineReport::factory()->create();
+    $file = UploadedFile::fake()->image('screenshot.jpg', 400, 300);
+
+    AttachDisciplineReportImages::run($report, [$file]);
+
+    $image = DisciplineReportImage::where('discipline_report_id', $report->id)->first();
+
+    expect($image)->not->toBeNull()
+        ->and($image->original_filename)->toBe('screenshot.jpg')
+        ->and($image->path)->toStartWith("report-evidence/{$report->id}/");
+
+    Storage::disk(config('filesystems.public_disk'))->assertExists($image->path);
+});
+
+it('creates multiple image records when multiple files are provided', function () {
+    $report = DisciplineReport::factory()->create();
+    $files = [
+        UploadedFile::fake()->image('shot1.jpg', 200, 200),
+        UploadedFile::fake()->image('shot2.png', 200, 200),
+    ];
+
+    AttachDisciplineReportImages::run($report, $files);
+
+    expect(DisciplineReportImage::where('discipline_report_id', $report->id)->count())->toBe(2);
+});
+
+it('throws an exception when attaching images to a published report', function () {
+    $report = DisciplineReport::factory()->published()->create();
+    $file = UploadedFile::fake()->image('screenshot.jpg', 200, 200);
+
+    expect(fn () => AttachDisciplineReportImages::run($report, [$file]))
+        ->toThrow(\RuntimeException::class);
+});
+
+it('removes file from disk when a DisciplineReportImage record is deleted', function () {
+    $report = DisciplineReport::factory()->create();
+    $file = UploadedFile::fake()->image('evidence.jpg', 200, 200);
+
+    AttachDisciplineReportImages::run($report, [$file]);
+
+    $image = DisciplineReportImage::where('discipline_report_id', $report->id)->first();
+    $path = $image->path;
+
+    Storage::disk(config('filesystems.public_disk'))->assertExists($path);
+
+    $image->delete();
+
+    Storage::disk(config('filesystems.public_disk'))->assertMissing($path);
+});

--- a/tests/Feature/Finance/FinanceDashboardTest.php
+++ b/tests/Feature/Finance/FinanceDashboardTest.php
@@ -1,0 +1,258 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Actions\CreateJournalEntry;
+use App\Models\FinancialAccount;
+use App\Models\FinancialJournalEntry;
+use App\Models\FinancialPeriod;
+use App\Models\User;
+use Livewire\Volt\Volt;
+
+uses()->group('finance', 'finance-dashboard');
+
+// == Access control ==
+
+it('finance-view user can access finance dashboard', function () {
+    $user = User::factory()->withRole('Finance - View')->create();
+
+    $this->actingAs($user)
+        ->get(route('finance.dashboard.index'))
+        ->assertOk();
+});
+
+it('user without finance role cannot access finance dashboard', function () {
+    $user = User::factory()->create();
+
+    $this->actingAs($user)
+        ->get(route('finance.dashboard.index'))
+        ->assertForbidden();
+});
+
+it('unauthenticated user cannot access finance dashboard', function () {
+    $this->get(route('finance.dashboard.index'))
+        ->assertRedirect(route('login'));
+});
+
+// == Cash position ==
+
+it('cash position shows correct balance for a posted journal entry', function () {
+    $user = User::factory()->withRole('Finance - Record')->create();
+
+    $period = FinancialPeriod::factory()->create(['status' => 'open']);
+    $bank = FinancialAccount::factory()->create([
+        'name' => 'Checking Account',
+        'type' => 'asset',
+        'normal_balance' => 'debit',
+        'is_bank_account' => true,
+        'is_active' => true,
+    ]);
+    $revenue = FinancialAccount::factory()->create(['type' => 'revenue', 'normal_balance' => 'credit']);
+
+    CreateJournalEntry::run(
+        user: $user,
+        type: 'income',
+        periodId: $period->id,
+        date: $period->start_date->toDateString(),
+        description: 'Donation',
+        amountCents: 50000,
+        primaryAccountId: $revenue->id,
+        bankAccountId: $bank->id,
+        status: 'posted',
+    );
+
+    $component = Volt::actingAs($user)->test('finance.dashboard');
+    $cashPosition = $component->get('cashPosition');
+
+    $accountBalance = collect($cashPosition['accounts'])->firstWhere('name', 'Checking Account');
+    expect($accountBalance['balance'])->toBe(50000);
+});
+
+it('draft entries are excluded from cash position', function () {
+    $user = User::factory()->withRole('Finance - Record')->create();
+
+    $period = FinancialPeriod::factory()->create(['status' => 'open']);
+    $bank = FinancialAccount::factory()->create([
+        'name' => 'Draft Test Bank',
+        'type' => 'asset',
+        'normal_balance' => 'debit',
+        'is_bank_account' => true,
+        'is_active' => true,
+    ]);
+    $revenue = FinancialAccount::factory()->create(['type' => 'revenue', 'normal_balance' => 'credit']);
+
+    CreateJournalEntry::run(
+        user: $user,
+        type: 'income',
+        periodId: $period->id,
+        date: $period->start_date->toDateString(),
+        description: 'Draft income',
+        amountCents: 99900,
+        primaryAccountId: $revenue->id,
+        bankAccountId: $bank->id,
+        status: 'draft',
+    );
+
+    $component = Volt::actingAs($user)->test('finance.dashboard');
+    $cashPosition = $component->get('cashPosition');
+
+    $accountBalance = collect($cashPosition['accounts'])->firstWhere('name', 'Draft Test Bank');
+    expect($accountBalance['balance'])->toBe(0);
+});
+
+// == Current month income/expense ==
+
+it('current month income total reflects posted entries in current calendar month', function () {
+    $user = User::factory()->withRole('Finance - Record')->create();
+
+    $period = FinancialPeriod::factory()->create([
+        'status' => 'open',
+        'start_date' => now()->startOfMonth()->toDateString(),
+        'end_date' => now()->endOfMonth()->toDateString(),
+    ]);
+    $bank = FinancialAccount::factory()->create([
+        'type' => 'asset',
+        'normal_balance' => 'debit',
+        'is_bank_account' => true,
+        'is_active' => true,
+    ]);
+    $revenue = FinancialAccount::factory()->create(['type' => 'revenue', 'normal_balance' => 'credit']);
+
+    CreateJournalEntry::run(
+        user: $user,
+        type: 'income',
+        periodId: $period->id,
+        date: now()->toDateString(),
+        description: 'Monthly income',
+        amountCents: 75000,
+        primaryAccountId: $revenue->id,
+        bankAccountId: $bank->id,
+        status: 'posted',
+    );
+
+    $component = Volt::actingAs($user)->test('finance.dashboard');
+    $currentMonth = $component->get('currentMonth');
+
+    expect($currentMonth['income'])->toBeGreaterThanOrEqual(75000);
+});
+
+it('current month expenses reflect posted entries in current calendar month', function () {
+    $user = User::factory()->withRole('Finance - Record')->create();
+
+    $period = FinancialPeriod::factory()->create([
+        'status' => 'open',
+        'start_date' => now()->startOfMonth()->toDateString(),
+        'end_date' => now()->endOfMonth()->toDateString(),
+    ]);
+    $bank = FinancialAccount::factory()->create([
+        'type' => 'asset',
+        'normal_balance' => 'debit',
+        'is_bank_account' => true,
+        'is_active' => true,
+    ]);
+    $expense = FinancialAccount::factory()->create(['type' => 'expense', 'normal_balance' => 'debit']);
+
+    CreateJournalEntry::run(
+        user: $user,
+        type: 'expense',
+        periodId: $period->id,
+        date: now()->toDateString(),
+        description: 'Monthly expense',
+        amountCents: 30000,
+        primaryAccountId: $expense->id,
+        bankAccountId: $bank->id,
+        status: 'posted',
+    );
+
+    $component = Volt::actingAs($user)->test('finance.dashboard');
+    $currentMonth = $component->get('currentMonth');
+
+    expect($currentMonth['expenses'])->toBeGreaterThanOrEqual(30000);
+});
+
+it('draft entries are excluded from current month totals', function () {
+    $user = User::factory()->withRole('Finance - Record')->create();
+
+    $period = FinancialPeriod::factory()->create([
+        'status' => 'open',
+        'start_date' => now()->startOfMonth()->toDateString(),
+        'end_date' => now()->endOfMonth()->toDateString(),
+    ]);
+    $bank = FinancialAccount::factory()->create([
+        'type' => 'asset',
+        'normal_balance' => 'debit',
+        'is_bank_account' => true,
+        'is_active' => true,
+    ]);
+    $revenue = FinancialAccount::factory()->create([
+        'type' => 'revenue',
+        'normal_balance' => 'credit',
+        'name' => 'Draft Revenue Account',
+        'code' => 88001,
+    ]);
+
+    // Only post a draft — income should remain 0 (from this account)
+    CreateJournalEntry::run(
+        user: $user,
+        type: 'income',
+        periodId: $period->id,
+        date: now()->toDateString(),
+        description: 'Should not appear',
+        amountCents: 123456,
+        primaryAccountId: $revenue->id,
+        bankAccountId: $bank->id,
+        status: 'draft',
+    );
+
+    // Load a fresh component to get isolated results
+    $component = Volt::actingAs($user)->test('finance.dashboard');
+    $currentMonth = $component->instance()->getCurrentMonthProperty();
+
+    // Total income in current month should not include the draft amount
+    // We can't assert exact 0 because other tests may have added posted entries,
+    // so assert the total is less than 123456 from THIS test's data in isolation.
+    // Instead verify via a direct DB check approach: revenue account line not counted
+    $postedIncome = \Illuminate\Support\Facades\DB::table('financial_journal_entry_lines as jel')
+        ->join('financial_journal_entries as je', 'je.id', '=', 'jel.journal_entry_id')
+        ->join('financial_accounts as fa', 'fa.id', '=', 'jel.account_id')
+        ->where('je.status', 'posted')
+        ->where('fa.id', $revenue->id)
+        ->whereBetween('je.date', [now()->startOfMonth()->toDateString(), now()->endOfMonth()->toDateString()])
+        ->selectRaw('COALESCE(SUM(jel.credit) - SUM(jel.debit), 0) as total')
+        ->value('total');
+
+    expect((int) $postedIncome)->toBe(0);
+});
+
+// == Pending drafts count ==
+
+it('pending drafts count matches draft journal entries', function () {
+    $user = User::factory()->withRole('Finance - Record')->create();
+
+    $initialCount = FinancialJournalEntry::where('status', 'draft')->count();
+
+    $period = FinancialPeriod::factory()->create(['status' => 'open']);
+    $bank = FinancialAccount::factory()->create([
+        'type' => 'asset',
+        'normal_balance' => 'debit',
+        'is_bank_account' => true,
+        'is_active' => true,
+    ]);
+    $revenue = FinancialAccount::factory()->create(['type' => 'revenue', 'normal_balance' => 'credit']);
+
+    CreateJournalEntry::run(
+        user: $user,
+        type: 'income',
+        periodId: $period->id,
+        date: $period->start_date->toDateString(),
+        description: 'Draft entry',
+        amountCents: 10000,
+        primaryAccountId: $revenue->id,
+        bankAccountId: $bank->id,
+        status: 'draft',
+    );
+
+    $component = Volt::actingAs($user)->test('finance.dashboard');
+
+    expect($component->get('pendingDrafts'))->toBe($initialCount + 1);
+});

--- a/tests/Feature/Finance/FinanceDashboardTest.php
+++ b/tests/Feature/Finance/FinanceDashboardTest.php
@@ -133,7 +133,7 @@ it('current month income total reflects posted entries in current calendar month
     $component = Volt::actingAs($user)->test('finance.dashboard');
     $currentMonth = $component->get('currentMonth');
 
-    expect($currentMonth['income'])->toBeGreaterThanOrEqual(75000);
+    expect($currentMonth['income'])->toBe(75000);
 });
 
 it('current month expenses reflect posted entries in current calendar month', function () {
@@ -167,7 +167,7 @@ it('current month expenses reflect posted entries in current calendar month', fu
     $component = Volt::actingAs($user)->test('finance.dashboard');
     $currentMonth = $component->get('currentMonth');
 
-    expect($currentMonth['expenses'])->toBeGreaterThanOrEqual(30000);
+    expect($currentMonth['expenses'])->toBe(30000);
 });
 
 it('draft entries are excluded from current month totals', function () {
@@ -204,24 +204,10 @@ it('draft entries are excluded from current month totals', function () {
         status: 'draft',
     );
 
-    // Load a fresh component to get isolated results
     $component = Volt::actingAs($user)->test('finance.dashboard');
-    $currentMonth = $component->instance()->getCurrentMonthProperty();
+    $currentMonth = $component->get('currentMonth');
 
-    // Total income in current month should not include the draft amount
-    // We can't assert exact 0 because other tests may have added posted entries,
-    // so assert the total is less than 123456 from THIS test's data in isolation.
-    // Instead verify via a direct DB check approach: revenue account line not counted
-    $postedIncome = \Illuminate\Support\Facades\DB::table('financial_journal_entry_lines as jel')
-        ->join('financial_journal_entries as je', 'je.id', '=', 'jel.journal_entry_id')
-        ->join('financial_accounts as fa', 'fa.id', '=', 'jel.account_id')
-        ->where('je.status', 'posted')
-        ->where('fa.id', $revenue->id)
-        ->whereBetween('je.date', [now()->startOfMonth()->toDateString(), now()->endOfMonth()->toDateString()])
-        ->selectRaw('COALESCE(SUM(jel.credit) - SUM(jel.debit), 0) as total')
-        ->value('total');
-
-    expect((int) $postedIncome)->toBe(0);
+    expect($currentMonth['income'])->toBe(0);
 });
 
 // == Pending drafts count ==

--- a/tests/Feature/Livewire/ReportEvidenceUITest.php
+++ b/tests/Feature/Livewire/ReportEvidenceUITest.php
@@ -1,0 +1,130 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Actions\AttachDisciplineReportImages;
+use App\Models\DisciplineReport;
+use App\Models\DisciplineReportImage;
+use App\Models\User;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Storage;
+use Livewire\Volt\Volt;
+
+uses()->group('discipline-reports', 'evidence-ui');
+
+beforeEach(function () {
+    Storage::fake(config('filesystems.public_disk'));
+});
+
+// == view-report.blade.php: Evidence section visibility ==
+
+it('view-report shows Evidence section with img elements when report has images', function () {
+    $staff = officerCommand();
+    $subject = User::factory()->create();
+    $report = DisciplineReport::factory()->forSubject($subject)->create(); // draft — staff can view
+
+    $file = UploadedFile::fake()->image('screenshot.jpg', 400, 300);
+    AttachDisciplineReportImages::run($report, [$file]);
+
+    $component = Volt::actingAs($staff)->test('reports.view-report', ['report' => $report]);
+
+    $component->assertSee('Evidence');
+    $component->assertSee('<img', false);
+});
+
+it('view-report does not render Evidence section when report has no images', function () {
+    $staff = officerCommand();
+    $subject = User::factory()->create();
+    $report = DisciplineReport::factory()->forSubject($subject)->published()->create();
+
+    $component = Volt::actingAs($staff)->test('reports.view-report', ['report' => $report]);
+
+    $component->assertDontSee('Evidence');
+});
+
+// == discipline-reports-card: image UI visibility ==
+
+it('opening edit modal for a published report is forbidden', function () {
+    $staff = officerCommand();
+    loginAs($staff);
+    $subject = User::factory()->create();
+    $report = DisciplineReport::factory()->forSubject($subject)->published()->create();
+
+    // Published reports cannot be edited — the update policy returns false
+    // which means image add/remove controls are never accessible
+    Volt::actingAs($staff)->test('users.discipline-reports-card', ['user' => $subject])
+        ->call('openEditModal', $report->id)
+        ->assertForbidden();
+});
+
+it('edit modal image UI is rendered for a draft report', function () {
+    $staff = officerCommand();
+    loginAs($staff);
+    $subject = User::factory()->create();
+    $report = DisciplineReport::factory()->forSubject($subject)->byReporter($staff)->create(); // draft
+
+    $component = Volt::actingAs($staff)->test('users.discipline-reports-card', ['user' => $subject]);
+    $component->call('openEditModal', $report->id);
+
+    $component->assertSee('Add More Evidence Images');
+});
+
+// == images attached during creation are persisted ==
+
+it('images attached via AttachDisciplineReportImages are retrievable from the report', function () {
+    $staff = officerCommand();
+    $subject = User::factory()->create();
+    $report = DisciplineReport::factory()->forSubject($subject)->create();
+
+    $files = [
+        UploadedFile::fake()->image('evidence1.jpg', 300, 300),
+        UploadedFile::fake()->image('evidence2.png', 300, 300),
+    ];
+
+    AttachDisciplineReportImages::run($report, $files);
+
+    expect($report->images()->count())->toBe(2);
+    Storage::disk(config('filesystems.public_disk'))->assertExists(
+        $report->images()->first()->path
+    );
+});
+
+// == cascade delete ==
+
+it('deleting a report also removes its image files from disk', function () {
+    $report = DisciplineReport::factory()->create();
+    $file = UploadedFile::fake()->image('to-delete.jpg', 200, 200);
+
+    AttachDisciplineReportImages::run($report, [$file]);
+
+    $path = $report->images()->first()->path;
+    Storage::disk(config('filesystems.public_disk'))->assertExists($path);
+
+    $report->delete();
+
+    Storage::disk(config('filesystems.public_disk'))->assertMissing($path);
+    expect(DisciplineReportImage::where('discipline_report_id', $report->id)->count())->toBe(0);
+});
+
+// == removeImage tracks pending removal ==
+
+it('removeImage marks an image ID for pending removal without immediately deleting', function () {
+    $staff = officerCommand();
+    loginAs($staff);
+    $subject = User::factory()->create();
+    $report = DisciplineReport::factory()->forSubject($subject)->byReporter($staff)->create();
+
+    $file = UploadedFile::fake()->image('existing.jpg', 200, 200);
+    AttachDisciplineReportImages::run($report, [$file]);
+    $image = $report->images()->first();
+
+    $component = Volt::actingAs($staff)->test('users.discipline-reports-card', ['user' => $subject]);
+    $component->call('openEditModal', $report->id);
+    $component->call('removeImage', $image->id);
+
+    // Image still exists in DB (not committed until updateReport is called)
+    expect(DisciplineReportImage::find($image->id))->not->toBeNull();
+
+    // But it's tracked in removedImageIds
+    expect($component->get('removedImageIds'))->toContain($image->id);
+});

--- a/tests/Feature/Livewire/ReportEvidenceUITest.php
+++ b/tests/Feature/Livewire/ReportEvidenceUITest.php
@@ -40,6 +40,7 @@ it('view-report does not render Evidence section when report has no images', fun
     $component = Volt::actingAs($staff)->test('reports.view-report', ['report' => $report]);
 
     $component->assertDontSee('Evidence');
+    $component->assertDontSee('<img', false);
 });
 
 // == discipline-reports-card: image UI visibility ==

--- a/tests/Feature/StaffPageTest.php
+++ b/tests/Feature/StaffPageTest.php
@@ -8,6 +8,7 @@ use App\Models\BoardMember;
 use App\Models\StaffPosition;
 use App\Models\User;
 use App\Services\MinecraftRconService;
+use Livewire\Volt\Volt;
 
 uses()->group('staff');
 
@@ -106,4 +107,33 @@ it('shows unlinked board member with display name', function () {
     $this->get(route('staff.index'))
         ->assertOk()
         ->assertSee('External Board Member');
+});
+
+it('does not render the old sidebar panel markup', function () {
+    $this->get(route('staff.index'))
+        ->assertOk()
+        ->assertDontSee('lg:w-1/4 lg:sticky', false);
+});
+
+it('selectPosition sets selectedPositionId and selectedPosition returns the correct model', function () {
+    $position = StaffPosition::factory()->officer()->inDepartment(StaffDepartment::Command)->create([
+        'title' => 'Unique Test Officer Title XYZ',
+    ]);
+
+    $component = Volt::test('staff.page');
+    $component->call('selectPosition', $position->id);
+
+    expect($component->get('selectedPositionId'))->toBe($position->id);
+    $component->assertSee('Unique Test Officer Title XYZ');
+});
+
+it('renders markdown responsibilities as HTML in the modal content', function () {
+    $position = StaffPosition::factory()->officer()->inDepartment(StaffDepartment::Command)->create([
+        'responsibilities' => '**bold text**',
+    ]);
+
+    $component = Volt::test('staff.page');
+    $component->call('selectPosition', $position->id);
+
+    $component->assertSee('<strong>bold text</strong>', false);
 });


### PR DESCRIPTION
## What Changed

This PR delivers three improvements for staff and visitors:

1. **Staff page modals** -- The `/staff` page now opens a full-detail modal when you click any position card or board member card, replacing the old sidebar. Position details (responsibilities, requirements) render as markdown. The modal is full-width on mobile.

2. **Discipline report evidence images** -- Staff can now attach image evidence (screenshots, photos) to a discipline report while it's in draft. Images appear in an Evidence section on the view modal and on the standalone report view page. Images are locked after a report is published -- they can't be added or removed. Deleting a report also removes its image files.

3. **Finance staff dashboard** -- A new `/finance/dashboard` page is now the landing page for all Finance-role staff. It shows cash position (per bank account + total), current-month income/expenses vs. budget, a 6-month trend chart, YTD summary, net assets (unrestricted vs. restricted), and a pending drafts count. All figures are from posted entries only.

## How to Test

### Staff Page Modals

1. Visit `/staff` (no login required)
2. Click any filled or vacant position card
3. Expected: a modal opens showing the position's title, department, rank, description, responsibilities (rendered as markdown bullets/bold if present), requirements, and the assigned staff member's photo/name/links (for filled positions)
4. Click the X or outside the modal to close it
5. Click a board member card in the lower section
6. Expected: a board member modal opens with their name, title, bio, and any contact links
7. Test on a mobile-width browser window -- expected: modal is full-width, no horizontal scroll

### Discipline Report Evidence Images

1. Log in as a staff member with the Discipline Report - Manager role
2. Navigate to any member's profile page and open the Discipline Reports card
3. Click **New Report**, fill in required fields
4. In the Evidence Images section, upload one or more images (jpg/png/gif/webp)
5. Verify thumbnail previews appear before saving
6. Click **Save** -- report is created as a draft
7. Click the edit (pencil) icon to reopen the draft
8. Verify existing images show in the edit modal with × remove buttons
9. Remove one image and upload a new one, then click **Update Report**
10. Verify removed image is gone and new image appears
11. Publish the report -- verify the Evidence section no longer shows add/remove controls
12. View the published report -- verify the Evidence section shows the attached images
13. Log in as the report subject -- verify their published report shows the Evidence section

### Finance Staff Dashboard

1. Log in as a user with Finance - View, Finance - Record, or Finance - Manage role
2. Click **Finance** in the Ready Room
3. Expected: you land on the Finance Dashboard (not the journal)
4. Verify the **Cash Position** section shows bank account balances
5. Verify the **Current Month** section shows income/expenses for this calendar month
6. Verify the **6-Month Trend** chart renders (may be flat/empty if few entries exist)
7. Verify the **Pending Drafts** count matches draft entries in the journal
8. Create a draft journal entry, return to dashboard, reload -- verify count increased
9. Post the entry, return to dashboard, reload -- verify it now appears in the month totals and draft count decreased
10. Log in as a user without any Finance role -- expected: accessing `/finance/dashboard` returns 403

## Things to Watch For

- Staff modal: positions that are vacant (no assigned user) should show the position details without a staff member section
- Staff modal: positions with markdown in responsibilities/requirements should render with formatting (bold, bullets) -- not as raw asterisks
- Evidence images: the add/remove controls should be completely absent for published reports, not just disabled
- Evidence images: the × remove button should only stage the deletion -- the image should still appear until Update Report is clicked
- Finance dashboard: if no fiscal period covers today, the YTD section may appear empty -- this is expected behavior
- Finance dashboard: draft entries should NOT appear in any balance or income/expense figures

## Parent PRD

#637

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Evidence image upload, management, thumbnails and public URLs for discipline reports (edits blocked on published reports)
  * Finance dashboard (cash position, month vs budget, 6‑month trends, YTD summary, pending drafts) plus finance dashboard navigation
  * Staff page redesigned to use modal-based position/board member browsing

* **Documentation**
  * Staff, finance and user handbooks updated with guidance and notes

* **Tests**
  * New tests covering evidence uploads, cleanup, staff page and finance dashboard
<!-- end of auto-generated comment: release notes by coderabbit.ai -->