### PR TITLE
fix: render 6-month finance trend chart with time-axis #651

### DIFF
--- a/resources/views/livewire/finance/dashboard.blade.php
+++ b/resources/views/livewire/finance/dashboard.blade.php
@@ -119,7 +119,7 @@ new class extends Component
                 ->value('total');
 
             $data[] = [
-                'month' => $month->format('M Y'),
+                'month' => $start,
                 'income' => round($income / 100, 2),
                 'expense' => round($expense / 100, 2),
             ];
@@ -310,11 +310,11 @@ new class extends Component
         <flux:heading size="md" class="mb-4">6-Month Trend</flux:heading>
         <flux:chart :value="$this->sixMonthTrend" class="aspect-[3/1]">
             <flux:chart.svg gutter="8 8 28 8">
-                <flux:chart.axis axis="x" field="month">
+                <flux:chart.axis axis="x" field="month" :format="['month' => 'short', 'year' => 'numeric']">
                     <flux:chart.axis.tick class="text-zinc-400 text-xs" />
                     <flux:chart.axis.line class="text-zinc-600" />
                 </flux:chart.axis>
-                <flux:chart.axis axis="y">
+                <flux:chart.axis axis="y" tick-start="0">
                     <flux:chart.axis.grid class="text-zinc-700" />
                     <flux:chart.axis.tick class="text-zinc-400 text-xs" />
                 </flux:chart.axis>
@@ -325,7 +325,7 @@ new class extends Component
                 <flux:chart.cursor />
             </flux:chart.svg>
             <flux:chart.tooltip>
-                <flux:chart.tooltip.heading field="month" />
+                <flux:chart.tooltip.heading field="month" :format="['month' => 'short', 'year' => 'numeric']" />
                 <flux:chart.tooltip.value field="income" label="Income" />
                 <flux:chart.tooltip.value field="expense" label="Expenses" />
             </flux:chart.tooltip>

--- a/tests/Feature/Finance/FinanceDashboardTest.php
+++ b/tests/Feature/Finance/FinanceDashboardTest.php
@@ -242,3 +242,120 @@ it('pending drafts count matches draft journal entries', function () {
 
     expect($component->get('pendingDrafts'))->toBe($initialCount + 1);
 });
+
+// == 6-month trend ==
+
+it('six month trend includes income and expense from previous months', function () {
+    $user = User::factory()->withRole('Finance - Record')->create();
+
+    $threeMonthsAgo = now()->startOfMonth()->subMonths(3);
+
+    $period = FinancialPeriod::factory()->create([
+        'status' => 'open',
+        'fiscal_year' => $threeMonthsAgo->year,
+        'month_number' => $threeMonthsAgo->month,
+        'start_date' => $threeMonthsAgo->copy()->startOfMonth()->toDateString(),
+        'end_date' => $threeMonthsAgo->copy()->endOfMonth()->toDateString(),
+    ]);
+
+    $bank = FinancialAccount::factory()->create([
+        'type' => 'asset',
+        'normal_balance' => 'debit',
+        'is_bank_account' => true,
+        'is_active' => true,
+    ]);
+    $revenue = FinancialAccount::factory()->create(['type' => 'revenue', 'normal_balance' => 'credit']);
+    $expense = FinancialAccount::factory()->create(['type' => 'expense', 'normal_balance' => 'debit']);
+
+    CreateJournalEntry::run(
+        user: $user,
+        type: 'income',
+        periodId: $period->id,
+        date: $threeMonthsAgo->copy()->day(15)->toDateString(),
+        description: 'Past income',
+        amountCents: 42000,
+        primaryAccountId: $revenue->id,
+        bankAccountId: $bank->id,
+        status: 'posted',
+    );
+
+    CreateJournalEntry::run(
+        user: $user,
+        type: 'expense',
+        periodId: $period->id,
+        date: $threeMonthsAgo->copy()->day(20)->toDateString(),
+        description: 'Past expense',
+        amountCents: 17000,
+        primaryAccountId: $expense->id,
+        bankAccountId: $bank->id,
+        status: 'posted',
+    );
+
+    $component = Volt::actingAs($user)->test('finance.dashboard');
+    $trend = $component->get('sixMonthTrend');
+
+    expect($trend)->toHaveCount(6);
+
+    $monthKey = $threeMonthsAgo->copy()->startOfMonth()->toDateString();
+    $monthRow = collect($trend)->firstWhere('month', $monthKey);
+
+    expect($monthRow)->not->toBeNull("Trend should include row for {$monthKey}");
+    expect($monthRow['income'])->toBe(420.0);
+    expect($monthRow['expense'])->toBe(170.0);
+});
+
+it('six month trend month labels are unique across all six months', function () {
+    $user = User::factory()->withRole('Finance - View')->create();
+
+    $component = Volt::actingAs($user)->test('finance.dashboard');
+    $trend = $component->get('sixMonthTrend');
+
+    expect($trend)->toHaveCount(6);
+
+    $months = collect($trend)->pluck('month')->all();
+    expect(array_unique($months))->toHaveCount(6, 'All 6 month labels should be unique. Got: ' . implode(', ', $months));
+});
+
+it('six month trend includes data from each of the past six months when entries exist', function () {
+    $user = User::factory()->withRole('Finance - Record')->create();
+
+    $bank = FinancialAccount::factory()->create([
+        'type' => 'asset',
+        'normal_balance' => 'debit',
+        'is_bank_account' => true,
+        'is_active' => true,
+    ]);
+    $revenue = FinancialAccount::factory()->create(['type' => 'revenue', 'normal_balance' => 'credit']);
+
+    for ($i = 5; $i >= 0; $i--) {
+        $month = now()->startOfMonth()->subMonths($i);
+        $period = FinancialPeriod::factory()->create([
+            'status' => 'open',
+            'fiscal_year' => $month->year,
+            'month_number' => $month->month,
+            'start_date' => $month->copy()->startOfMonth()->toDateString(),
+            'end_date' => $month->copy()->endOfMonth()->toDateString(),
+        ]);
+
+        CreateJournalEntry::run(
+            user: $user,
+            type: 'income',
+            periodId: $period->id,
+            date: $month->copy()->day(15)->toDateString(),
+            description: "Month {$i} income",
+            amountCents: 10000 + $i * 1000,
+            primaryAccountId: $revenue->id,
+            bankAccountId: $bank->id,
+            status: 'posted',
+        );
+    }
+
+    $component = Volt::actingAs($user)->test('finance.dashboard');
+    $trend = $component->get('sixMonthTrend');
+
+    expect($trend)->toHaveCount(6);
+
+    foreach ($trend as $row) {
+        expect($row['income'])->toBeGreaterThan(0, "Month {$row['month']} should have income > 0");
+    }
+});


### PR DESCRIPTION
Fixes #651 — bug found in production after PRD #637 deployed. The 6-Month Trend chart on /finance/dashboard only showed data for the current month; the previous five months appeared blank because the multi-series line chart was using a categorical x-axis with M Y string labels. Switching to ISO date keys lets the chart render on its time-axis path; the x-axis still displays MMM YYYY via an Intl.DateTimeFormat directive, and the y-axis is pinned to zero so flat months stay visible. Parent PRD: #637. 🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Finance dashboard six-month trend now displays with refined date formatting and Y-axis starting at zero for improved visualization clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->