### PR TITLE
PRD: Backup Management System

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 /public/hot
 /public/storage
 /storage/*.key
+/storage/app/backups/
 /storage/pail
 /vendor
 .DS_Store

--- a/app/Actions/ClearCredentialRotationFlag.php
+++ b/app/Actions/ClearCredentialRotationFlag.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Actions;
+
+use App\Models\Credential;
+use App\Models\User;
+use Lorisleiva\Actions\Concerns\AsAction;
+
+class ClearCredentialRotationFlag
+{
+    use AsAction;
+
+    public function handle(Credential $credential, User $actor): Credential
+    {
+        $credential->update(['needs_password_change' => false]);
+
+        RecordActivity::run($credential, 'credential_rotation_flag_cleared', "Rotation flag manually cleared on \"{$credential->name}\" by {$actor->name}.", $actor);
+        RecordCredentialAccess::run($credential, $actor, 'cleared_rotation_flag');
+
+        return $credential->fresh();
+    }
+}

--- a/app/Console/Commands/CleanupBackups.php
+++ b/app/Console/Commands/CleanupBackups.php
@@ -3,6 +3,7 @@
 namespace App\Console\Commands;
 
 use App\Services\BackupRetentionService;
+use App\Services\BackupStorageService;
 use Illuminate\Console\Command;
 
 class CleanupBackups extends Command
@@ -23,6 +24,19 @@ class CleanupBackups extends Command
                 $this->info('Deleted: '.basename($path));
             }
             $this->info('Cleaned up '.count($deleted).' backup file(s).');
+        }
+
+        // Also enforce S3 retention when S3 is configured.
+        if (config('filesystems.disks.s3.key')) {
+            try {
+                $storageService = app(BackupStorageService::class);
+                $s3Deleted = $service->enforceS3Retention($storageService);
+                if (! empty($s3Deleted)) {
+                    $this->info('Cleaned up '.count($s3Deleted).' S3 backup(s).');
+                }
+            } catch (\Throwable $e) {
+                $this->warn('S3 retention failed: '.$e->getMessage());
+            }
         }
 
         return Command::SUCCESS;

--- a/app/Console/Commands/CleanupBackups.php
+++ b/app/Console/Commands/CleanupBackups.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Services\BackupRetentionService;
+use Illuminate\Console\Command;
+
+class CleanupBackups extends Command
+{
+    protected $signature = 'app:backup-cleanup';
+
+    protected $description = 'Delete local backup files older than the configured retention window';
+
+    public function handle(): int
+    {
+        $service = app(BackupRetentionService::class);
+        $deleted = $service->enforceLocalRetention();
+
+        if (empty($deleted)) {
+            $this->info('No backup files to clean up.');
+        } else {
+            foreach ($deleted as $path) {
+                $this->info('Deleted: '.basename($path));
+            }
+            $this->info('Cleaned up '.count($deleted).' backup file(s).');
+        }
+
+        return Command::SUCCESS;
+    }
+}

--- a/app/Console/Commands/CreateBackup.php
+++ b/app/Console/Commands/CreateBackup.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\Role;
+use App\Models\User;
+use App\Notifications\BackupCreatedNotification;
+use App\Notifications\BackupFailedNotification;
+use App\Services\BackupService;
+use App\Services\TicketNotificationService;
+use Illuminate\Console\Command;
+
+class CreateBackup extends Command
+{
+    protected $signature = 'app:backup-create
+                            {--skip-offline : Skip maintenance mode regardless of SiteConfig}';
+
+    protected $description = 'Create a compressed database backup';
+
+    public function handle(): int
+    {
+        $service = app(BackupService::class);
+
+        if ($this->option('skip-offline')) {
+            $service->setSkipOffline(true);
+        }
+
+        try {
+            $path = $service->create();
+            $this->info("Backup created: {$path}");
+            $this->notifyManagers('success', $path);
+
+            return Command::SUCCESS;
+        } catch (\Throwable $e) {
+            $this->error("Backup failed: {$e->getMessage()}");
+            $this->notifyManagers('failure', null, $e->getMessage());
+
+            return Command::FAILURE;
+        }
+    }
+
+    private function notifyManagers(string $outcome, ?string $path, string $error = ''): void
+    {
+        $roleId = Role::where('name', 'Backup Manager')->value('id');
+
+        if (! $roleId) {
+            return;
+        }
+
+        $backupManagers = User::where(function ($q) use ($roleId) {
+            $q->whereHas('staffPosition.roles', fn ($r) => $r->where('roles.id', $roleId))
+                ->orWhereHas('staffPosition', fn ($p) => $p->whereNotNull('has_all_roles_at'))
+                ->orWhereIn('staff_rank', function ($sub) use ($roleId) {
+                    $sub->select('staff_rank')->from('role_staff_rank')->where('role_id', $roleId);
+                });
+        })->get();
+
+        $notificationService = app(TicketNotificationService::class);
+
+        foreach ($backupManagers as $manager) {
+            $notification = $outcome === 'success'
+                ? new BackupCreatedNotification(basename($path))
+                : new BackupFailedNotification($error);
+
+            $notificationService->send($manager, $notification, 'staff_alerts');
+        }
+    }
+}

--- a/app/Console/Commands/PushBackupToS3.php
+++ b/app/Console/Commands/PushBackupToS3.php
@@ -28,6 +28,13 @@ class PushBackupToS3 extends Command
         $localPath = $files[0];
 
         $storageService = app(BackupStorageService::class);
+
+        if (! $storageService->isConfigured()) {
+            $this->warn('S3 is not configured; skipping upload.');
+
+            return Command::SUCCESS;
+        }
+
         $retentionService = app(BackupRetentionService::class);
 
         $key = $storageService->upload($localPath);

--- a/app/Console/Commands/PushBackupToS3.php
+++ b/app/Console/Commands/PushBackupToS3.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Services\BackupRetentionService;
+use App\Services\BackupStorageService;
+use Illuminate\Console\Command;
+
+class PushBackupToS3 extends Command
+{
+    protected $signature = 'app:backup-push-s3';
+
+    protected $description = 'Push the most recent local backup to S3 and enforce S3 retention tiers';
+
+    public function handle(): int
+    {
+        $dir = storage_path('app/backups');
+        $files = glob("{$dir}/*.sql.gz") ?: [];
+
+        if (empty($files)) {
+            $this->error('No local backup files found.');
+
+            return Command::FAILURE;
+        }
+
+        // Most recent by mtime
+        usort($files, fn ($a, $b) => filemtime($b) - filemtime($a));
+        $localPath = $files[0];
+
+        $storageService = app(BackupStorageService::class);
+        $retentionService = app(BackupRetentionService::class);
+
+        $key = $storageService->upload($localPath);
+        $this->info("Uploaded: {$key}");
+
+        $deleted = $retentionService->enforceS3Retention($storageService);
+
+        if (! empty($deleted)) {
+            foreach ($deleted as $d) {
+                $this->info("Removed from S3: {$d}");
+            }
+            $this->info('Cleaned up '.count($deleted).' S3 backup(s).');
+        }
+
+        return Command::SUCCESS;
+    }
+}

--- a/app/Console/Commands/RestoreBackup.php
+++ b/app/Console/Commands/RestoreBackup.php
@@ -19,12 +19,27 @@ class RestoreBackup extends Command
     public function handle(): int
     {
         $filename = $this->argument('filename');
+
+        if ($filename !== basename($filename) || ! str_ends_with($filename, '.sql.gz')) {
+            $this->error('Invalid backup filename.');
+
+            return Command::FAILURE;
+        }
+
+        $backupsDir = realpath(storage_path('app/backups'));
         $path = storage_path("app/backups/{$filename}");
+        $realPath = realpath($path);
+
+        if ($realPath === false || $backupsDir === false || ! str_starts_with($realPath, $backupsDir.DIRECTORY_SEPARATOR)) {
+            $this->error('Invalid backup path.');
+
+            return Command::FAILURE;
+        }
 
         $service = app(RestoreService::class);
 
         try {
-            $service->restore($path);
+            $service->restore($realPath);
             $this->info("Restore completed from: {$filename}");
             $this->notifyManagers('success', $filename);
 

--- a/app/Console/Commands/RestoreBackup.php
+++ b/app/Console/Commands/RestoreBackup.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\Role;
+use App\Models\User;
+use App\Notifications\RestoreCompletedNotification;
+use App\Notifications\RestoreFailedNotification;
+use App\Services\RestoreService;
+use App\Services\TicketNotificationService;
+use Illuminate\Console\Command;
+
+class RestoreBackup extends Command
+{
+    protected $signature = 'app:backup-restore {filename : Bare filename inside storage/app/backups/}';
+
+    protected $description = 'Restore database from a local backup file';
+
+    public function handle(): int
+    {
+        $filename = $this->argument('filename');
+        $path = storage_path("app/backups/{$filename}");
+
+        $service = app(RestoreService::class);
+
+        try {
+            $service->restore($path);
+            $this->info("Restore completed from: {$filename}");
+            $this->notifyManagers('success', $filename);
+
+            return Command::SUCCESS;
+        } catch (\Throwable $e) {
+            $this->error("Restore failed: {$e->getMessage()}");
+            $this->notifyManagers('failure', $filename, $e->getMessage());
+
+            return Command::FAILURE;
+        }
+    }
+
+    private function notifyManagers(string $outcome, string $filename, string $error = ''): void
+    {
+        $roleId = Role::where('name', 'Backup Manager')->value('id');
+
+        if (! $roleId) {
+            return;
+        }
+
+        $backupManagers = User::where(function ($q) use ($roleId) {
+            $q->whereHas('staffPosition.roles', fn ($r) => $r->where('roles.id', $roleId))
+                ->orWhereHas('staffPosition', fn ($p) => $p->whereNotNull('has_all_roles_at'))
+                ->orWhereIn('staff_rank', function ($sub) use ($roleId) {
+                    $sub->select('staff_rank')->from('role_staff_rank')->where('role_id', $roleId);
+                });
+        })->get();
+
+        $notificationService = app(TicketNotificationService::class);
+
+        foreach ($backupManagers as $manager) {
+            $notification = $outcome === 'success'
+                ? new RestoreCompletedNotification($filename)
+                : new RestoreFailedNotification($error);
+
+            $notificationService->send($manager, $notification, 'staff_alerts');
+        }
+    }
+}

--- a/app/Jobs/CreateBackupJob.php
+++ b/app/Jobs/CreateBackupJob.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Jobs;
+
+use App\Services\BackupService;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Queue\Queueable;
+
+class CreateBackupJob implements ShouldQueue
+{
+    use Queueable;
+
+    public function handle(BackupService $service): void
+    {
+        $service->create();
+    }
+}

--- a/app/Jobs/CreateBackupJob.php
+++ b/app/Jobs/CreateBackupJob.php
@@ -22,6 +22,7 @@ class CreateBackupJob implements ShouldQueue
         SiteConfig::setValue('backup.last_job_status', 'completed');
         SiteConfig::setValue('backup.last_job_updated_at', now()->toIso8601String());
         SiteConfig::setValue('backup.last_job_filename', basename($path));
+        SiteConfig::setValue('backup.last_job_full_path', $path);
     }
 
     public function failed(Throwable $e): void

--- a/app/Jobs/CreateBackupJob.php
+++ b/app/Jobs/CreateBackupJob.php
@@ -17,15 +17,17 @@ class CreateBackupJob implements ShouldQueue
         SiteConfig::setValue('backup.last_job_status', 'running');
         SiteConfig::setValue('backup.last_job_updated_at', now()->toIso8601String());
 
-        $service->create();
+        $path = $service->create();
 
         SiteConfig::setValue('backup.last_job_status', 'completed');
         SiteConfig::setValue('backup.last_job_updated_at', now()->toIso8601String());
+        SiteConfig::setValue('backup.last_job_filename', basename($path));
     }
 
     public function failed(Throwable $e): void
     {
         SiteConfig::setValue('backup.last_job_status', 'failed');
         SiteConfig::setValue('backup.last_job_updated_at', now()->toIso8601String());
+        SiteConfig::setValue('backup.last_job_filename', null);
     }
 }

--- a/app/Jobs/CreateBackupJob.php
+++ b/app/Jobs/CreateBackupJob.php
@@ -2,9 +2,11 @@
 
 namespace App\Jobs;
 
+use App\Models\SiteConfig;
 use App\Services\BackupService;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Queue\Queueable;
+use Throwable;
 
 class CreateBackupJob implements ShouldQueue
 {
@@ -12,6 +14,18 @@ class CreateBackupJob implements ShouldQueue
 
     public function handle(BackupService $service): void
     {
+        SiteConfig::setValue('backup.last_job_status', 'running');
+        SiteConfig::setValue('backup.last_job_updated_at', now()->toIso8601String());
+
         $service->create();
+
+        SiteConfig::setValue('backup.last_job_status', 'completed');
+        SiteConfig::setValue('backup.last_job_updated_at', now()->toIso8601String());
+    }
+
+    public function failed(Throwable $e): void
+    {
+        SiteConfig::setValue('backup.last_job_status', 'failed');
+        SiteConfig::setValue('backup.last_job_updated_at', now()->toIso8601String());
     }
 }

--- a/app/Jobs/RestoreBackupJob.php
+++ b/app/Jobs/RestoreBackupJob.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Jobs;
+
+use App\Services\RestoreService;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Queue\Queueable;
+
+class RestoreBackupJob implements ShouldQueue
+{
+    use Queueable;
+
+    public function __construct(public string $path) {}
+
+    public function handle(RestoreService $service): void
+    {
+        $service->restore($this->path);
+    }
+}

--- a/app/Models/Credential.php
+++ b/app/Models/Credential.php
@@ -157,7 +157,9 @@ class Credential extends Model
     public function latestAccessLog(): HasOne
     {
         return $this->hasOne(CredentialAccessLog::class)
-            ->whereIn('action', ['viewed_password', 'viewed_totp'])
-            ->latestOfMany('created_at');
+            ->ofMany(
+                ['created_at' => 'max'],
+                fn ($q) => $q->whereIn('action', ['viewed_password', 'viewed_totp'])
+            );
     }
 }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -598,20 +598,36 @@ class User extends Authenticatable // implements MustVerifyEmail
     /**
      * The current onboarding step for this user.
      *
-     * Returns one of: 'discord', 'waiting', 'minecraft', 'complete'.
+     * Returns one of: 'discord', 'discord-join', 'waiting', 'minecraft', 'complete'.
      * Steps are derived from current user state and activity log entries — no separate step column.
      */
     public function currentOnboardingStep(): string
     {
         // Discord and waiting steps apply only to Stowaways (not yet Traveler)
         if ($this->isLevel(MembershipLevel::Stowaway)) {
-            $discordProcessed = $this->discordAccounts()->active()->exists()
-                || ActivityLog::where('subject_type', User::class)
-                    ->where('subject_id', $this->id)
-                    ->whereIn('action', ['onboarding_discord_skipped', 'onboarding_discord_disabled'])
-                    ->exists();
+            $discordSkippedOrDisabled = ActivityLog::where('subject_type', User::class)
+                ->where('subject_id', $this->id)
+                ->whereIn('action', ['onboarding_discord_skipped', 'onboarding_discord_disabled'])
+                ->exists();
 
-            return $discordProcessed ? 'waiting' : 'discord';
+            // If Discord was explicitly skipped/disabled, jump straight to waiting
+            if ($discordSkippedOrDisabled) {
+                return 'waiting';
+            }
+
+            $discordConnected = $this->discordAccounts()->active()->exists();
+
+            if (! $discordConnected) {
+                return 'discord';
+            }
+
+            // Discord is connected — show the join-server step unless already done
+            $discordJoinDone = ActivityLog::where('subject_type', User::class)
+                ->where('subject_id', $this->id)
+                ->where('action', 'onboarding_discord_join_done')
+                ->exists();
+
+            return $discordJoinDone ? 'waiting' : 'discord-join';
         }
 
         // Traveler+: Minecraft step. Shows explanation when parent has disabled Minecraft,
@@ -623,6 +639,14 @@ class User extends Authenticatable // implements MustVerifyEmail
                 ->exists();
 
         return $minecraftProcessed ? 'complete' : 'minecraft';
+    }
+
+    public function hasEverBeenOnStaff(): bool
+    {
+        return ActivityLog::where('subject_type', User::class)
+            ->where('subject_id', $this->id)
+            ->where('action', 'staff_position_removed')
+            ->exists();
     }
 
     public function canSendPushover(): bool

--- a/app/Notifications/BackupCreatedNotification.php
+++ b/app/Notifications/BackupCreatedNotification.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace App\Notifications;
+
+use App\Notifications\Channels\PushoverChannel;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Notifications\Messages\MailMessage;
+use Illuminate\Notifications\Notification;
+
+class BackupCreatedNotification extends Notification implements ShouldQueue
+{
+    use Queueable;
+
+    protected array $allowedChannels = ['mail'];
+
+    protected ?string $pushoverKey = null;
+
+    public function __construct(public string $filename) {}
+
+    public function setChannels(array $channels, ?string $pushoverKey = null): self
+    {
+        $this->allowedChannels = $channels;
+        $this->pushoverKey = $pushoverKey;
+
+        return $this;
+    }
+
+    public function via(object $notifiable): array
+    {
+        $channels = [];
+
+        if (in_array('mail', $this->allowedChannels)) {
+            $channels[] = 'mail';
+        }
+
+        if (in_array('pushover', $this->allowedChannels) && $this->pushoverKey) {
+            $channels[] = PushoverChannel::class;
+        }
+
+        return $channels;
+    }
+
+    public function toMail(object $notifiable): MailMessage
+    {
+        return (new MailMessage)
+            ->subject('Database Backup Created')
+            ->line('A database backup was created successfully.')
+            ->line('File: '.basename($this->filename));
+    }
+
+    public function toPushover(object $notifiable): array
+    {
+        return [
+            'title' => 'Backup Created',
+            'message' => 'Database backup created successfully: '.basename($this->filename),
+        ];
+    }
+}

--- a/app/Notifications/BackupFailedNotification.php
+++ b/app/Notifications/BackupFailedNotification.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace App\Notifications;
+
+use App\Notifications\Channels\PushoverChannel;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Notifications\Messages\MailMessage;
+use Illuminate\Notifications\Notification;
+
+class BackupFailedNotification extends Notification implements ShouldQueue
+{
+    use Queueable;
+
+    protected array $allowedChannels = ['mail'];
+
+    protected ?string $pushoverKey = null;
+
+    public function __construct(public string $error) {}
+
+    public function setChannels(array $channels, ?string $pushoverKey = null): self
+    {
+        $this->allowedChannels = $channels;
+        $this->pushoverKey = $pushoverKey;
+
+        return $this;
+    }
+
+    public function via(object $notifiable): array
+    {
+        $channels = [];
+
+        if (in_array('mail', $this->allowedChannels)) {
+            $channels[] = 'mail';
+        }
+
+        if (in_array('pushover', $this->allowedChannels) && $this->pushoverKey) {
+            $channels[] = PushoverChannel::class;
+        }
+
+        return $channels;
+    }
+
+    public function toMail(object $notifiable): MailMessage
+    {
+        return (new MailMessage)
+            ->subject('Database Backup Failed')
+            ->line('A database backup attempt failed.')
+            ->line('Error: '.$this->error);
+    }
+
+    public function toPushover(object $notifiable): array
+    {
+        return [
+            'title' => 'Backup Failed',
+            'message' => 'Database backup failed: '.$this->error,
+        ];
+    }
+}

--- a/app/Notifications/RestoreCompletedNotification.php
+++ b/app/Notifications/RestoreCompletedNotification.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace App\Notifications;
+
+use App\Notifications\Channels\PushoverChannel;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Notifications\Messages\MailMessage;
+use Illuminate\Notifications\Notification;
+
+class RestoreCompletedNotification extends Notification implements ShouldQueue
+{
+    use Queueable;
+
+    protected array $allowedChannels = ['mail'];
+
+    protected ?string $pushoverKey = null;
+
+    public function __construct(public string $filename) {}
+
+    public function setChannels(array $channels, ?string $pushoverKey = null): self
+    {
+        $this->allowedChannels = $channels;
+        $this->pushoverKey = $pushoverKey;
+
+        return $this;
+    }
+
+    public function via(object $notifiable): array
+    {
+        $channels = [];
+
+        if (in_array('mail', $this->allowedChannels)) {
+            $channels[] = 'mail';
+        }
+
+        if (in_array('pushover', $this->allowedChannels) && $this->pushoverKey) {
+            $channels[] = PushoverChannel::class;
+        }
+
+        return $channels;
+    }
+
+    public function toMail(object $notifiable): MailMessage
+    {
+        return (new MailMessage)
+            ->subject('Database Restore Completed')
+            ->line('Database restore completed successfully.')
+            ->line('File: '.$this->filename);
+    }
+
+    public function toPushover(object $notifiable): array
+    {
+        return [
+            'title' => 'Restore Completed',
+            'message' => 'Database restore completed successfully from: '.$this->filename,
+        ];
+    }
+}

--- a/app/Notifications/RestoreFailedNotification.php
+++ b/app/Notifications/RestoreFailedNotification.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace App\Notifications;
+
+use App\Notifications\Channels\PushoverChannel;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Notifications\Messages\MailMessage;
+use Illuminate\Notifications\Notification;
+
+class RestoreFailedNotification extends Notification implements ShouldQueue
+{
+    use Queueable;
+
+    protected array $allowedChannels = ['mail'];
+
+    protected ?string $pushoverKey = null;
+
+    public function __construct(public string $error) {}
+
+    public function setChannels(array $channels, ?string $pushoverKey = null): self
+    {
+        $this->allowedChannels = $channels;
+        $this->pushoverKey = $pushoverKey;
+
+        return $this;
+    }
+
+    public function via(object $notifiable): array
+    {
+        $channels = [];
+
+        if (in_array('mail', $this->allowedChannels)) {
+            $channels[] = 'mail';
+        }
+
+        if (in_array('pushover', $this->allowedChannels) && $this->pushoverKey) {
+            $channels[] = PushoverChannel::class;
+        }
+
+        return $channels;
+    }
+
+    public function toMail(object $notifiable): MailMessage
+    {
+        return (new MailMessage)
+            ->subject('Database Restore Failed')
+            ->line('A database restore attempt failed.')
+            ->line('Error: '.$this->error);
+    }
+
+    public function toPushover(object $notifiable): array
+    {
+        return [
+            'title' => 'Restore Failed',
+            'message' => 'Database restore failed: '.$this->error,
+        ];
+    }
+}

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -289,5 +289,9 @@ class AuthServiceProvider extends ServiceProvider
         Gate::define('rules.approve', function ($user) {
             return $user->hasRole('Rules - Approve');
         });
+
+        Gate::define('backup-manager', function ($user) {
+            return $user->hasRole('Backup Manager');
+        });
     }
 }

--- a/app/Services/BackupRetentionService.php
+++ b/app/Services/BackupRetentionService.php
@@ -21,8 +21,9 @@ class BackupRetentionService
 
         foreach (glob("{$dir}/*.sql.gz") ?: [] as $file) {
             if (Carbon::createFromTimestamp(filemtime($file))->lt($cutoff)) {
-                @unlink($file);
-                $deleted[] = $file;
+                if (@unlink($file)) {
+                    $deleted[] = $file;
+                }
             }
         }
 

--- a/app/Services/BackupRetentionService.php
+++ b/app/Services/BackupRetentionService.php
@@ -14,7 +14,7 @@ class BackupRetentionService
      */
     public function enforceLocalRetention(): array
     {
-        $days = (int) SiteConfig::getValue('backup.local_retention_days', '7');
+        $days = max(1, (int) SiteConfig::getValue('backup.local_retention_days', '7'));
         $cutoff = Carbon::now()->subDays($days);
         $dir = storage_path('app/backups');
         $deleted = [];
@@ -45,16 +45,21 @@ class BackupRetentionService
             return [];
         }
 
-        $keepKeys = collect();
+        // Separate files into those with a parseable timestamp and those without.
+        // Non-conforming filenames (no backup_YYYY-MM-DD pattern) are never auto-deleted.
+        $conforming = array_filter($files, fn ($k) => preg_match('/backup_\d{4}-\d{2}-\d{2}_\d{2}-\d{2}-\d{2}/', $k) === 1);
+        $nonConforming = array_diff($files, $conforming);
 
-        // Tier 1: 2 most recent
-        $keepKeys = $keepKeys->merge(collect($files)->take(2));
+        $keepKeys = collect($nonConforming); // always keep non-standard files
+
+        // Tier 1: 2 most recent conforming
+        $keepKeys = $keepKeys->merge(collect(array_values($conforming))->take(2));
 
         // Tier 2: 1 per 7-day window for the past 4 weeks
         for ($week = 1; $week <= 4; $week++) {
             $end = now()->subDays(($week - 1) * 7);
             $start = now()->subDays($week * 7);
-            $match = collect($files)->first(
+            $match = collect($conforming)->first(
                 fn ($k) => $storage->parseTimestamp($k)->between($start, $end)
             );
             if ($match !== null) {
@@ -67,7 +72,7 @@ class BackupRetentionService
             $ref = now()->subMonths($month);
             $start = $ref->copy()->startOfMonth();
             $end = $ref->copy()->endOfMonth();
-            $match = collect($files)->first(
+            $match = collect($conforming)->first(
                 fn ($k) => $storage->parseTimestamp($k)->between($start, $end)
             );
             if ($match !== null) {
@@ -78,7 +83,7 @@ class BackupRetentionService
         $keepKeys = $keepKeys->unique();
         $deleted = [];
 
-        foreach ($files as $key) {
+        foreach ($conforming as $key) {
             if (! $keepKeys->contains($key)) {
                 $storage->delete($key);
                 $deleted[] = $key;

--- a/app/Services/BackupRetentionService.php
+++ b/app/Services/BackupRetentionService.php
@@ -28,4 +28,63 @@ class BackupRetentionService
 
         return $deleted;
     }
+
+    /**
+     * Enforce S3 retention tiers, deleting keys that fall outside:
+     *   - 2 most recent uploads (3-day cadence)
+     *   - 1 per week for the past 4 weeks
+     *   - 1 per month for the past 3 months
+     *
+     * @return string[] Deleted S3 keys.
+     */
+    public function enforceS3Retention(BackupStorageService $storage): array
+    {
+        $files = $storage->list(); // sorted newest-first by filename timestamp
+
+        if (empty($files)) {
+            return [];
+        }
+
+        $keepKeys = collect();
+
+        // Tier 1: 2 most recent
+        $keepKeys = $keepKeys->merge(collect($files)->take(2));
+
+        // Tier 2: 1 per 7-day window for the past 4 weeks
+        for ($week = 1; $week <= 4; $week++) {
+            $end = now()->subDays(($week - 1) * 7);
+            $start = now()->subDays($week * 7);
+            $match = collect($files)->first(
+                fn ($k) => $storage->parseTimestamp($k)->between($start, $end)
+            );
+            if ($match !== null) {
+                $keepKeys->push($match);
+            }
+        }
+
+        // Tier 3: 1 per calendar month for the past 3 months
+        for ($month = 1; $month <= 3; $month++) {
+            $ref = now()->subMonths($month);
+            $start = $ref->copy()->startOfMonth();
+            $end = $ref->copy()->endOfMonth();
+            $match = collect($files)->first(
+                fn ($k) => $storage->parseTimestamp($k)->between($start, $end)
+            );
+            if ($match !== null) {
+                $keepKeys->push($match);
+            }
+        }
+
+        $keepKeys = $keepKeys->unique();
+        $deleted = [];
+
+        foreach ($files as $key) {
+            if (! $keepKeys->contains($key)) {
+                $storage->delete($key);
+                $deleted[] = $key;
+            }
+        }
+
+        return $deleted;
+    }
 }

--- a/app/Services/BackupRetentionService.php
+++ b/app/Services/BackupRetentionService.php
@@ -67,10 +67,13 @@ class BackupRetentionService
             }
         }
 
-        // Tier 3: 1 per calendar month for the past 3 months
+        // Tier 3: 1 per calendar month for the past 3 months.
+        // Anchor to the 1st of the current month before subtracting so that
+        // months with fewer days than today's date-of-month don't overflow
+        // into the following month (e.g. April 29 - 2 months = Feb 28, not Mar 1).
         for ($month = 1; $month <= 3; $month++) {
-            $ref = now()->subMonths($month);
-            $start = $ref->copy()->startOfMonth();
+            $ref = now()->startOfMonth()->subMonths($month);
+            $start = $ref->copy();
             $end = $ref->copy()->endOfMonth();
             $match = collect($conforming)->first(
                 fn ($k) => $storage->parseTimestamp($k)->between($start, $end)

--- a/app/Services/BackupRetentionService.php
+++ b/app/Services/BackupRetentionService.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\SiteConfig;
+use Carbon\Carbon;
+
+class BackupRetentionService
+{
+    /**
+     * Delete local backup files older than the configured retention window.
+     *
+     * @return string[] Paths of deleted files.
+     */
+    public function enforceLocalRetention(): array
+    {
+        $days = (int) SiteConfig::getValue('backup.local_retention_days', '7');
+        $cutoff = Carbon::now()->subDays($days);
+        $dir = storage_path('app/backups');
+        $deleted = [];
+
+        foreach (glob("{$dir}/*.sql.gz") ?: [] as $file) {
+            if (Carbon::createFromTimestamp(filemtime($file))->lt($cutoff)) {
+                @unlink($file);
+                $deleted[] = $file;
+            }
+        }
+
+        return $deleted;
+    }
+}

--- a/app/Services/BackupService.php
+++ b/app/Services/BackupService.php
@@ -28,6 +28,9 @@ class BackupService
         if (! is_dir($backupsDir)) {
             mkdir($backupsDir, 0755, true);
         }
+        // Ensure the directory is traversable regardless of which OS user
+        // (queue worker vs. web server) created it.
+        @chmod($backupsDir, 0755);
 
         $dbType = match ($driver) {
             'pgsql' => 'pgsql',
@@ -53,6 +56,7 @@ class BackupService
             $gz = gzopen($path, 'wb9');
             gzwrite($gz, $sql);
             gzclose($gz);
+            @chmod($path, 0644);
         } catch (\Throwable $e) {
             if ($shouldGoOffline) {
                 Artisan::call('up');

--- a/app/Services/BackupService.php
+++ b/app/Services/BackupService.php
@@ -1,0 +1,146 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\SiteConfig;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Process;
+
+class BackupService
+{
+    private bool $skipOffline = false;
+
+    public function setSkipOffline(bool $skip): self
+    {
+        $this->skipOffline = $skip;
+
+        return $this;
+    }
+
+    public function create(): string
+    {
+        $driver = config('database.default');
+        $config = config("database.connections.{$driver}");
+
+        $backupsDir = storage_path('app/backups');
+        if (! is_dir($backupsDir)) {
+            mkdir($backupsDir, 0755, true);
+        }
+
+        $dbType = match ($driver) {
+            'pgsql' => 'pgsql',
+            'mysql', 'mariadb' => 'mysql',
+            'sqlite' => 'sqlite',
+            default => throw new \RuntimeException("Unsupported database driver: {$driver}"),
+        };
+
+        $timestamp = now()->format('Y-m-d_H-i-s');
+        $filename = "backup_{$timestamp}_{$dbType}.sql.gz";
+        $path = "{$backupsDir}/{$filename}";
+
+        $offline = SiteConfig::getValue('backup.offline_during_backup', 'false') === 'true';
+        $shouldGoOffline = ! $this->skipOffline && $offline;
+
+        if ($shouldGoOffline) {
+            Artisan::call('down');
+        }
+
+        try {
+            $sql = $this->dump($driver, $config);
+
+            $gz = gzopen($path, 'wb9');
+            gzwrite($gz, $sql);
+            gzclose($gz);
+        } catch (\Throwable $e) {
+            if ($shouldGoOffline) {
+                Artisan::call('up');
+            }
+            throw $e;
+        }
+
+        if ($shouldGoOffline) {
+            Artisan::call('up');
+        }
+
+        return $path;
+    }
+
+    private function dump(string $driver, array $config): string
+    {
+        return match ($driver) {
+            'pgsql' => $this->dumpPostgres($config),
+            'mysql', 'mariadb' => $this->dumpMysql($config),
+            'sqlite' => $this->dumpSqlite(),
+            default => throw new \RuntimeException("Unsupported driver: {$driver}"),
+        };
+    }
+
+    private function dumpPostgres(array $config): string
+    {
+        $result = Process::env(['PGPASSWORD' => $config['password'] ?? ''])
+            ->run([
+                'pg_dump',
+                '-h', $config['host'] ?? 'localhost',
+                '-p', (string) ($config['port'] ?? 5432),
+                '-U', $config['username'],
+                $config['database'],
+            ]);
+
+        if (! $result->successful()) {
+            throw new \RuntimeException('pg_dump failed: '.$result->errorOutput());
+        }
+
+        return $result->output();
+    }
+
+    private function dumpMysql(array $config): string
+    {
+        $result = Process::run([
+            'mysqldump',
+            '-h', $config['host'] ?? 'localhost',
+            '-P', (string) ($config['port'] ?? 3306),
+            '-u', $config['username'],
+            '-p'.$config['password'],
+            $config['database'],
+        ]);
+
+        if (! $result->successful()) {
+            throw new \RuntimeException('mysqldump failed: '.$result->errorOutput());
+        }
+
+        return $result->output();
+    }
+
+    private function dumpSqlite(): string
+    {
+        $pdo = DB::connection()->getPdo();
+
+        $tables = $pdo->query(
+            "SELECT name, sql FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%' ORDER BY name"
+        )->fetchAll(\PDO::FETCH_ASSOC);
+
+        $sql = "-- SQLite dump\n\n";
+
+        foreach ($tables as $table) {
+            if ($table['sql']) {
+                $sql .= $table['sql'].";\n\n";
+            }
+
+            $rows = $pdo->query("SELECT * FROM \"{$table['name']}\"")->fetchAll(\PDO::FETCH_ASSOC);
+
+            foreach ($rows as $row) {
+                $columns = implode(', ', array_map(fn ($c) => '"'.$c.'"', array_keys($row)));
+                $values = implode(', ', array_map(
+                    fn ($v) => $v === null ? 'NULL' : $pdo->quote((string) $v),
+                    array_values($row)
+                ));
+                $sql .= "INSERT INTO \"{$table['name']}\" ({$columns}) VALUES ({$values});\n";
+            }
+
+            $sql .= "\n";
+        }
+
+        return $sql;
+    }
+}

--- a/app/Services/BackupService.php
+++ b/app/Services/BackupService.php
@@ -20,8 +20,9 @@ class BackupService
 
     public function create(): string
     {
-        $driver = config('database.default');
-        $config = config("database.connections.{$driver}");
+        $connectionName = config('database.default');
+        $config = config("database.connections.{$connectionName}");
+        $driver = $config['driver'] ?? $connectionName;
 
         $backupsDir = storage_path('app/backups');
         if (! is_dir($backupsDir)) {
@@ -96,14 +97,14 @@ class BackupService
 
     private function dumpMysql(array $config): string
     {
-        $result = Process::run([
-            'mysqldump',
-            '-h', $config['host'] ?? 'localhost',
-            '-P', (string) ($config['port'] ?? 3306),
-            '-u', $config['username'],
-            '-p'.$config['password'],
-            $config['database'],
-        ]);
+        $result = Process::env(['MYSQL_PWD' => $config['password'] ?? ''])
+            ->run([
+                'mysqldump',
+                '-h', $config['host'] ?? 'localhost',
+                '-P', (string) ($config['port'] ?? 3306),
+                '-u', $config['username'],
+                $config['database'],
+            ]);
 
         if (! $result->successful()) {
             throw new \RuntimeException('mysqldump failed: '.$result->errorOutput());

--- a/app/Services/BackupService.php
+++ b/app/Services/BackupService.php
@@ -5,7 +5,6 @@ namespace App\Services;
 use App\Models\SiteConfig;
 use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\DB;
-use Illuminate\Support\Facades\Process;
 
 class BackupService
 {
@@ -51,11 +50,7 @@ class BackupService
         }
 
         try {
-            $sql = $this->dump($driver, $config);
-
-            $gz = gzopen($path, 'wb9');
-            gzwrite($gz, $sql);
-            gzclose($gz);
+            $this->dump($driver, $config, $path);
             @chmod($path, 0644);
         } catch (\Throwable $e) {
             if ($shouldGoOffline) {
@@ -71,53 +66,81 @@ class BackupService
         return $path;
     }
 
-    private function dump(string $driver, array $config): string
+    private function dump(string $driver, array $config, string $path): void
     {
-        return match ($driver) {
-            'pgsql' => $this->dumpPostgres($config),
-            'mysql', 'mariadb' => $this->dumpMysql($config),
-            'sqlite' => $this->dumpSqlite(),
+        match ($driver) {
+            'pgsql' => $this->dumpPostgres($config, $path),
+            'mysql', 'mariadb' => $this->dumpMysql($config, $path),
+            'sqlite' => $this->dumpSqlite($path),
             default => throw new \RuntimeException("Unsupported driver: {$driver}"),
         };
     }
 
-    private function dumpPostgres(array $config): string
+    private function dumpPostgres(array $config, string $path): void
     {
-        $result = Process::env(['PGPASSWORD' => $config['password'] ?? ''])
-            ->run([
-                'pg_dump',
-                '-h', $config['host'] ?? 'localhost',
-                '-p', (string) ($config['port'] ?? 5432),
-                '-U', $config['username'],
-                $config['database'],
-            ]);
+        $cmd = 'PGPASSWORD='.escapeshellarg($config['password'] ?? '')
+            .' pg_dump'
+            .' -h '.escapeshellarg($config['host'] ?? 'localhost')
+            .' -p '.escapeshellarg((string) ($config['port'] ?? 5432))
+            .' -U '.escapeshellarg($config['username'])
+            .' '.escapeshellarg($config['database']);
 
-        if (! $result->successful()) {
-            throw new \RuntimeException('pg_dump failed: '.$result->errorOutput());
+        $handle = popen($cmd, 'r');
+        if ($handle === false) {
+            throw new \RuntimeException('Failed to open pg_dump process');
         }
 
-        return $result->output();
-    }
-
-    private function dumpMysql(array $config): string
-    {
-        $result = Process::env(['MYSQL_PWD' => $config['password'] ?? ''])
-            ->run([
-                'mysqldump',
-                '-h', $config['host'] ?? 'localhost',
-                '-P', (string) ($config['port'] ?? 3306),
-                '-u', $config['username'],
-                $config['database'],
-            ]);
-
-        if (! $result->successful()) {
-            throw new \RuntimeException('mysqldump failed: '.$result->errorOutput());
+        $gz = gzopen($path, 'wb9');
+        try {
+            while (! feof($handle)) {
+                $chunk = fread($handle, 65536);
+                if ($chunk !== false && $chunk !== '') {
+                    gzwrite($gz, $chunk);
+                }
+            }
+        } finally {
+            gzclose($gz);
+            $exitCode = pclose($handle);
         }
 
-        return $result->output();
+        if ($exitCode !== 0) {
+            throw new \RuntimeException("pg_dump failed with exit code {$exitCode}");
+        }
     }
 
-    private function dumpSqlite(): string
+    private function dumpMysql(array $config, string $path): void
+    {
+        $cmd = 'MYSQL_PWD='.escapeshellarg($config['password'] ?? '')
+            .' mysqldump'
+            .' -h '.escapeshellarg($config['host'] ?? 'localhost')
+            .' -P '.escapeshellarg((string) ($config['port'] ?? 3306))
+            .' -u '.escapeshellarg($config['username'])
+            .' '.escapeshellarg($config['database']);
+
+        $handle = popen($cmd, 'r');
+        if ($handle === false) {
+            throw new \RuntimeException('Failed to open mysqldump process');
+        }
+
+        $gz = gzopen($path, 'wb9');
+        try {
+            while (! feof($handle)) {
+                $chunk = fread($handle, 65536);
+                if ($chunk !== false && $chunk !== '') {
+                    gzwrite($gz, $chunk);
+                }
+            }
+        } finally {
+            gzclose($gz);
+            $exitCode = pclose($handle);
+        }
+
+        if ($exitCode !== 0) {
+            throw new \RuntimeException("mysqldump failed with exit code {$exitCode}");
+        }
+    }
+
+    private function dumpSqlite(string $path): void
     {
         $pdo = DB::connection()->getPdo();
 
@@ -125,27 +148,32 @@ class BackupService
             "SELECT name, sql FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%' ORDER BY name"
         )->fetchAll(\PDO::FETCH_ASSOC);
 
-        $sql = "-- SQLite dump\n\n";
+        $gz = gzopen($path, 'wb9');
+        try {
+            gzwrite($gz, "-- SQLite dump\n\n");
 
-        foreach ($tables as $table) {
-            if ($table['sql']) {
-                $sql .= $table['sql'].";\n\n";
+            foreach ($tables as $table) {
+                if ($table['sql']) {
+                    gzwrite($gz, $table['sql'].";\n\n");
+                }
+
+                $colNames = null;
+                $stmt = $pdo->query("SELECT * FROM \"{$table['name']}\"");
+                while ($row = $stmt->fetch(\PDO::FETCH_ASSOC)) {
+                    if ($colNames === null) {
+                        $colNames = implode(', ', array_map(fn ($c) => '"'.$c.'"', array_keys($row)));
+                    }
+                    $values = implode(', ', array_map(
+                        fn ($v) => $v === null ? 'NULL' : $pdo->quote((string) $v),
+                        array_values($row)
+                    ));
+                    gzwrite($gz, "INSERT INTO \"{$table['name']}\" ({$colNames}) VALUES ({$values});\n");
+                }
+
+                gzwrite($gz, "\n");
             }
-
-            $rows = $pdo->query("SELECT * FROM \"{$table['name']}\"")->fetchAll(\PDO::FETCH_ASSOC);
-
-            foreach ($rows as $row) {
-                $columns = implode(', ', array_map(fn ($c) => '"'.$c.'"', array_keys($row)));
-                $values = implode(', ', array_map(
-                    fn ($v) => $v === null ? 'NULL' : $pdo->quote((string) $v),
-                    array_values($row)
-                ));
-                $sql .= "INSERT INTO \"{$table['name']}\" ({$columns}) VALUES ({$values});\n";
-            }
-
-            $sql .= "\n";
+        } finally {
+            gzclose($gz);
         }
-
-        return $sql;
     }
 }

--- a/app/Services/BackupService.php
+++ b/app/Services/BackupService.php
@@ -5,6 +5,7 @@ namespace App\Services;
 use App\Models\SiteConfig;
 use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Process;
 
 class BackupService
 {
@@ -85,26 +86,16 @@ class BackupService
             .' -U '.escapeshellarg($config['username'])
             .' '.escapeshellarg($config['database']);
 
-        $handle = popen($cmd, 'r');
-        if ($handle === false) {
-            throw new \RuntimeException('Failed to open pg_dump process');
-        }
-
         $gz = gzopen($path, 'wb9');
-        try {
-            while (! feof($handle)) {
-                $chunk = fread($handle, 65536);
-                if ($chunk !== false && $chunk !== '') {
-                    gzwrite($gz, $chunk);
-                }
+        $result = Process::run($cmd, function (string $type, string $output) use ($gz): void {
+            if ($type === 'out') {
+                gzwrite($gz, $output);
             }
-        } finally {
-            gzclose($gz);
-            $exitCode = pclose($handle);
-        }
+        });
+        gzclose($gz);
 
-        if ($exitCode !== 0) {
-            throw new \RuntimeException("pg_dump failed with exit code {$exitCode}");
+        if (! $result->successful()) {
+            throw new \RuntimeException("pg_dump failed with exit code {$result->exitCode()}");
         }
     }
 
@@ -117,26 +108,16 @@ class BackupService
             .' -u '.escapeshellarg($config['username'])
             .' '.escapeshellarg($config['database']);
 
-        $handle = popen($cmd, 'r');
-        if ($handle === false) {
-            throw new \RuntimeException('Failed to open mysqldump process');
-        }
-
         $gz = gzopen($path, 'wb9');
-        try {
-            while (! feof($handle)) {
-                $chunk = fread($handle, 65536);
-                if ($chunk !== false && $chunk !== '') {
-                    gzwrite($gz, $chunk);
-                }
+        $result = Process::run($cmd, function (string $type, string $output) use ($gz): void {
+            if ($type === 'out') {
+                gzwrite($gz, $output);
             }
-        } finally {
-            gzclose($gz);
-            $exitCode = pclose($handle);
-        }
+        });
+        gzclose($gz);
 
-        if ($exitCode !== 0) {
-            throw new \RuntimeException("mysqldump failed with exit code {$exitCode}");
+        if (! $result->successful()) {
+            throw new \RuntimeException("mysqldump failed with exit code {$result->exitCode()}");
         }
     }
 

--- a/app/Services/BackupStorageService.php
+++ b/app/Services/BackupStorageService.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace App\Services;
+
+use Carbon\Carbon;
+use Illuminate\Support\Facades\Storage;
+
+class BackupStorageService
+{
+    private const PREFIX = 'backups/';
+
+    /**
+     * Upload a local backup file to S3 and return the S3 key.
+     */
+    public function upload(string $localPath): string
+    {
+        $filename = basename($localPath);
+        $key = self::PREFIX.$filename;
+
+        Storage::disk('s3')->put($key, file_get_contents($localPath));
+
+        return $key;
+    }
+
+    /**
+     * List all S3 backup keys sorted by filename timestamp (newest first).
+     *
+     * @return string[]
+     */
+    public function list(): array
+    {
+        $files = Storage::disk('s3')->files(self::PREFIX);
+
+        // Keep only .sql.gz backup files
+        $files = array_filter($files, fn ($f) => str_ends_with($f, '.sql.gz'));
+
+        usort($files, function ($a, $b) {
+            return $this->parseTimestamp($b) <=> $this->parseTimestamp($a);
+        });
+
+        return array_values($files);
+    }
+
+    /**
+     * Download an S3 backup to a temp file and return the local path.
+     * The caller is responsible for deleting the temp file.
+     */
+    public function download(string $key): string
+    {
+        $tmpPath = sys_get_temp_dir().'/s3_backup_'.uniqid().'.sql.gz';
+
+        file_put_contents($tmpPath, Storage::disk('s3')->get($key));
+
+        return $tmpPath;
+    }
+
+    /**
+     * Delete an S3 backup by key.
+     */
+    public function delete(string $key): void
+    {
+        Storage::disk('s3')->delete($key);
+    }
+
+    /**
+     * Parse the timestamp embedded in a backup filename.
+     * Filename format: backups/backup_YYYY-MM-DD_HH-MM-SS_<type>.sql.gz
+     */
+    public function parseTimestamp(string $key): Carbon
+    {
+        preg_match('/backup_(\d{4}-\d{2}-\d{2}_\d{2}-\d{2}-\d{2})/', $key, $m);
+
+        if (empty($m[1])) {
+            return Carbon::createFromTimestamp(0);
+        }
+
+        return Carbon::createFromFormat('Y-m-d_H-i-s', $m[1]);
+    }
+}

--- a/app/Services/BackupStorageService.php
+++ b/app/Services/BackupStorageService.php
@@ -63,6 +63,48 @@ class BackupStorageService
     }
 
     /**
+     * Return true if S3 is configured with credentials and reachable.
+     */
+    public function isConfigured(): bool
+    {
+        $cfg = config('filesystems.disks.s3', []);
+
+        return ! empty($cfg['key']) && ! empty($cfg['bucket']);
+    }
+
+    public function isConnected(): bool
+    {
+        if (! $this->isConfigured()) {
+            return false;
+        }
+
+        try {
+            Storage::disk('s3')->files(self::PREFIX);
+
+            return true;
+        } catch (\Throwable) {
+            return false;
+        }
+    }
+
+    /**
+     * List S3 backups with metadata (filename, size, date, key).
+     *
+     * @return array<int, array{key: string, filename: string, size: string, date: string}>
+     */
+    public function listWithMetadata(): array
+    {
+        return array_map(function (string $key) {
+            return [
+                'key' => $key,
+                'filename' => basename($key),
+                'size' => $this->formatBytes(Storage::disk('s3')->size($key)),
+                'date' => Carbon::createFromTimestamp(Storage::disk('s3')->lastModified($key))->format('Y-m-d H:i'),
+            ];
+        }, $this->list());
+    }
+
+    /**
      * Parse the timestamp embedded in a backup filename.
      * Filename format: backups/backup_YYYY-MM-DD_HH-MM-SS_<type>.sql.gz
      */
@@ -75,5 +117,18 @@ class BackupStorageService
         }
 
         return Carbon::createFromFormat('Y-m-d_H-i-s', $m[1]);
+    }
+
+    private function formatBytes(int $bytes): string
+    {
+        if ($bytes >= 1_048_576) {
+            return number_format($bytes / 1_048_576, 1).' MB';
+        }
+
+        if ($bytes >= 1_024) {
+            return number_format($bytes / 1_024, 1).' KB';
+        }
+
+        return $bytes.' B';
     }
 }

--- a/app/Services/BackupStorageService.php
+++ b/app/Services/BackupStorageService.php
@@ -17,7 +17,12 @@ class BackupStorageService
         $filename = basename($localPath);
         $key = self::PREFIX.$filename;
 
-        Storage::disk('s3')->put($key, file_get_contents($localPath));
+        $stream = fopen($localPath, 'r');
+        try {
+            Storage::disk('s3')->put($key, $stream);
+        } finally {
+            fclose($stream);
+        }
 
         return $key;
     }
@@ -49,7 +54,14 @@ class BackupStorageService
     {
         $tmpPath = sys_get_temp_dir().'/s3_backup_'.uniqid().'.sql.gz';
 
-        file_put_contents($tmpPath, Storage::disk('s3')->get($key));
+        $stream = Storage::disk('s3')->readStream($key);
+        $dest = fopen($tmpPath, 'w');
+        try {
+            stream_copy_to_stream($stream, $dest);
+        } finally {
+            fclose($stream);
+            fclose($dest);
+        }
 
         return $tmpPath;
     }

--- a/app/Services/RestoreService.php
+++ b/app/Services/RestoreService.php
@@ -69,18 +69,6 @@ class RestoreService
         throw new \RuntimeException("Cannot detect source database type from filename: {$filename}");
     }
 
-    private function readGzip(string $path): string
-    {
-        $gz = gzopen($path, 'rb');
-        $sql = '';
-        while (! gzeof($gz)) {
-            $sql .= gzread($gz, 65536);
-        }
-        gzclose($gz);
-
-        return $sql;
-    }
-
     private function restoreSameType(string $path, string $type, array $config): void
     {
         match ($type) {
@@ -93,40 +81,78 @@ class RestoreService
 
     private function restorePostgres(string $path, array $config): void
     {
-        $sql = $this->readGzip($path);
+        $cmd = 'PGPASSWORD='.escapeshellarg($config['password'] ?? '')
+            .' psql'
+            .' -h '.escapeshellarg($config['host'] ?? 'localhost')
+            .' -p '.escapeshellarg((string) ($config['port'] ?? 5432))
+            .' -U '.escapeshellarg($config['username'])
+            .' '.escapeshellarg($config['database']);
 
-        $result = Process::env(['PGPASSWORD' => $config['password'] ?? ''])
-            ->input($sql)
-            ->run([
-                'psql',
-                '-h', $config['host'] ?? 'localhost',
-                '-p', (string) ($config['port'] ?? 5432),
-                '-U', $config['username'],
-                $config['database'],
-            ]);
+        $handle = popen($cmd, 'w');
+        if ($handle === false) {
+            throw new \RuntimeException('Failed to open psql process');
+        }
 
-        if (! $result->successful()) {
-            throw new \RuntimeException('psql restore failed: '.$result->errorOutput());
+        $gz = gzopen($path, 'rb');
+        try {
+            while (! gzeof($gz)) {
+                $chunk = gzread($gz, 65536);
+                if ($chunk !== false && $chunk !== '') {
+                    fwrite($handle, $chunk);
+                }
+            }
+        } finally {
+            gzclose($gz);
+            $exitCode = pclose($handle);
+        }
+
+        if ($exitCode !== 0) {
+            throw new \RuntimeException("psql restore failed with exit code {$exitCode}");
         }
     }
 
     private function restoreMysql(string $path, array $config): void
     {
-        $sql = $this->readGzip($path);
+        $cmd = 'MYSQL_PWD='.escapeshellarg($config['password'] ?? '')
+            .' mysql'
+            .' -h '.escapeshellarg($config['host'] ?? 'localhost')
+            .' -P '.escapeshellarg((string) ($config['port'] ?? 3306))
+            .' -u '.escapeshellarg($config['username'])
+            .' '.escapeshellarg($config['database']);
 
-        $result = Process::env(['MYSQL_PWD' => $config['password'] ?? ''])
-            ->input($sql)
-            ->run([
-                'mysql',
-                '-h', $config['host'] ?? 'localhost',
-                '-P', (string) ($config['port'] ?? 3306),
-                '-u', $config['username'],
-                $config['database'],
-            ]);
-
-        if (! $result->successful()) {
-            throw new \RuntimeException('mysql restore failed: '.$result->errorOutput());
+        $handle = popen($cmd, 'w');
+        if ($handle === false) {
+            throw new \RuntimeException('Failed to open mysql process');
         }
+
+        $gz = gzopen($path, 'rb');
+        try {
+            while (! gzeof($gz)) {
+                $chunk = gzread($gz, 65536);
+                if ($chunk !== false && $chunk !== '') {
+                    fwrite($handle, $chunk);
+                }
+            }
+        } finally {
+            gzclose($gz);
+            $exitCode = pclose($handle);
+        }
+
+        if ($exitCode !== 0) {
+            throw new \RuntimeException("mysql restore failed with exit code {$exitCode}");
+        }
+    }
+
+    private function readGzip(string $path): string
+    {
+        $gz = gzopen($path, 'rb');
+        $sql = '';
+        while (! gzeof($gz)) {
+            $sql .= gzread($gz, 65536);
+        }
+        gzclose($gz);
+
+        return $sql;
     }
 
     private function restoreSqlite(string $path): void

--- a/app/Services/RestoreService.php
+++ b/app/Services/RestoreService.php
@@ -1,0 +1,194 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\SiteConfig;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Process;
+
+class RestoreService
+{
+    public function restore(string $path): void
+    {
+        if (! file_exists($path)) {
+            throw new \RuntimeException("Backup file not found: {$path}");
+        }
+
+        $filename = basename($path);
+        $sourceType = $this->detectSourceType($filename);
+
+        $targetDriver = config('database.default');
+        $targetConfig = config("database.connections.{$targetDriver}");
+
+        $targetType = match ($targetConfig['driver'] ?? $targetDriver) {
+            'pgsql' => 'pgsql',
+            'mysql', 'mariadb' => 'mysql',
+            'sqlite' => 'sqlite',
+            default => throw new \RuntimeException("Unsupported target database driver: {$targetDriver}"),
+        };
+
+        $offline = SiteConfig::getValue('backup.offline_during_restore', 'true') === 'true';
+
+        if ($offline) {
+            Artisan::call('down');
+        }
+
+        try {
+            if ($sourceType === $targetType) {
+                $this->restoreSameType($path, $targetType, $targetConfig);
+            } else {
+                $this->restoreCrossType($path, $sourceType, $targetType, $targetConfig);
+            }
+        } catch (\Throwable $e) {
+            if ($offline) {
+                Artisan::call('up');
+            }
+            throw $e;
+        }
+
+        if ($offline) {
+            Artisan::call('up');
+        }
+    }
+
+    private function detectSourceType(string $filename): string
+    {
+        if (str_contains($filename, '_pgsql.sql.gz')) {
+            return 'pgsql';
+        }
+
+        if (str_contains($filename, '_mysql.sql.gz')) {
+            return 'mysql';
+        }
+
+        if (str_contains($filename, '_sqlite.sql.gz')) {
+            return 'sqlite';
+        }
+
+        throw new \RuntimeException("Cannot detect source database type from filename: {$filename}");
+    }
+
+    private function readGzip(string $path): string
+    {
+        $gz = gzopen($path, 'rb');
+        $sql = '';
+        while (! gzeof($gz)) {
+            $sql .= gzread($gz, 65536);
+        }
+        gzclose($gz);
+
+        return $sql;
+    }
+
+    private function restoreSameType(string $path, string $type, array $config): void
+    {
+        match ($type) {
+            'pgsql' => $this->restorePostgres($path, $config),
+            'mysql' => $this->restoreMysql($path, $config),
+            'sqlite' => $this->restoreSqlite($path),
+            default => throw new \RuntimeException("Unsupported type: {$type}"),
+        };
+    }
+
+    private function restorePostgres(string $path, array $config): void
+    {
+        $sql = $this->readGzip($path);
+
+        $result = Process::env(['PGPASSWORD' => $config['password'] ?? ''])
+            ->input($sql)
+            ->run([
+                'psql',
+                '-h', $config['host'] ?? 'localhost',
+                '-p', (string) ($config['port'] ?? 5432),
+                '-U', $config['username'],
+                $config['database'],
+            ]);
+
+        if (! $result->successful()) {
+            throw new \RuntimeException('psql restore failed: '.$result->errorOutput());
+        }
+    }
+
+    private function restoreMysql(string $path, array $config): void
+    {
+        $sql = $this->readGzip($path);
+
+        $result = Process::input($sql)->run([
+            'mysql',
+            '-h', $config['host'] ?? 'localhost',
+            '-P', (string) ($config['port'] ?? 3306),
+            '-u', $config['username'],
+            '-p'.$config['password'],
+            $config['database'],
+        ]);
+
+        if (! $result->successful()) {
+            throw new \RuntimeException('mysql restore failed: '.$result->errorOutput());
+        }
+    }
+
+    private function restoreSqlite(string $path): void
+    {
+        $sql = $this->readGzip($path);
+        $pdo = DB::connection()->getPdo();
+
+        $pdo->exec('PRAGMA foreign_keys = OFF');
+
+        $tables = $pdo->query(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%'"
+        )->fetchAll(\PDO::FETCH_COLUMN);
+
+        foreach ($tables as $table) {
+            $pdo->exec("DROP TABLE IF EXISTS \"{$table}\"");
+        }
+
+        // Strip SQL comments, then execute each statement individually.
+        // PDO::exec() for SQLite only runs the first statement in a multi-statement
+        // string, so we must split and execute one at a time.
+        $cleanSql = preg_replace('/--[^\n]*/', '', $sql);
+        foreach (array_filter(array_map('trim', explode(';', $cleanSql))) as $stmt) {
+            $pdo->exec($stmt);
+        }
+
+        $pdo->exec('PRAGMA foreign_keys = ON');
+    }
+
+    private function restoreCrossType(string $path, string $sourceType, string $targetType, array $config): void
+    {
+        $check = Process::run(['which', 'pgloader']);
+
+        if (! $check->successful() || empty(trim($check->output()))) {
+            throw new \RuntimeException(
+                "Cross-type restore from {$sourceType} to {$targetType} requires pgloader, ".
+                'which was not found in $PATH. '.
+                'Please pre-convert the dump file locally using pgloader (https://pgloader.io) '.
+                'or pg2mysql (https://github.com/dolthub/pg2mysql), then upload the converted '.
+                'file and restore from that.'
+            );
+        }
+
+        $tempPath = sys_get_temp_dir().'/restore_'.uniqid().'.sql';
+        file_put_contents($tempPath, $this->readGzip($path));
+
+        try {
+            $dsn = $this->buildTargetDsn($targetType, $config);
+            $result = Process::run(['pgloader', $tempPath, $dsn]);
+
+            if (! $result->successful()) {
+                throw new \RuntimeException('pgloader failed: '.$result->errorOutput());
+            }
+        } finally {
+            @unlink($tempPath);
+        }
+    }
+
+    private function buildTargetDsn(string $type, array $config): string
+    {
+        return match ($type) {
+            'pgsql' => "postgresql://{$config['username']}:{$config['password']}@{$config['host']}:{$config['port']}/{$config['database']}",
+            'mysql', 'mariadb' => "mysql://{$config['username']}:{$config['password']}@{$config['host']}:{$config['port']}/{$config['database']}",
+            default => throw new \RuntimeException("Cannot build DSN for type: {$type}"),
+        };
+    }
+}

--- a/app/Services/RestoreService.php
+++ b/app/Services/RestoreService.php
@@ -114,14 +114,15 @@ class RestoreService
     {
         $sql = $this->readGzip($path);
 
-        $result = Process::input($sql)->run([
-            'mysql',
-            '-h', $config['host'] ?? 'localhost',
-            '-P', (string) ($config['port'] ?? 3306),
-            '-u', $config['username'],
-            '-p'.$config['password'],
-            $config['database'],
-        ]);
+        $result = Process::env(['MYSQL_PWD' => $config['password'] ?? ''])
+            ->input($sql)
+            ->run([
+                'mysql',
+                '-h', $config['host'] ?? 'localhost',
+                '-P', (string) ($config['port'] ?? 3306),
+                '-u', $config['username'],
+                $config['database'],
+            ]);
 
         if (! $result->successful()) {
             throw new \RuntimeException('mysql restore failed: '.$result->errorOutput());
@@ -185,9 +186,15 @@ class RestoreService
 
     private function buildTargetDsn(string $type, array $config): string
     {
+        $username = rawurlencode((string) ($config['username'] ?? ''));
+        $password = rawurlencode((string) ($config['password'] ?? ''));
+        $database = rawurlencode((string) ($config['database'] ?? ''));
+        $host = $config['host'] ?? 'localhost';
+        $port = (string) ($config['port'] ?? ($type === 'pgsql' ? 5432 : 3306));
+
         return match ($type) {
-            'pgsql' => "postgresql://{$config['username']}:{$config['password']}@{$config['host']}:{$config['port']}/{$config['database']}",
-            'mysql', 'mariadb' => "mysql://{$config['username']}:{$config['password']}@{$config['host']}:{$config['port']}/{$config['database']}",
+            'pgsql' => "postgresql://{$username}:{$password}@{$host}:{$port}/{$database}",
+            'mysql', 'mariadb' => "mysql://{$username}:{$password}@{$host}:{$port}/{$database}",
             default => throw new \RuntimeException("Cannot build DSN for type: {$type}"),
         };
     }

--- a/app/Services/RestoreService.php
+++ b/app/Services/RestoreService.php
@@ -144,11 +144,10 @@ class RestoreService
             $pdo->exec("DROP TABLE IF EXISTS \"{$table}\"");
         }
 
-        // Strip SQL comments, then execute each statement individually.
         // PDO::exec() for SQLite only runs the first statement in a multi-statement
-        // string, so we must split and execute one at a time.
-        $cleanSql = preg_replace('/--[^\n]*/', '', $sql);
-        foreach (array_filter(array_map('trim', explode(';', $cleanSql))) as $stmt) {
+        // string, so we must split and execute one at a time. Use a character-level
+        // parser so semicolons inside string literals are not treated as delimiters.
+        foreach ($this->splitSqlStatements($sql) as $stmt) {
             $pdo->exec($stmt);
         }
 
@@ -182,6 +181,79 @@ class RestoreService
         } finally {
             @unlink($tempPath);
         }
+    }
+
+    /**
+     * Split a SQL string into individual statements, respecting single- and
+     * double-quoted literals so semicolons inside values are not treated as
+     * statement terminators. Also skips -- line comments.
+     *
+     * @return string[]
+     */
+    private function splitSqlStatements(string $sql): array
+    {
+        $statements = [];
+        $current = '';
+        $len = strlen($sql);
+        $i = 0;
+
+        while ($i < $len) {
+            $char = $sql[$i];
+
+            // Line comment: skip to end of line.
+            if ($char === '-' && isset($sql[$i + 1]) && $sql[$i + 1] === '-') {
+                while ($i < $len && $sql[$i] !== "\n") {
+                    $i++;
+                }
+
+                continue;
+            }
+
+            // Quoted string: consume until closing quote, handling doubled-quote escapes.
+            if ($char === "'" || $char === '"') {
+                $quote = $char;
+                $current .= $char;
+                $i++;
+                while ($i < $len) {
+                    $c = $sql[$i];
+                    $current .= $c;
+                    $i++;
+                    if ($c === $quote) {
+                        // Doubled quote is an escape inside the literal.
+                        if ($i < $len && $sql[$i] === $quote) {
+                            $current .= $sql[$i];
+                            $i++;
+                        } else {
+                            break;
+                        }
+                    }
+                }
+
+                continue;
+            }
+
+            // Statement terminator.
+            if ($char === ';') {
+                $stmt = trim($current);
+                if ($stmt !== '') {
+                    $statements[] = $stmt;
+                }
+                $current = '';
+                $i++;
+
+                continue;
+            }
+
+            $current .= $char;
+            $i++;
+        }
+
+        $stmt = trim($current);
+        if ($stmt !== '') {
+            $statements[] = $stmt;
+        }
+
+        return $statements;
     }
 
     private function buildTargetDsn(string $type, array $config): string

--- a/app/Services/RestoreService.php
+++ b/app/Services/RestoreService.php
@@ -11,6 +11,13 @@ class RestoreService
 {
     public function restore(string $path): void
     {
+        if (app()->environment('production')) {
+            throw new \RuntimeException(
+                'Restore is blocked in the production environment. '.
+                'To perform an emergency restore, set APP_ENV=backup-restore in .env and restart PHP-FPM and the queue worker.'
+            );
+        }
+
         if (! file_exists($path)) {
             throw new \RuntimeException("Backup file not found: {$path}");
         }

--- a/database/migrations/2026_04_28_000001_seed_backup_manager_role.php
+++ b/database/migrations/2026_04_28_000001_seed_backup_manager_role.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        $exists = DB::table('roles')->where('name', 'Backup Manager')->exists();
+        if (! $exists) {
+            DB::table('roles')->insert([
+                'name' => 'Backup Manager',
+                'description' => 'Access to the backup management dashboard: create, download, restore, and delete database backups.',
+                'color' => 'amber',
+                'icon' => 'circle-stack',
+                'created_at' => now(),
+                'updated_at' => now(),
+            ]);
+        }
+    }
+
+    public function down(): void
+    {
+        DB::table('roles')->where('name', 'Backup Manager')->delete();
+    }
+};

--- a/database/migrations/2026_04_28_000001_seed_backup_manager_role.php
+++ b/database/migrations/2026_04_28_000001_seed_backup_manager_role.php
@@ -22,6 +22,7 @@ return new class extends Migration
 
     public function down(): void
     {
-        DB::table('roles')->where('name', 'Backup Manager')->delete();
+        // up() is conditional (only inserts if missing), so rollback cannot safely
+        // determine whether this role pre-existed — leave it in place.
     }
 };

--- a/database/migrations/2026_04_28_000002_seed_backup_site_config.php
+++ b/database/migrations/2026_04_28_000002_seed_backup_site_config.php
@@ -1,0 +1,34 @@
+<?php
+
+use App\Models\SiteConfig;
+use Illuminate\Database\Migrations\Migration;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        SiteConfig::setValue('backup.local_retention_days', '7');
+        SiteConfig::query()->where('key', 'backup.local_retention_days')->update([
+            'description' => 'Number of days to retain local backup files before automatic cleanup',
+        ]);
+
+        SiteConfig::setValue('backup.offline_during_backup', 'false');
+        SiteConfig::query()->where('key', 'backup.offline_during_backup')->update([
+            'description' => 'Whether to put the site into maintenance mode during a backup operation',
+        ]);
+
+        SiteConfig::setValue('backup.offline_during_restore', 'true');
+        SiteConfig::query()->where('key', 'backup.offline_during_restore')->update([
+            'description' => 'Whether to put the site into maintenance mode during a restore operation',
+        ]);
+    }
+
+    public function down(): void
+    {
+        SiteConfig::query()->whereIn('key', [
+            'backup.local_retention_days',
+            'backup.offline_during_backup',
+            'backup.offline_during_restore',
+        ])->delete();
+    }
+};

--- a/docs/features/backup-management.md
+++ b/docs/features/backup-management.md
@@ -1,0 +1,644 @@
+# Backup Management -- Technical Documentation
+
+> **Audience:** Project owner, developers, AI agents
+> **Generated:** 2026-04-28
+> **Generator:** `/document-feature` skill
+
+---
+
+## Table of Contents
+
+1. [Overview](#1-overview)
+2. [Database Schema](#2-database-schema)
+3. [Models & Relationships](#3-models--relationships)
+4. [Enums Reference](#4-enums-reference)
+5. [Authorization & Permissions](#5-authorization--permissions)
+6. [Routes](#6-routes)
+7. [User Interface Components](#7-user-interface-components)
+8. [Actions (Business Logic)](#8-actions-business-logic)
+9. [Notifications](#9-notifications)
+10. [Background Jobs](#10-background-jobs)
+11. [Console Commands & Scheduled Tasks](#11-console-commands--scheduled-tasks)
+12. [Services](#12-services)
+13. [Activity Log Entries](#13-activity-log-entries)
+14. [Data Flow Diagrams](#14-data-flow-diagrams)
+15. [Configuration](#15-configuration)
+16. [Test Coverage](#16-test-coverage)
+17. [File Map](#17-file-map)
+18. [Known Issues & Improvement Opportunities](#18-known-issues--improvement-opportunities)
+
+---
+
+## 1. Overview
+
+The Backup Management feature provides Backup Manager staff with a complete database backup lifecycle: creating, downloading, restoring, and deleting both local and S3-hosted backups of the application database. It supports PostgreSQL, MySQL/MariaDB, and SQLite databases.
+
+The feature is accessible only to users holding the **Backup Manager** role. The dashboard is linked from the Staff Ready Room. Automated scheduling handles daily backup creation, daily local retention cleanup, and S3 uploads every three days.
+
+Key concepts:
+- **Local backups**: Compressed SQL dumps (`.sql.gz`) stored at `storage/app/backups/`. Created on-demand or by the daily cron. Retained for a configurable window (default: 7 days).
+- **S3 backups**: Copies of local backups uploaded to the configured S3 bucket under the `backups/` prefix. Retained using a three-tier strategy: 2 most recent, 1 per week for 4 weeks, and 1 per calendar month for 3 months.
+- **Maintenance mode**: Optionally puts the site into Laravel maintenance mode during backup and restore operations, configurable via `SiteConfig`.
+- **Storage stats**: An informational panel showing file counts and sizes for all public asset directories (staff photos, board member photos, message images, etc.).
+
+Users interact primarily via the `/backups` dashboard. Artisan commands (`app:backup-create`, `app:backup-restore`, `app:backup-cleanup`, `app:backup-push-s3`) allow CLI-level operation as well.
+
+---
+
+## 2. Database Schema
+
+No new tables are created by this feature. It seeds two sets of existing-table data:
+
+### `roles` table (seeded entry)
+
+| Column | Type | Value |
+|--------|------|-------|
+| `name` | string | `Backup Manager` |
+| `description` | string | `Access to the backup management dashboard: create, download, restore, and delete database backups.` |
+| `color` | string | `amber` |
+| `icon` | string | `circle-stack` |
+
+**Migration:** `database/migrations/2026_04_28_000001_seed_backup_manager_role.php`
+
+### `site_configs` table (seeded entries)
+
+| Key | Default Value | Description |
+|-----|---------------|-------------|
+| `backup.local_retention_days` | `7` | Number of days to retain local backup files |
+| `backup.offline_during_backup` | `false` | Whether to enter maintenance mode during backup |
+| `backup.offline_during_restore` | `true` | Whether to enter maintenance mode during restore |
+
+**Migration:** `database/migrations/2026_04_28_000002_seed_backup_site_config.php`
+
+Backup files themselves are stored on the filesystem, not in the database.
+
+---
+
+## 3. Models & Relationships
+
+### SiteConfig (`app/Models/SiteConfig.php`)
+
+Used as the backing store for backup configuration. No backup-specific relationships.
+
+**Key Methods:**
+- `getValue(string $key, ?string $default): ?string` -- Retrieves a config value with a 5-minute cache TTL.
+- `setValue(string $key, ?string $value): void` -- Upserts a value and clears the cache.
+
+**Casts:** None relevant to this feature.
+
+No dedicated model exists for backups — files are managed directly via the filesystem and S3 SDK.
+
+---
+
+## 4. Enums Reference
+
+Not applicable for this feature. No enums are used in the backup system.
+
+---
+
+## 5. Authorization & Permissions
+
+### Gates (from `AuthServiceProvider`)
+
+| Gate Name | Who Can Pass | Logic Summary |
+|-----------|-------------|---------------|
+| `backup-manager` | Users with the "Backup Manager" role | `$user->hasRole('Backup Manager')` |
+
+The `hasRole()` method on `User` checks three paths in order: admin override (admins pass all gates), staff position roles (direct assignment or `has_all_roles_at` flag), and rank-based role assignments.
+
+### Policies
+
+No policies are defined for this feature. Authorization is enforced entirely via the `backup-manager` gate.
+
+### Permissions Matrix
+
+| User Type | Access Dashboard | Create Backup | Restore | Upload | Delete Local | Delete S3 | View Stats |
+|-----------|:---:|:---:|:---:|:---:|:---:|:---:|:---:|
+| Unauthenticated | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
+| Authenticated (no role) | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
+| Backup Manager | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
+| Admin | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
+
+---
+
+## 6. Routes
+
+| Method | URL | Middleware | Handler | Route Name |
+|--------|-----|-----------|---------|------------|
+| GET | `/backups` | `auth`, `can:backup-manager` | `backup.dashboard` (Volt) | `backups.index` |
+
+---
+
+## 7. User Interface Components
+
+### Backup Dashboard
+**File:** `resources/views/livewire/backup/dashboard.blade.php`
+**Route:** `/backups` (route name: `backups.index`)
+
+**Purpose:** Single-page dashboard for all backup operations: listing/creating/downloading/restoring/deleting local backups, S3 backup management, file upload, storage stats, and maintenance mode settings.
+
+**Authorization:** `$this->authorize('backup-manager')` called in `mount()` and each mutating method.
+
+**User Actions Available:**
+- **Create Backup Now** — dispatches `CreateBackupJob` → `BackupService::create()` → creates `.sql.gz` file
+- **Download (local)** — streams local file to browser via `response()->streamDownload()`
+- **Restore (local)** — confirms via modal, then dispatches `RestoreBackupJob` → `RestoreService::restore()`
+- **Delete (local)** — confirms via modal, then calls `unlink()` on the file path
+- **Download (S3)** — streams S3 file to browser via `Storage::disk('s3')->readStream()`
+- **Delete (S3)** — confirms via modal, then calls `BackupStorageService::delete()`
+- **Upload** — uploads a `.sql.gz` file from the browser to `storage/app/backups/`
+- **Offline During Backup toggle** — saves to `SiteConfig::setValue('backup.offline_during_backup', ...)`
+- **Offline During Restore toggle** — saves to `SiteConfig::setValue('backup.offline_during_restore', ...)`
+
+**Computed Properties:**
+- `localBackups()` — globs `storage/app/backups/*.sql.gz`, returns array with `filename`, `size`, `date`, `db_type`
+- `s3Configured()` — checks `filesystems.disks.s3.key` and `bucket` are non-empty
+- `s3Connected()` — calls `BackupStorageService::isConnected()`; short-circuits to `false` if not configured
+- `s3Backups()` — calls `BackupStorageService::listWithMetadata()`; returns `[]` when not connected
+- `storageStats()` — iterates 7 known public asset directories using `Storage::disk($publicDisk)->allFiles()`, returns `label`, `directory`, `count`, `total_size`
+
+**UI Elements:**
+- Local Backups card: table of local `.sql.gz` files with Download/Restore/Delete buttons per row; "Create Backup Now" primary button
+- S3 Backups card: connectivity badge (green/red/grey), table of S3 files with Download/Delete buttons; configured/unreachable/not-configured states
+- Upload Backup card: file input (`accept=".gz"`), form submit
+- File Asset Storage card: table of asset directory stats (label, path, file count, total size)
+- Settings card: two `flux:switch` toggles with `wire:model.live`
+- Three confirmation modals: `confirm-restore`, `confirm-delete`, `confirm-delete-s3`
+
+---
+
+## 8. Actions (Business Logic)
+
+Not applicable for this feature — the feature does not use Action classes (the `AsAction` trait pattern). Business logic lives in Service classes. See [Section 12: Services](#12-services).
+
+---
+
+## 9. Notifications
+
+### BackupCreatedNotification (`app/Notifications/BackupCreatedNotification.php`)
+
+**Triggered by:** `CreateBackup` Artisan command (after successful `BackupService::create()`)
+**Recipient:** All users with the "Backup Manager" role
+**Channels:** `mail` (always), `pushover` (if `pushoverKey` set on the notification)
+**Mail subject:** `"Database Backup Created"`
+**Content summary:** "A database backup was created successfully. File: {filename}"
+**Queued:** Yes (`ShouldQueue`)
+
+### BackupFailedNotification (`app/Notifications/BackupFailedNotification.php`)
+
+**Triggered by:** `CreateBackup` Artisan command (on exception from `BackupService::create()`)
+**Recipient:** All users with the "Backup Manager" role
+**Channels:** `mail` (always), `pushover` (if `pushoverKey` set)
+**Mail subject:** `"Database Backup Failed"`
+**Content summary:** "A database backup attempt failed. Error: {error message}"
+**Queued:** Yes (`ShouldQueue`)
+
+### RestoreCompletedNotification (`app/Notifications/RestoreCompletedNotification.php`)
+
+**Triggered by:** `RestoreBackup` Artisan command (after successful `RestoreService::restore()`)
+**Recipient:** All users with the "Backup Manager" role
+**Channels:** `mail` (always), `pushover` (if `pushoverKey` set)
+**Mail subject:** `"Database Restore Completed"`
+**Content summary:** "Database restore completed successfully. File: {filename}"
+**Queued:** Yes (`ShouldQueue`)
+
+### RestoreFailedNotification (`app/Notifications/RestoreFailedNotification.php`)
+
+**Triggered by:** `RestoreBackup` Artisan command (on exception from `RestoreService::restore()`)
+**Recipient:** All users with the "Backup Manager" role
+**Channels:** `mail` (always), `pushover` (if `pushoverKey` set)
+**Mail subject:** `"Database Restore Failed"`
+**Content summary:** "A database restore attempt failed. Error: {error message}"
+**Queued:** Yes (`ShouldQueue`)
+
+> **Note:** Notifications are sent via `TicketNotificationService::send($manager, $notification, 'staff_alerts')`. Only the Artisan commands send notifications — the Livewire dashboard jobs (`CreateBackupJob`, `RestoreBackupJob`) do **not** send notifications directly. To receive notifications on dashboard-triggered operations, the jobs would need to call the commands or notify separately.
+
+---
+
+## 10. Background Jobs
+
+### CreateBackupJob (`app/Jobs/CreateBackupJob.php`)
+
+**Triggered by:** `Flux::button` → `createBackup()` in the Backup Dashboard Volt component
+**What it does:** Resolves `BackupService` from the container and calls `create()`, which produces a `.sql.gz` file in `storage/app/backups/`
+**Queue/Delay:** Default queue, no delay. `ShouldQueue`. No retry configuration specified (uses framework defaults).
+
+### RestoreBackupJob (`app/Jobs/RestoreBackupJob.php`)
+
+**Triggered by:** `restoreBackup()` in the Backup Dashboard Volt component, after the confirmation modal
+**What it does:** Receives the full `$path` as a constructor argument, resolves `RestoreService`, and calls `restore($path)`
+**Queue/Delay:** Default queue, no delay. `ShouldQueue`. No retry configuration specified.
+
+> **Important:** Both dashboard jobs run silently — they do not send success/failure notifications. Notifications are only sent by the `CreateBackup` and `RestoreBackup` Artisan commands.
+
+---
+
+## 11. Console Commands & Scheduled Tasks
+
+### `app:backup-create`
+**File:** `app/Console/Commands/CreateBackup.php`
+**Scheduled:** Yes — daily at `03:00` (`runInBackground`)
+**What it does:** Calls `BackupService::create()`. Optionally skips maintenance mode with `--skip-offline`. Notifies all Backup Manager users of success or failure via `BackupCreatedNotification` / `BackupFailedNotification`.
+**Options:** `--skip-offline` — bypasses the `backup.offline_during_backup` SiteConfig check.
+
+### `app:backup-restore`
+**File:** `app/Console/Commands/RestoreBackup.php`
+**Scheduled:** No (manual only)
+**What it does:** Accepts a bare filename argument (e.g., `backup_2026-04-28_03-00-00_sqlite.sql.gz`), builds the full path from `storage/app/backups/`, calls `RestoreService::restore($path)`. Notifies all Backup Manager users of success or failure.
+
+### `app:backup-cleanup`
+**File:** `app/Console/Commands/CleanupBackups.php`
+**Scheduled:** Yes — daily at `04:00` (`runInBackground`)
+**What it does:** Calls `BackupRetentionService::enforceLocalRetention()` to delete local files older than `backup.local_retention_days` (default: 7). If S3 is configured (`filesystems.disks.s3.key` is non-empty), also runs `enforceS3Retention()` — failures are caught and warned but do not fail the command.
+
+### `app:backup-push-s3`
+**File:** `app/Console/Commands/PushBackupToS3.php`
+**Scheduled:** Yes — every 3 days at `03:30` (`cron('30 3 */3 * *')`, `runInBackground`)
+**What it does:** Finds the most recent local `.sql.gz` by `filemtime()`, uploads it to S3 via `BackupStorageService::upload()`, then enforces S3 retention tiers via `BackupRetentionService::enforceS3Retention()`. Returns `FAILURE` if no local backup files exist.
+
+---
+
+## 12. Services
+
+### BackupService (`app/Services/BackupService.php`)
+
+**Purpose:** Creates a gzip-compressed SQL dump of the active database and writes it to `storage/app/backups/`.
+
+**Key methods:**
+- `setSkipOffline(bool $skip): self` — Chainable; bypasses the maintenance mode setting for this instance.
+- `create(): string` — Orchestrates: resolves DB driver, formats filename (`backup_YYYY-MM-DD_HH-MM-SS_{dbtype}.sql.gz`), optionally enters maintenance mode, dumps the database, writes to disk, exits maintenance mode. Returns the file path.
+
+**Driver support:**
+| Driver | Tool used |
+|--------|-----------|
+| `pgsql` | `pg_dump` via `Process::run()` with `PGPASSWORD` env var |
+| `mysql` / `mariadb` | `mysqldump` via `Process::run()` |
+| `sqlite` | Native PDO: reads all non-system tables' CREATE statements and INSERT rows |
+
+**Called by:** `CreateBackupJob`, `CreateBackup` Artisan command.
+
+---
+
+### RestoreService (`app/Services/RestoreService.php`)
+
+**Purpose:** Restores a gzip-compressed SQL backup file into the active database.
+
+**Key methods:**
+- `restore(string $path): void` — Detects source DB type from filename, matches against target DB driver, optionally enters maintenance mode, calls the appropriate restore path.
+
+**Source type detection:** Reads `_pgsql.sql.gz`, `_mysql.sql.gz`, or `_sqlite.sql.gz` suffix from the filename.
+
+**Restore paths:**
+| Source = Target | Method |
+|-----------------|--------|
+| `pgsql → pgsql` | Pipes SQL to `psql` via `Process::input()` |
+| `mysql → mysql` | Pipes SQL to `mysql` via `Process::input()` |
+| `sqlite → sqlite` | Drops all tables, re-runs CREATE + INSERT via PDO (splits on `;`, strips comments) |
+| Cross-type | Requires `pgloader` on `$PATH`; builds DSN and invokes `pgloader`; raises a clear error if missing |
+
+**Driver resolution:** Uses `$targetConfig['driver']` (not the connection name) to handle named connections like `restore_test`.
+
+**Called by:** `RestoreBackupJob`, `RestoreBackup` Artisan command.
+
+---
+
+### BackupStorageService (`app/Services/BackupStorageService.php`)
+
+**Purpose:** Wraps S3 operations for backup files under the `backups/` prefix.
+
+**Key methods:**
+- `upload(string $localPath): string` — Uploads file to S3 at `backups/{filename}`, returns the S3 key.
+- `list(): array` — Returns all `.sql.gz` keys under `backups/`, sorted newest-first by filename timestamp.
+- `download(string $key): string` — Downloads S3 file to a temp path and returns the local path. Caller is responsible for cleanup.
+- `delete(string $key): void` — Deletes the S3 key.
+- `isConfigured(): bool` — Returns `true` when `filesystems.disks.s3.key` and `bucket` are both non-empty.
+- `isConnected(): bool` — Returns `true` if configured and `Storage::disk('s3')->files(...)` succeeds without exception.
+- `listWithMetadata(): array` — Returns array of `{key, filename, size (formatted), date}` for each S3 backup.
+- `parseTimestamp(string $key): Carbon` — Extracts `YYYY-MM-DD_HH-MM-SS` from the filename and returns a Carbon instance. Returns `Carbon::epoch()` if the pattern does not match.
+
+**Called by:** `PushBackupToS3` command, `CleanupBackups` command, `BackupRetentionService`, Backup Dashboard component.
+
+---
+
+### BackupRetentionService (`app/Services/BackupRetentionService.php`)
+
+**Purpose:** Enforces retention policies for both local and S3 backups.
+
+**Key methods:**
+- `enforceLocalRetention(): array` — Deletes `.sql.gz` files in `storage/app/backups/` older than `backup.local_retention_days` SiteConfig days. Returns array of deleted paths.
+- `enforceS3Retention(BackupStorageService $storage): array` — Applies three-tier retention to S3 keys. Returns array of deleted keys.
+
+**S3 retention tiers:**
+1. **2 most recent** (by filename timestamp, regardless of age)
+2. **1 per 7-day window** for the past 4 weeks
+3. **1 per calendar month** for the past 3 months
+
+Any key not selected by any tier is deleted. Note: a key can qualify for multiple tiers and is kept once.
+
+**Called by:** `CleanupBackups` command, `PushBackupToS3` command.
+
+---
+
+## 13. Activity Log Entries
+
+Not applicable for this feature. No `RecordActivity::run()` calls are made in the backup system. Backup operations are tracked via notifications to managers rather than the activity log.
+
+---
+
+## 14. Data Flow Diagrams
+
+### Creating a Backup (Dashboard)
+
+```
+User clicks "Create Backup Now" on /backups
+  -> wire:click="createBackup"
+    -> dashboard.blade.php::createBackup()
+      -> $this->authorize('backup-manager')
+      -> CreateBackupJob::dispatch()
+        [queued job]
+        -> BackupService::create()
+          -> Reads DB driver from config
+          -> Optionally: Artisan::call('down') [if offline_during_backup=true]
+          -> Dumps DB (pg_dump / mysqldump / PDO SQLite)
+          -> gzopen() + gzwrite() → storage/app/backups/backup_YYYY-MM-DD_HH-MM-SS_<type>.sql.gz
+          -> Optionally: Artisan::call('up')
+          -> Returns file path
+      -> Flux::toast('Backup job queued.', 'Success', variant: 'success')
+```
+
+### Creating a Backup (Scheduled)
+
+```
+Scheduler fires dailyAt('03:00')
+  -> app:backup-create (CreateBackup command)
+    -> BackupService::create() [same as above]
+    -> On success:
+      -> BackupCreatedNotification sent to all Backup Manager users (mail + pushover)
+    -> On failure:
+      -> BackupFailedNotification sent to all Backup Manager users (mail + pushover)
+```
+
+### Restoring a Backup (Dashboard)
+
+```
+User clicks "Restore" button on a local backup row
+  -> wire:click="confirmRestore('{filename}')"
+    -> $restoreTarget = $filename
+    -> Flux::modal('confirm-restore')->show()
+
+User clicks "Restore" in the confirmation modal
+  -> wire:click="restoreBackup"
+    -> $this->authorize('backup-manager')
+    -> Builds path: storage/app/backups/{$restoreTarget}
+    -> RestoreBackupJob::dispatch($path)
+      [queued job]
+      -> RestoreService::restore($path)
+        -> Detects source type from filename
+        -> Resolves target driver from config
+        -> Optionally: Artisan::call('down')
+        -> Restores via psql / mysql / PDO (same-type) or pgloader (cross-type)
+        -> Optionally: Artisan::call('up')
+    -> Flux::modal('confirm-restore')->close()
+    -> Flux::toast('Restore job queued.', 'Success', variant: 'success')
+```
+
+### Uploading a Backup
+
+```
+User selects a .gz file in the Upload form and clicks "Upload"
+  -> wire:submit="uploadBackup"
+    -> $this->authorize('backup-manager')
+    -> validate(['uploadFile' => ['required','file','mimes:gz','max:524288']])
+    -> Checks getClientOriginalName() ends with '.sql.gz'
+      -> If not: $this->addError('uploadFile', '...')  [return early]
+    -> Ensures storage/app/backups/ directory exists
+    -> $this->uploadFile->storeAs('backups', $originalName, 'local')
+    -> $this->uploadFile = null
+    -> unset($this->localBackups) [clears computed cache]
+    -> Flux::toast("Uploaded {filename}.", 'Done', variant: 'success')
+```
+
+### S3 Upload (Scheduled)
+
+```
+Scheduler fires cron('30 3 */3 * *')
+  -> app:backup-push-s3 (PushBackupToS3 command)
+    -> Globs storage/app/backups/*.sql.gz, picks most recent by filemtime()
+    -> BackupStorageService::upload($localPath)
+      -> Storage::disk('s3')->put("backups/{$filename}", file_get_contents($localPath))
+    -> BackupRetentionService::enforceS3Retention($storageService)
+      -> Evaluates 3-tier retention, deletes excess keys from S3
+```
+
+### Local Retention Cleanup (Scheduled)
+
+```
+Scheduler fires dailyAt('04:00')
+  -> app:backup-cleanup (CleanupBackups command)
+    -> BackupRetentionService::enforceLocalRetention()
+      -> Globs storage/app/backups/*.sql.gz
+      -> Deletes files with filemtime() older than backup.local_retention_days
+    -> If S3 configured:
+      -> BackupRetentionService::enforceS3Retention(BackupStorageService)
+```
+
+---
+
+## 15. Configuration
+
+### Environment Variables
+
+| Variable | Used By | Purpose |
+|----------|---------|---------|
+| `AWS_ACCESS_KEY_ID` | `config/filesystems.php` (s3 disk) | S3 authentication key |
+| `AWS_SECRET_ACCESS_KEY` | `config/filesystems.php` (s3 disk) | S3 authentication secret |
+| `AWS_DEFAULT_REGION` | `config/filesystems.php` (s3 disk) | S3 region (e.g., `us-east-1`) |
+| `AWS_BUCKET` | `config/filesystems.php` (s3 disk) | S3 bucket name |
+| `AWS_URL` | `config/filesystems.php` (s3 disk) | Custom S3 endpoint URL (optional) |
+| `AWS_ENDPOINT` | `config/filesystems.php` (s3 disk) | Custom S3 endpoint (e.g., for MinIO) |
+| `AWS_USE_PATH_STYLE_ENDPOINT` | `config/filesystems.php` (s3 disk) | Path-style endpoint toggle (default: `false`) |
+
+### SiteConfig Keys
+
+| Key | Default | Purpose | Set By |
+|-----|---------|---------|--------|
+| `backup.local_retention_days` | `7` | Days before local backups are auto-deleted | Migration (seeded) |
+| `backup.offline_during_backup` | `false` | Maintenance mode during backup | Dashboard toggle |
+| `backup.offline_during_restore` | `true` | Maintenance mode during restore | Dashboard toggle |
+
+### Config Files
+
+| File | Key | Purpose |
+|------|-----|---------|
+| `config/filesystems.php` | `public_disk` | Disk name for public asset storage (default: `public`); used by storage stats panel |
+| `config/filesystems.php` | `disks.s3.*` | S3 connection parameters |
+
+---
+
+## 16. Test Coverage
+
+### Test Files
+
+| File | Tests | What It Covers |
+|------|-------|----------------|
+| `tests/Feature/Backup/BackupDashboardTest.php` | 20 | Dashboard auth, local backup list, create job, delete, restore, upload, settings, S3 panel, storage stats |
+| `tests/Feature/Commands/CreateBackupTest.php` | 8 | Backup file creation, filename format, notifications, maintenance mode, scheduling |
+| `tests/Feature/Commands/RestoreBackupTest.php` | 5 | Database state restoration, cross-type error, maintenance mode, notifications |
+| `tests/Feature/Commands/CleanupBackupsTest.php` | 5 | Local retention policy, custom retention, scheduling |
+| `tests/Feature/Services/BackupStorageServiceTest.php` | 15 | S3 upload/list/download/delete, retention tiers, push command, isConfigured/isConnected, listWithMetadata |
+
+### Test Case Inventory
+
+#### `BackupDashboardTest.php`
+- unauthenticated users are redirected from the backup dashboard
+- users without backup-manager role get 403 on the backup dashboard
+- backup manager can access the backup dashboard
+- ready room header shows Backups link only for backup managers
+- dashboard lists local backup files with metadata
+- clicking Create Backup Now dispatches a CreateBackupJob
+- deleting a backup removes it from disk
+- non-backup-manager is blocked at the route level
+- restore action dispatches RestoreBackupJob
+- confirmRestore sets restoreTarget
+- uploading a valid .sql.gz file places it in storage
+- uploading a non-.sql.gz file is rejected
+- toggling offlineDuringBackup persists to SiteConfig
+- toggling offlineDuringRestore persists to SiteConfig
+- mount loads SiteConfig values into toggle properties
+- dashboard shows S3 not configured when credentials are missing
+- dashboard shows S3 connected when S3 is reachable
+- dashboard lists S3 backup files in the S3 panel
+- deleteS3Backup removes file from S3
+- dashboard storage stats panel shows known asset directories
+
+#### `CreateBackupTest.php`
+- creates a .sql.gz backup file
+- backup file has non-zero size
+- backup filename includes timestamp and database type
+- notifies backup managers on success
+- notifies backup managers on failure
+- does not trigger maintenance mode when offline_during_backup is false
+- does not trigger maintenance mode with --skip-offline flag
+- is scheduled daily at 03:00
+
+#### `RestoreBackupTest.php`
+- restores a backup and results in expected database state
+- aborts cross-type restore with clear error when pgloader is not installed
+- enters and exits maintenance mode during restore when offline_during_restore is true
+- notifies backup managers on successful restore
+- notifies backup managers on restore failure
+
+#### `CleanupBackupsTest.php`
+- deletes files older than the retention window and keeps newer files
+- respects a custom retention window from SiteConfig
+- returns an empty array when no files need to be deleted
+- the app:backup-cleanup command exits successfully
+- app:backup-cleanup is scheduled daily at 04:00
+
+#### `BackupStorageServiceTest.php`
+- uploads a local backup to S3 under the backups/ prefix
+- lists S3 backups sorted newest-first by filename timestamp
+- downloads an S3 backup to a temp file
+- deletes an S3 backup by key
+- S3 retention keeps 2 most recent, 1 per week for 4 weeks, 1 per month for 3 months
+- S3 retention returns empty when no files exist
+- app:backup-push-s3 uploads most recent local backup to S3
+- app:backup-push-s3 fails when no local backups exist
+- app:backup-push-s3 is scheduled every 3 days at 03:30
+- isConfigured returns true when S3 credentials are set
+- isConfigured returns false when S3 key is missing
+- isConnected returns true when S3 is reachable
+- isConnected returns false when S3 is not configured
+- listWithMetadata returns filename, size, and date for each S3 backup
+- listWithMetadata returns newest-first ordering
+
+### Coverage Gaps
+
+- **Dashboard-triggered job notifications**: `CreateBackupJob` and `RestoreBackupJob` (dispatched from the dashboard) do not send notifications on success or failure. Only the Artisan commands do. There are no tests verifying dashboard-triggered backup/restore outcomes beyond job dispatch.
+- **Cross-type restore with pgloader present**: The cross-type restore path is only tested for the error case (pgloader missing). The success path when pgloader is available is untested.
+- **S3 download streaming to browser**: `downloadFromS3()` uses `Storage::disk('s3')->readStream()` but this is not covered by any test (only `BackupStorageService::download()` to a temp file is tested).
+- **Storage stats accuracy**: The storage stats panel test only checks that directory labels appear in the output — it does not verify correct file counts or sizes.
+- **Maintenance mode lifecycle during jobs**: `RestoreBackupTest` tests maintenance mode for the Artisan command path, but not for the `RestoreBackupJob` queue path.
+
+---
+
+## 17. File Map
+
+**Models:**
+- `app/Models/SiteConfig.php` (configuration store)
+
+**Enums:** None
+
+**Actions:** None (uses Services instead)
+
+**Policies:** None
+
+**Gates:** `app/Providers/AuthServiceProvider.php` — gate: `backup-manager`
+
+**Notifications:**
+- `app/Notifications/BackupCreatedNotification.php`
+- `app/Notifications/BackupFailedNotification.php`
+- `app/Notifications/RestoreCompletedNotification.php`
+- `app/Notifications/RestoreFailedNotification.php`
+
+**Jobs:**
+- `app/Jobs/CreateBackupJob.php`
+- `app/Jobs/RestoreBackupJob.php`
+
+**Services:**
+- `app/Services/BackupService.php`
+- `app/Services/RestoreService.php`
+- `app/Services/BackupStorageService.php`
+- `app/Services/BackupRetentionService.php`
+
+**Controllers:** None (Volt component handles everything)
+
+**Volt Components:**
+- `resources/views/livewire/backup/dashboard.blade.php`
+
+**Routes:**
+- `GET /backups` → `backups.index`
+
+**Migrations:**
+- `database/migrations/2026_04_28_000001_seed_backup_manager_role.php`
+- `database/migrations/2026_04_28_000002_seed_backup_site_config.php`
+
+**Console Commands:**
+- `app/Console/Commands/CreateBackup.php` (`app:backup-create`)
+- `app/Console/Commands/RestoreBackup.php` (`app:backup-restore`)
+- `app/Console/Commands/CleanupBackups.php` (`app:backup-cleanup`)
+- `app/Console/Commands/PushBackupToS3.php` (`app:backup-push-s3`)
+
+**Tests:**
+- `tests/Feature/Backup/BackupDashboardTest.php`
+- `tests/Feature/Commands/CreateBackupTest.php`
+- `tests/Feature/Commands/RestoreBackupTest.php`
+- `tests/Feature/Commands/CleanupBackupsTest.php`
+- `tests/Feature/Services/BackupStorageServiceTest.php`
+
+**Config:**
+- `config/filesystems.php` — `disks.s3.*`, `public_disk`
+- `routes/console.php` — scheduled task registrations
+
+**Other:**
+- `resources/views/dashboard/ready-room.blade.php` — Backups button (conditional on `backup-manager` gate)
+
+---
+
+## 18. Known Issues & Improvement Opportunities
+
+1. **Dashboard jobs do not notify on completion**: `CreateBackupJob` and `RestoreBackupJob` run silently. Staff who trigger a backup or restore from the dashboard have no way to know if it succeeded or failed other than checking back on the dashboard. The Artisan commands send notifications but the jobs do not. Consider adding a `onFailed()` method to both jobs, or integrating notifications into the service layer rather than only the commands.
+
+2. **`BackupService` reads the entire SQLite DB into memory**: The SQLite dump in `BackupService::dumpSqlite()` fetches all rows from all tables via `fetchAll()`. For large databases this could exhaust memory. A streaming approach or use of the `sqlite3` CLI tool would be more robust.
+
+3. **S3 download (`downloadFromS3`) downloads the entire file to memory before streaming**: The current implementation uses `Storage::disk('s3')->readStream()` and `fpassthru()`, which should stream correctly. However, if the S3 stream is unavailable, `abort(404)` is called inside a streaming closure, which may produce inconsistent behavior.
+
+4. **Storage stats panel performs N×M filesystem calls**: `storageStats()` calls `Storage::disk($publicDisk)->allFiles($dir)` plus `->size($file)` for every file in every directory. On large deployments this could be slow. No caching is applied to the computed property.
+
+5. **`backup.local_retention_days` is not exposed in the dashboard UI**: The SiteConfig key exists and is respected by the cleanup command, but there is no UI control to change it. It can only be updated by direct database manipulation or migration.
+
+6. **Cross-type restore error message references pgloader as the only solution**: The error message in `RestoreService::restoreCrossType()` only mentions `pgloader` and `pg2mysql`. If a user is trying to restore a PostgreSQL backup to SQLite (common in dev), this error is not particularly actionable.
+
+7. **No audit trail for backup operations**: Backup creates, restores, and deletes are not logged to the `activity_logs` table. If a restore causes data loss, there is no in-app record of who triggered it or when.
+
+8. **Hardcoded asset directory list in `storageStats()`**: The list of asset directories to inspect is hardcoded in the Volt component (`staff-photos`, `board-member-photos`, etc.). Adding a new upload type requires updating this list manually.

--- a/docs/features/backup-management.md
+++ b/docs/features/backup-management.md
@@ -246,6 +246,14 @@ Not applicable for this feature — the feature does not use Action classes (the
 **Scheduled:** No (manual only)
 **What it does:** Accepts a bare filename argument (e.g., `backup_2026-04-28_03-00-00_sqlite.sql.gz`), builds the full path from `storage/app/backups/`, calls `RestoreService::restore($path)`. Notifies all Backup Manager users of success or failure.
 
+> **⚠️ Production Safety Lock:** Restore is blocked when `APP_ENV=production`. The command (and the Livewire dashboard) will immediately abort with an error. To perform an emergency restore on production, you must:
+> 1. Edit `.env` and change `APP_ENV=backup-restore`
+> 2. Restart PHP-FPM and the queue worker so the new env value takes effect
+> 3. Run the restore command (or use the dashboard)
+> 4. Set `APP_ENV=production` again and restart
+>
+> **Do not leave `APP_ENV=backup-restore` running in production** — set it back to `production` as soon as the restore is complete.
+
 ### `app:backup-cleanup`
 **File:** `app/Console/Commands/CleanupBackups.php`
 **Scheduled:** Yes — daily at `04:00` (`runInBackground`)
@@ -284,7 +292,7 @@ Not applicable for this feature — the feature does not use Action classes (the
 **Purpose:** Restores a gzip-compressed SQL backup file into the active database.
 
 **Key methods:**
-- `restore(string $path): void` — Detects source DB type from filename, matches against target DB driver, optionally enters maintenance mode, calls the appropriate restore path.
+- `restore(string $path): void` — First checks that `APP_ENV` is not `production` (throws `RuntimeException` if it is). Then detects source DB type from filename, matches against target DB driver, optionally enters maintenance mode, calls the appropriate restore path.
 
 **Source type detection:** Reads `_pgsql.sql.gz`, `_mysql.sql.gz`, or `_sqlite.sql.gz` suffix from the filename.
 
@@ -450,6 +458,7 @@ Scheduler fires dailyAt('04:00')
 
 | Variable | Used By | Purpose |
 |----------|---------|---------|
+| `APP_ENV` | `RestoreService`, Backup Dashboard | **Restore safety lock.** Restore is blocked when `production`. Set to `backup-restore` to enable an emergency restore. Must restart PHP-FPM and queue workers after changing. |
 | `AWS_ACCESS_KEY_ID` | `config/filesystems.php` (s3 disk) | S3 authentication key |
 | `AWS_SECRET_ACCESS_KEY` | `config/filesystems.php` (s3 disk) | S3 authentication secret |
 | `AWS_DEFAULT_REGION` | `config/filesystems.php` (s3 disk) | S3 region (e.g., `us-east-1`) |

--- a/resources/library/books/staff-handbook/07-administration/07-backup-management/01-backup-dashboard.md
+++ b/resources/library/books/staff-handbook/07-administration/07-backup-management/01-backup-dashboard.md
@@ -1,0 +1,72 @@
+---
+title: 'Using the Backup Dashboard'
+visibility: officer
+order: 1
+summary: 'How to create, download, upload, and delete backups from the dashboard.'
+---
+
+## Overview
+
+The **Backup Dashboard** is your central hub for managing database backups. You can reach it from the Ready Room -- the **Backups** button only appears if you have the Backup Manager role.
+
+The dashboard shows three backup sources: local files stored on the server, backups stored in S3 (cloud), and an upload panel for importing a backup from another server.
+
+## Who Can Use This
+
+Only users assigned the **Backup Manager** role can access the Backup Dashboard. Admins also have access by default.
+
+## Creating a Backup
+
+1. Go to Ready Room and click **Backups**.
+2. In the **Local Backups** section, click **Create Backup Now**.
+3. You'll see a "Backup job queued" confirmation. The backup runs in the background -- refresh the page after a minute to see it appear in the list.
+
+The backup file is named `backup_YYYY-MM-DD_HH-MM-SS_<dbtype>.sql.gz` and stored on the server. Backups also run automatically every day at 3:00 AM -- you only need to click this manually when you want a backup right now (before a deployment, for example).
+
+## Downloading a Backup
+
+To download a local backup file to your computer:
+
+1. Find the backup in the **Local Backups** table.
+2. Click **Download** in that row.
+3. The file will download as a `.sql.gz` compressed archive.
+
+To download from S3, use the **Download** button in the **S3 Backups** section instead.
+
+## Uploading a Backup
+
+If you have a backup file from another server and want to bring it into this one:
+
+1. Scroll to the **Upload Backup** section.
+2. Click the file picker and select your `.sql.gz` file.
+3. Click **Upload**. The file will appear in the Local Backups list.
+
+The file must end in `.sql.gz` -- plain `.gz` files that aren't SQL dumps will be rejected.
+
+## Deleting a Backup
+
+To delete a local backup:
+
+1. Find it in the **Local Backups** table.
+2. Click **Delete** and confirm in the popup.
+
+To delete an S3 backup, use the **Delete** button in the **S3 Backups** section. Both actions are permanent -- there's no undo.
+
+## The S3 Panel
+
+If S3 is configured, the **S3 Backups** section shows all backups stored in cloud storage with a connectivity status badge at the top:
+
+- **S3 Connected** (green) -- S3 is reachable and the file list is live.
+- **S3 Unreachable** (red) -- Credentials are set but S3 isn't responding. Check with an Admin.
+- **S3 Not Configured** (grey) -- No S3 credentials are set up on this server.
+
+## Storage Stats
+
+The **File Asset Storage** panel at the bottom shows file counts and total sizes for each asset directory (staff photos, message images, blog images, etc.). This is informational only -- use it to get a sense of how much disk space uploaded files are consuming.
+
+## Settings
+
+At the bottom of the dashboard are two toggles:
+
+- **Take site offline during backup** -- Puts the site into maintenance mode while a backup runs. Off by default. Only useful if you're concerned about data consistency during large backups.
+- **Take site offline during restore** -- Puts the site into maintenance mode during a restore. On by default. Leave this on -- restoring while the site is live can cause data corruption.

--- a/resources/library/books/staff-handbook/07-administration/07-backup-management/02-restoring-a-backup.md
+++ b/resources/library/books/staff-handbook/07-administration/07-backup-management/02-restoring-a-backup.md
@@ -1,0 +1,49 @@
+---
+title: 'Restoring a Backup'
+visibility: officer
+order: 2
+summary: 'Step-by-step guide to restoring the database from a backup file.'
+---
+
+## Overview
+
+Restoring a backup replaces the current database with the contents of a backup file. This is a destructive, irreversible operation -- **everything in the database after the backup was made will be lost**. Only restore when you need to, and always make a fresh backup immediately before you start.
+
+## Who Can Do This
+
+Only users with the **Backup Manager** role (or Admins) can initiate a restore.
+
+## Before You Restore
+
+Take a fresh backup first. If the restore goes wrong or the backup file is corrupted, you'll want a snapshot of the current state to fall back to.
+
+1. Click **Create Backup Now** on the Backup Dashboard and wait for it to finish.
+2. Confirm the new backup appears at the top of the **Local Backups** list.
+
+## How to Restore
+
+1. Go to Ready Room → **Backups**.
+2. In the **Local Backups** table, find the backup file you want to restore from.
+3. Click **Restore** in that row.
+4. Read the confirmation carefully -- it shows you exactly which file you're restoring from.
+5. Click **Restore** in the modal to confirm.
+
+You'll see a "Restore job queued" confirmation. The restore runs in the background. If the **Take site offline during restore** setting is on (it is by default), the site will enter maintenance mode automatically and come back up when the restore finishes.
+
+## What Happens During a Restore
+
+- The current database is wiped and replaced with the contents of the backup file.
+- If maintenance mode is enabled, the site shows an "under maintenance" page to visitors during the restore.
+- All Backup Manager users receive an email notification when the restore completes or fails.
+
+The restore matches backup type to the current database -- a SQLite backup restores to a SQLite database, a PostgreSQL backup restores to PostgreSQL, and so on. Cross-type restores (e.g., restoring a PostgreSQL backup to a SQLite database) require additional server-side tooling and may not be available.
+
+## After a Restore
+
+Check that the site is working as expected after the restore completes. Log out and back in to make sure your session is fresh. If anything looks wrong, you can restore again from a different backup file.
+
+## Important Notes
+
+- **There is no undo.** Once the restore starts, there's no way to cancel it.
+- **The restore runs asynchronously.** The dashboard confirmation means the job was queued, not that it finished. Wait for the notification email to know whether it succeeded.
+- **Restoring doesn't notify other staff proactively.** If you're restoring due to an incident, let your team know manually.

--- a/resources/library/books/staff-handbook/07-administration/07-backup-management/03-automated-backups.md
+++ b/resources/library/books/staff-handbook/07-administration/07-backup-management/03-automated-backups.md
@@ -1,0 +1,51 @@
+---
+title: 'Automated Backup Schedule'
+visibility: officer
+order: 3
+summary: 'How automatic backups, cleanup, and S3 uploads are scheduled.'
+---
+
+## Overview
+
+The server runs several backup-related tasks automatically. You don't need to manage these day-to-day -- they run on their own. This page explains what's happening and when, so you know what to expect if something looks off.
+
+## What Runs Automatically
+
+| Schedule | What Happens |
+|----------|-------------|
+| Daily at 3:00 AM | New database backup is created and saved locally |
+| Daily at 4:00 AM | Old local backups are deleted (default: files older than 7 days) |
+| Every 3 days at 3:30 AM | Most recent local backup is uploaded to S3 |
+
+The daily backup and cleanup happen regardless of whether S3 is configured. The S3 upload only runs when S3 credentials are set up on the server.
+
+## Email Notifications
+
+When the daily backup job runs, all Backup Manager users receive an email:
+- **"Database Backup Created"** -- backup succeeded, with the filename
+- **"Database Backup Failed"** -- backup failed, with the error message
+
+These notifications only come from the automated schedule -- if you create a backup manually from the dashboard, you won't get an email.
+
+## Local Retention Policy
+
+The server keeps 7 days of local backups by default. Files older than that are deleted automatically during the 4:00 AM cleanup. If you want to keep a backup longer than that, download it to your local machine before it expires.
+
+## S3 Retention Policy
+
+S3 keeps backups on a tiered schedule designed to minimize storage costs while keeping useful recovery points:
+
+- **2 most recent uploads** -- always kept
+- **1 per week** for the past 4 weeks
+- **1 per month** for the past 3 months
+
+Backups older than 3 months with no matching tier are automatically deleted from S3. This runs each time a new backup is uploaded to S3.
+
+## If a Backup Fails
+
+You'll get a failure notification email with the error message. Common causes:
+- The database tool isn't available (`pg_dump`, `mysqldump`)
+- The server is out of disk space in `storage/app/backups/`
+- Permissions issue on the backups directory
+
+If you're getting repeated failure emails, raise it with whoever manages server infrastructure.

--- a/resources/library/books/staff-handbook/07-administration/07-backup-management/_index.md
+++ b/resources/library/books/staff-handbook/07-administration/07-backup-management/_index.md
@@ -1,0 +1,8 @@
+---
+title: 'Backup Management'
+visibility: officer
+order: 7
+summary: 'Creating, downloading, restoring, and managing database backups.'
+---
+
+The Backup Management dashboard gives Backup Managers full control over database backups -- creating them on demand, downloading them for safekeeping, restoring from a previous backup, and monitoring the automated backup schedule.

--- a/resources/library/books/user-handbook/01-getting-started/02-account-setup/02-connecting-discord.md
+++ b/resources/library/books/user-handbook/01-getting-started/02-account-setup/02-connecting-discord.md
@@ -1,6 +1,6 @@
 ---
 title: "Connecting Discord"
-visibility: users
+visibility: public
 order: 2
 summary: "What to do on the Discord setup step and how to complete it."
 ---

--- a/resources/library/books/user-handbook/01-getting-started/02-account-setup/03-waiting-for-approval.md
+++ b/resources/library/books/user-handbook/01-getting-started/02-account-setup/03-waiting-for-approval.md
@@ -1,6 +1,6 @@
 ---
 title: "Waiting for Approval"
-visibility: users
+visibility: public
 order: 3
 summary: "What happens between the Discord step and getting access to the Minecraft server."
 ---

--- a/resources/library/books/user-handbook/01-getting-started/02-account-setup/04-linking-minecraft.md
+++ b/resources/library/books/user-handbook/01-getting-started/02-account-setup/04-linking-minecraft.md
@@ -1,6 +1,6 @@
 ---
 title: "Linking Minecraft"
-visibility: users
+visibility: public
 order: 4
 summary: "What to do on the Minecraft setup step to get whitelisted on the server."
 ---

--- a/resources/library/books/user-handbook/03-website/03-parent-portal/05-cancelled-minecraft-accounts.md
+++ b/resources/library/books/user-handbook/03-website/03-parent-portal/05-cancelled-minecraft-accounts.md
@@ -1,6 +1,6 @@
 ---
 title: 'Handling Cancelled Minecraft Accounts'
-visibility: users
+visibility: public
 order: 5
 summary: 'What to do when your child''s Minecraft account shows a Cancelled or Cancelling Verification status.'
 ---

--- a/resources/library/books/user-handbook/03-website/07-blog/03-uploading-images.md
+++ b/resources/library/books/user-handbook/03-website/07-blog/03-uploading-images.md
@@ -1,6 +1,6 @@
 ---
 title: 'Uploading Images'
-visibility: staff
+visibility: citizen
 order: 3
 summary: 'How to upload and insert images into your blog posts using the image manager.'
 ---

--- a/resources/library/books/user-handbook/03-website/07-blog/03-uploading-images.md
+++ b/resources/library/books/user-handbook/03-website/07-blog/03-uploading-images.md
@@ -1,6 +1,6 @@
 ---
 title: 'Uploading Images'
-visibility: citizen
+visibility: public
 order: 3
 summary: 'How to upload and insert images into your blog posts using the image manager.'
 ---

--- a/resources/library/books/user-handbook/03-website/07-blog/04-browsing-the-image-library.md
+++ b/resources/library/books/user-handbook/03-website/07-blog/04-browsing-the-image-library.md
@@ -1,6 +1,6 @@
 ---
 title: 'Browsing the Image Library'
-visibility: citizen
+visibility: public
 order: 4
 summary: 'How to browse, search, and reuse images from the shared image library.'
 ---

--- a/resources/library/books/user-handbook/03-website/07-blog/04-browsing-the-image-library.md
+++ b/resources/library/books/user-handbook/03-website/07-blog/04-browsing-the-image-library.md
@@ -1,6 +1,6 @@
 ---
 title: 'Browsing the Image Library'
-visibility: staff
+visibility: citizen
 order: 4
 summary: 'How to browse, search, and reuse images from the shared image library.'
 ---

--- a/resources/library/books/user-handbook/03-website/07-blog/05-hero-and-og-images.md
+++ b/resources/library/books/user-handbook/03-website/07-blog/05-hero-and-og-images.md
@@ -1,6 +1,6 @@
 ---
 title: 'Hero and OG Images'
-visibility: citizen
+visibility: public
 order: 5
 summary: 'How to set a hero image and social sharing image for your blog posts.'
 ---

--- a/resources/library/books/user-handbook/03-website/07-blog/05-hero-and-og-images.md
+++ b/resources/library/books/user-handbook/03-website/07-blog/05-hero-and-og-images.md
@@ -1,6 +1,6 @@
 ---
 title: 'Hero and OG Images'
-visibility: staff
+visibility: citizen
 order: 5
 summary: 'How to set a hero image and social sharing image for your blog posts.'
 ---

--- a/resources/library/books/user-handbook/06-community-policies/02-community-rules/02-agreeing-to-the-rules.md
+++ b/resources/library/books/user-handbook/06-community-policies/02-community-rules/02-agreeing-to-the-rules.md
@@ -1,6 +1,6 @@
 ---
 title: "Agreeing to the Rules"
-visibility: users
+visibility: public
 order: 2
 summary: "How to read and agree to the Community Rules as a new or returning member."
 ---

--- a/resources/views/dashboard/ready-room.blade.php
+++ b/resources/views/dashboard/ready-room.blade.php
@@ -25,6 +25,11 @@
                     Vault
                 </flux:button>
             @endcan
+            @can('backup-manager')
+                <flux:button href="{{ route('backups.index') }}" wire:navigate icon="circle-stack">
+                    Backups
+                </flux:button>
+            @endcan
         </div>
     </div>
 

--- a/resources/views/livewire/backup/dashboard.blade.php
+++ b/resources/views/livewire/backup/dashboard.blade.php
@@ -32,6 +32,16 @@ new class extends Component
         $this->offlineDuringRestore = SiteConfig::getValue('backup.offline_during_restore', 'true') === 'true';
     }
 
+    private function validateBackupFilename(string $filename): string
+    {
+        abort_unless(
+            preg_match('/\A[a-zA-Z0-9._-]+\.sql\.gz\z/', $filename) === 1,
+            404
+        );
+
+        return $filename;
+    }
+
     #[\Livewire\Attributes\Computed]
     public function localBackups(): array
     {
@@ -127,9 +137,9 @@ new class extends Component
             'uploadFile' => ['required', 'file', 'mimes:gz', 'max:524288'], // 512 MB
         ]);
 
-        $originalName = $this->uploadFile->getClientOriginalName();
+        $originalName = basename($this->uploadFile->getClientOriginalName());
 
-        if (! str_ends_with($originalName, '.sql.gz')) {
+        if (! str_ends_with($originalName, '.sql.gz') || preg_match('/\A[a-zA-Z0-9._-]+\.sql\.gz\z/', $originalName) !== 1) {
             $this->addError('uploadFile', 'File must be a .sql.gz backup file.');
 
             return;
@@ -149,6 +159,7 @@ new class extends Component
     public function download(string $filename): StreamedResponse
     {
         $this->authorize('backup-manager');
+        $filename = $this->validateBackupFilename($filename);
 
         $path = storage_path("app/backups/{$filename}");
         abort_if(! file_exists($path), 404);
@@ -161,6 +172,7 @@ new class extends Component
     public function downloadFromS3(string $filename): StreamedResponse
     {
         $this->authorize('backup-manager');
+        $filename = $this->validateBackupFilename($filename);
 
         $key = "backups/{$filename}";
 
@@ -176,7 +188,7 @@ new class extends Component
 
     public function confirmRestore(string $filename): void
     {
-        $this->restoreTarget = $filename;
+        $this->restoreTarget = $this->validateBackupFilename($filename);
         Flux::modal('confirm-restore')->show();
     }
 
@@ -188,6 +200,7 @@ new class extends Component
             return;
         }
 
+        $this->validateBackupFilename($this->restoreTarget);
         $path = storage_path("app/backups/{$this->restoreTarget}");
         abort_if(! file_exists($path), 404);
 
@@ -199,7 +212,7 @@ new class extends Component
 
     public function confirmDelete(string $filename): void
     {
-        $this->deleteTarget = $filename;
+        $this->deleteTarget = $this->validateBackupFilename($filename);
         Flux::modal('confirm-delete')->show();
     }
 
@@ -211,6 +224,7 @@ new class extends Component
             return;
         }
 
+        $this->validateBackupFilename($this->deleteTarget);
         $path = storage_path("app/backups/{$this->deleteTarget}");
         if (file_exists($path)) {
             unlink($path);
@@ -224,7 +238,7 @@ new class extends Component
 
     public function confirmDeleteS3(string $filename): void
     {
-        $this->deleteS3Target = $filename;
+        $this->deleteS3Target = $this->validateBackupFilename($filename);
         Flux::modal('confirm-delete-s3')->show();
     }
 
@@ -236,6 +250,7 @@ new class extends Component
             return;
         }
 
+        $this->validateBackupFilename($this->deleteS3Target);
         app(BackupStorageService::class)->delete("backups/{$this->deleteS3Target}");
 
         $this->deleteS3Target = null;

--- a/resources/views/livewire/backup/dashboard.blade.php
+++ b/resources/views/livewire/backup/dashboard.blade.php
@@ -285,7 +285,7 @@ new class extends Component
     }
 }; ?>
 
-<x-layouts.app>
+<div>
     <div class="mb-6 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
         <flux:heading size="xl">Backup Management</flux:heading>
         <flux:button href="{{ route('ready-room.index') }}" wire:navigate icon="arrow-left">
@@ -501,4 +501,4 @@ new class extends Component
             <flux:button variant="danger" wire:click="deleteS3Backup">Delete</flux:button>
         </div>
     </flux:modal>
-</x-layouts.app>
+</div>

--- a/resources/views/livewire/backup/dashboard.blade.php
+++ b/resources/views/livewire/backup/dashboard.blade.php
@@ -1,0 +1,167 @@
+<?php
+
+use App\Jobs\CreateBackupJob;
+use Flux\Flux;
+use Livewire\Volt\Component;
+use Symfony\Component\HttpFoundation\StreamedResponse;
+
+new class extends Component
+{
+    public ?string $deleteTarget = null;
+
+    public function mount(): void
+    {
+        $this->authorize('backup-manager');
+    }
+
+    #[\Livewire\Attributes\Computed]
+    public function localBackups(): array
+    {
+        $dir = storage_path('app/backups');
+        $files = glob("{$dir}/*.sql.gz") ?: [];
+
+        usort($files, fn ($a, $b) => filemtime($b) - filemtime($a));
+
+        return array_map(function ($path) {
+            $filename = basename($path);
+
+            preg_match('/_(pgsql|mysql|sqlite)\.sql\.gz$/', $filename, $m);
+            $dbType = $m[1] ?? 'unknown';
+
+            return [
+                'filename' => $filename,
+                'size'     => $this->formatBytes(filesize($path)),
+                'date'     => \Carbon\Carbon::createFromTimestamp(filemtime($path))->format('Y-m-d H:i'),
+                'db_type'  => $dbType,
+            ];
+        }, $files);
+    }
+
+    public function createBackup(): void
+    {
+        $this->authorize('backup-manager');
+        CreateBackupJob::dispatch();
+        Flux::toast('Backup job queued.', 'Success', variant: 'success');
+    }
+
+    public function download(string $filename): StreamedResponse
+    {
+        $this->authorize('backup-manager');
+
+        $path = storage_path("app/backups/{$filename}");
+
+        abort_if(! file_exists($path), 404);
+
+        return response()->streamDownload(function () use ($path) {
+            readfile($path);
+        }, $filename, ['Content-Type' => 'application/gzip']);
+    }
+
+    public function confirmDelete(string $filename): void
+    {
+        $this->deleteTarget = $filename;
+        Flux::modal('confirm-delete')->show();
+    }
+
+    public function deleteBackup(): void
+    {
+        $this->authorize('backup-manager');
+
+        if ($this->deleteTarget === null) {
+            return;
+        }
+
+        $path = storage_path("app/backups/{$this->deleteTarget}");
+
+        if (file_exists($path)) {
+            unlink($path);
+        }
+
+        $this->deleteTarget = null;
+        Flux::modal('confirm-delete')->close();
+        Flux::toast('Backup deleted.', 'Done', variant: 'success');
+        unset($this->localBackups);
+    }
+
+    private function formatBytes(int $bytes): string
+    {
+        if ($bytes >= 1_048_576) {
+            return number_format($bytes / 1_048_576, 1).' MB';
+        }
+
+        if ($bytes >= 1_024) {
+            return number_format($bytes / 1_024, 1).' KB';
+        }
+
+        return $bytes.' B';
+    }
+}; ?>
+
+<x-layouts.app>
+    <div class="mb-6 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <flux:heading size="xl">Backup Management</flux:heading>
+        <flux:button href="{{ route('ready-room.index') }}" wire:navigate icon="arrow-left">
+            Back to Ready Room
+        </flux:button>
+    </div>
+
+    {{-- Local Backups Panel --}}
+    <flux:card class="mb-6">
+        <div class="flex items-center justify-between mb-4">
+            <flux:heading size="lg">Local Backups</flux:heading>
+            <flux:button variant="primary" icon="plus" wire:click="createBackup">
+                Create Backup Now
+            </flux:button>
+        </div>
+
+        @if (count($this->localBackups) === 0)
+            <p class="text-sm text-zinc-500 dark:text-zinc-400">No local backups found.</p>
+        @else
+            <flux:table>
+                <flux:table.columns>
+                    <flux:table.column>Filename</flux:table.column>
+                    <flux:table.column>DB Type</flux:table.column>
+                    <flux:table.column>Size</flux:table.column>
+                    <flux:table.column>Created</flux:table.column>
+                    <flux:table.column></flux:table.column>
+                </flux:table.columns>
+                <flux:table.rows>
+                    @foreach ($this->localBackups as $backup)
+                        <flux:table.row wire:key="backup-{{ $backup['filename'] }}">
+                            <flux:table.cell class="font-mono text-sm">{{ $backup['filename'] }}</flux:table.cell>
+                            <flux:table.cell>
+                                <flux:badge size="sm" color="blue">{{ $backup['db_type'] }}</flux:badge>
+                            </flux:table.cell>
+                            <flux:table.cell>{{ $backup['size'] }}</flux:table.cell>
+                            <flux:table.cell>{{ $backup['date'] }}</flux:table.cell>
+                            <flux:table.cell>
+                                <div class="flex gap-2">
+                                    <flux:button size="sm" icon="arrow-down-tray" wire:click="download('{{ $backup['filename'] }}')">
+                                        Download
+                                    </flux:button>
+                                    <flux:button size="sm" variant="danger" icon="trash" wire:click="confirmDelete('{{ $backup['filename'] }}')">
+                                        Delete
+                                    </flux:button>
+                                </div>
+                            </flux:table.cell>
+                        </flux:table.row>
+                    @endforeach
+                </flux:table.rows>
+            </flux:table>
+        @endif
+    </flux:card>
+
+    {{-- Delete Confirmation Modal --}}
+    <flux:modal name="confirm-delete" class="w-full max-w-md">
+        <flux:heading size="lg">Delete Backup</flux:heading>
+        <p class="mt-2 text-sm text-zinc-600 dark:text-zinc-400">
+            Are you sure you want to permanently delete
+            <span class="font-mono font-semibold">{{ $deleteTarget }}</span>?
+            This cannot be undone.
+        </p>
+        <div class="mt-4 flex justify-end gap-2">
+            <flux:button x-on:click="$flux.modal('confirm-delete').close()">Cancel</flux:button>
+            <flux:button variant="danger" wire:click="deleteBackup">Delete</flux:button>
+        </div>
+    </flux:modal>
+</x-layouts.app>

--- a/resources/views/livewire/backup/dashboard.blade.php
+++ b/resources/views/livewire/backup/dashboard.blade.php
@@ -3,7 +3,9 @@
 use App\Jobs\CreateBackupJob;
 use App\Jobs\RestoreBackupJob;
 use App\Models\SiteConfig;
+use App\Services\BackupStorageService;
 use Flux\Flux;
+use Illuminate\Support\Facades\Storage;
 use Livewire\Volt\Component;
 use Livewire\WithFileUploads;
 use Symfony\Component\HttpFoundation\StreamedResponse;
@@ -12,8 +14,9 @@ new class extends Component
 {
     use WithFileUploads;
 
-    public ?string $deleteTarget  = null;
-    public ?string $restoreTarget = null;
+    public ?string $deleteTarget    = null;
+    public ?string $restoreTarget   = null;
+    public ?string $deleteS3Target  = null;
 
     // Settings
     public bool $offlineDuringBackup  = false;
@@ -48,6 +51,65 @@ new class extends Component
                 'db_type'  => $m[1] ?? 'unknown',
             ];
         }, $files);
+    }
+
+    #[\Livewire\Attributes\Computed]
+    public function s3Configured(): bool
+    {
+        return app(BackupStorageService::class)->isConfigured();
+    }
+
+    #[\Livewire\Attributes\Computed]
+    public function s3Connected(): bool
+    {
+        return app(BackupStorageService::class)->isConnected();
+    }
+
+    #[\Livewire\Attributes\Computed]
+    public function s3Backups(): array
+    {
+        if (! $this->s3Connected) {
+            return [];
+        }
+
+        return app(BackupStorageService::class)->listWithMetadata();
+    }
+
+    #[\Livewire\Attributes\Computed]
+    public function storageStats(): array
+    {
+        $publicDisk = config('filesystems.public_disk', 'public');
+
+        $directories = [
+            'Staff Photos'        => 'staff-photos',
+            'Board Member Photos' => 'board-member-photos',
+            'Community Stories'   => 'community-stories',
+            'Message Images'      => 'message-images',
+            'Report Evidence'     => 'report-evidence',
+            'Blog Images'         => 'blog/images',
+            'Blog Category Hero'  => 'blog/category-hero',
+        ];
+
+        $stats = [];
+
+        foreach ($directories as $label => $dir) {
+            $files     = Storage::disk($publicDisk)->allFiles($dir);
+            $count     = count($files);
+            $totalSize = 0;
+
+            foreach ($files as $file) {
+                $totalSize += Storage::disk($publicDisk)->size($file);
+            }
+
+            $stats[] = [
+                'label'      => $label,
+                'directory'  => $dir,
+                'count'      => $count,
+                'total_size' => $this->formatBytes($totalSize),
+            ];
+        }
+
+        return $stats;
     }
 
     public function createBackup(): void
@@ -93,6 +155,22 @@ new class extends Component
 
         return response()->streamDownload(function () use ($path) {
             readfile($path);
+        }, $filename, ['Content-Type' => 'application/gzip']);
+    }
+
+    public function downloadFromS3(string $filename): StreamedResponse
+    {
+        $this->authorize('backup-manager');
+
+        $key = "backups/{$filename}";
+
+        return response()->streamDownload(function () use ($key) {
+            $stream = Storage::disk('s3')->readStream($key);
+            if ($stream === null) {
+                abort(404);
+            }
+            fpassthru($stream);
+            fclose($stream);
         }, $filename, ['Content-Type' => 'application/gzip']);
     }
 
@@ -142,6 +220,28 @@ new class extends Component
         Flux::modal('confirm-delete')->close();
         Flux::toast('Backup deleted.', 'Done', variant: 'success');
         unset($this->localBackups);
+    }
+
+    public function confirmDeleteS3(string $filename): void
+    {
+        $this->deleteS3Target = $filename;
+        Flux::modal('confirm-delete-s3')->show();
+    }
+
+    public function deleteS3Backup(): void
+    {
+        $this->authorize('backup-manager');
+
+        if ($this->deleteS3Target === null) {
+            return;
+        }
+
+        app(BackupStorageService::class)->delete("backups/{$this->deleteS3Target}");
+
+        $this->deleteS3Target = null;
+        Flux::modal('confirm-delete-s3')->close();
+        Flux::toast('S3 backup deleted.', 'Done', variant: 'success');
+        unset($this->s3Backups);
     }
 
     public function updatedOfflineDuringBackup(bool $value): void
@@ -227,6 +327,58 @@ new class extends Component
         @endif
     </flux:card>
 
+    {{-- S3 Backups Panel --}}
+    <flux:card class="mb-6">
+        <div class="flex items-center justify-between mb-4">
+            <flux:heading size="lg">S3 Backups</flux:heading>
+            @if ($this->s3Configured)
+                @if ($this->s3Connected)
+                    <flux:badge color="green" icon="check-circle">S3 Connected</flux:badge>
+                @else
+                    <flux:badge color="red" icon="exclamation-triangle">S3 Unreachable</flux:badge>
+                @endif
+            @else
+                <flux:badge color="zinc" icon="exclamation-circle">S3 Not Configured</flux:badge>
+            @endif
+        </div>
+
+        @if (! $this->s3Configured)
+            <p class="text-sm text-zinc-500 dark:text-zinc-400">S3 is not configured. Set <code>AWS_ACCESS_KEY_ID</code> and <code>AWS_S3_BUCKET</code> to enable S3 backups.</p>
+        @elseif (! $this->s3Connected)
+            <p class="text-sm text-red-500">Unable to connect to S3. Check credentials and bucket configuration.</p>
+        @elseif (count($this->s3Backups) === 0)
+            <p class="text-sm text-zinc-500 dark:text-zinc-400">No S3 backups found.</p>
+        @else
+            <flux:table>
+                <flux:table.columns>
+                    <flux:table.column>Filename</flux:table.column>
+                    <flux:table.column>Size</flux:table.column>
+                    <flux:table.column>Stored</flux:table.column>
+                    <flux:table.column></flux:table.column>
+                </flux:table.columns>
+                <flux:table.rows>
+                    @foreach ($this->s3Backups as $backup)
+                        <flux:table.row wire:key="s3-{{ $backup['filename'] }}">
+                            <flux:table.cell class="font-mono text-sm">{{ $backup['filename'] }}</flux:table.cell>
+                            <flux:table.cell>{{ $backup['size'] }}</flux:table.cell>
+                            <flux:table.cell>{{ $backup['date'] }}</flux:table.cell>
+                            <flux:table.cell>
+                                <div class="flex gap-2">
+                                    <flux:button size="sm" icon="arrow-down-tray" wire:click="downloadFromS3('{{ $backup['filename'] }}')">
+                                        Download
+                                    </flux:button>
+                                    <flux:button size="sm" variant="danger" icon="trash" wire:click="confirmDeleteS3('{{ $backup['filename'] }}')">
+                                        Delete
+                                    </flux:button>
+                                </div>
+                            </flux:table.cell>
+                        </flux:table.row>
+                    @endforeach
+                </flux:table.rows>
+            </flux:table>
+        @endif
+    </flux:card>
+
     {{-- Upload Panel --}}
     <flux:card class="mb-6">
         <flux:heading size="lg" class="mb-4">Upload Backup</flux:heading>
@@ -246,6 +398,30 @@ new class extends Component
                 Upload
             </flux:button>
         </form>
+    </flux:card>
+
+    {{-- Storage Stats Panel --}}
+    <flux:card class="mb-6">
+        <flux:heading size="lg" class="mb-4">File Asset Storage</flux:heading>
+        <p class="text-sm text-zinc-500 dark:text-zinc-400 mb-4">File counts and sizes for each public asset directory.</p>
+        <flux:table>
+            <flux:table.columns>
+                <flux:table.column>Directory</flux:table.column>
+                <flux:table.column>Path</flux:table.column>
+                <flux:table.column>Files</flux:table.column>
+                <flux:table.column>Total Size</flux:table.column>
+            </flux:table.columns>
+            <flux:table.rows>
+                @foreach ($this->storageStats as $stat)
+                    <flux:table.row wire:key="stat-{{ $stat['directory'] }}">
+                        <flux:table.cell>{{ $stat['label'] }}</flux:table.cell>
+                        <flux:table.cell class="font-mono text-sm text-zinc-500">{{ $stat['directory'] }}</flux:table.cell>
+                        <flux:table.cell>{{ number_format($stat['count']) }}</flux:table.cell>
+                        <flux:table.cell>{{ $stat['total_size'] }}</flux:table.cell>
+                    </flux:table.row>
+                @endforeach
+            </flux:table.rows>
+        </flux:table>
     </flux:card>
 
     {{-- Settings Panel --}}
@@ -294,6 +470,20 @@ new class extends Component
         <div class="mt-4 flex justify-end gap-2">
             <flux:button x-on:click="$flux.modal('confirm-delete').close()">Cancel</flux:button>
             <flux:button variant="danger" wire:click="deleteBackup">Delete</flux:button>
+        </div>
+    </flux:modal>
+
+    {{-- S3 Delete Confirmation Modal --}}
+    <flux:modal name="confirm-delete-s3" class="w-full max-w-md">
+        <flux:heading size="lg">Delete S3 Backup</flux:heading>
+        <p class="mt-2 text-sm text-zinc-600 dark:text-zinc-400">
+            Are you sure you want to permanently delete
+            <span class="font-mono font-semibold">{{ $deleteS3Target }}</span>
+            from S3? This cannot be undone.
+        </p>
+        <div class="mt-4 flex justify-end gap-2">
+            <flux:button x-on:click="$flux.modal('confirm-delete-s3').close()">Cancel</flux:button>
+            <flux:button variant="danger" wire:click="deleteS3Backup">Delete</flux:button>
         </div>
     </flux:modal>
 </x-layouts.app>

--- a/resources/views/livewire/backup/dashboard.blade.php
+++ b/resources/views/livewire/backup/dashboard.blade.php
@@ -373,7 +373,7 @@ new class extends Component
                 @elseif ($jobStatus['status'] === 'running')
                     <flux:badge color="blue" icon="arrow-path">Running{{ $jobStatus['updated_at'] ? ' · '.$jobStatus['updated_at'] : '' }}</flux:badge>
                 @elseif ($jobStatus['status'] === 'completed')
-                    <flux:badge color="green" icon="check-circle">Completed{{ $jobStatus['updated_at'] ? ' · '.$jobStatus['updated_at'] : '' }}{{ $jobStatus['filename'] ? ' — '.$jobStatus['filename'] : '' }}</flux:badge>
+                    <flux:badge color="green" icon="check-circle">Completed{{ $jobStatus['updated_at'] ? ' · '.$jobStatus['updated_at'] : '' }}</flux:badge>
                 @elseif ($jobStatus['status'] === 'failed')
                     <flux:badge color="red" icon="exclamation-triangle">Failed{{ $jobStatus['updated_at'] ? ' · '.$jobStatus['updated_at'] : '' }}</flux:badge>
                 @endif

--- a/resources/views/livewire/backup/dashboard.blade.php
+++ b/resources/views/livewire/backup/dashboard.blade.php
@@ -207,7 +207,16 @@ new class extends Component
             mkdir($dir, 0755, true);
         }
 
-        $this->uploadFile->storeAs('backups', $originalName, 'local');
+        $src  = $this->uploadFile->getRealPath();
+        $dest = "{$dir}/{$originalName}";
+
+        if (! copy($src, $dest)) {
+            $this->addError('uploadFile', 'Failed to save the uploaded file. Check storage permissions.');
+
+            return;
+        }
+
+        @chmod($dest, 0644);
         $this->uploadFile = null;
         unset($this->localBackups);
         Flux::toast("Uploaded {$originalName}.", 'Done', variant: 'success');

--- a/resources/views/livewire/backup/dashboard.blade.php
+++ b/resources/views/livewire/backup/dashboard.blade.php
@@ -143,11 +143,15 @@ new class extends Component
         $status    = SiteConfig::getValue('backup.last_job_status');
         $updatedAt = SiteConfig::getValue('backup.last_job_updated_at');
         $filename  = SiteConfig::getValue('backup.last_job_filename');
+        $fullPath  = SiteConfig::getValue('backup.last_job_full_path');
 
         return [
             'status'     => $status,
             'updated_at' => $updatedAt ? \Carbon\Carbon::parse($updatedAt)->diffForHumans() : null,
             'filename'   => $filename,
+            'full_path'  => $fullPath,
+            'path_exists' => $fullPath ? file_exists($fullPath) : null,
+            'scan_dir'   => storage_path('app/backups'),
         ];
     }
 
@@ -359,6 +363,14 @@ new class extends Component
 
         @if (count($this->localBackups) === 0)
             <p class="text-sm text-zinc-500 dark:text-zinc-400">No local backups found.</p>
+            @if ($jobStatus['status'] === 'completed' && $jobStatus['filename'])
+                <div class="mt-3 rounded border border-yellow-300 bg-yellow-50 dark:bg-yellow-900/20 dark:border-yellow-700 p-3 text-sm space-y-1">
+                    <p class="font-medium text-yellow-800 dark:text-yellow-300">Backup was reported as completed but the file is not visible here.</p>
+                    <p class="text-yellow-700 dark:text-yellow-400">File created by worker: <code class="font-mono">{{ $jobStatus['full_path'] ?? 'unknown' }}</code></p>
+                    <p class="text-yellow-700 dark:text-yellow-400">Scanning for files in: <code class="font-mono">{{ $jobStatus['scan_dir'] }}</code></p>
+                    <p class="text-yellow-700 dark:text-yellow-400">File exists at worker path: <strong>{{ $jobStatus['path_exists'] === true ? 'Yes' : ($jobStatus['path_exists'] === false ? 'No — path mismatch between queue worker and web process' : 'Unknown') }}</strong></p>
+                </div>
+            @endif
         @else
             <flux:table>
                 <flux:table.columns>

--- a/resources/views/livewire/backup/dashboard.blade.php
+++ b/resources/views/livewire/backup/dashboard.blade.php
@@ -280,6 +280,12 @@ new class extends Component
     {
         $this->authorize('backup-manager');
 
+        if (app()->environment('production')) {
+            Flux::toast('Restore is disabled in production. Set APP_ENV=backup-restore in .env to enable an emergency restore.', 'Blocked', variant: 'danger');
+
+            return;
+        }
+
         if ($this->restoreTarget === null) {
             return;
         }

--- a/resources/views/livewire/backup/dashboard.blade.php
+++ b/resources/views/livewire/backup/dashboard.blade.php
@@ -142,10 +142,12 @@ new class extends Component
     {
         $status    = SiteConfig::getValue('backup.last_job_status');
         $updatedAt = SiteConfig::getValue('backup.last_job_updated_at');
+        $filename  = SiteConfig::getValue('backup.last_job_filename');
 
         return [
             'status'     => $status,
             'updated_at' => $updatedAt ? \Carbon\Carbon::parse($updatedAt)->diffForHumans() : null,
+            'filename'   => $filename,
         ];
     }
 
@@ -329,8 +331,9 @@ new class extends Component
         </flux:button>
     </div>
 
-    {{-- Poll while a job is in-flight --}}
-    @if (in_array($this->backupJobStatus['status'], ['queued', 'running']))
+    {{-- Poll while a job is in-flight, and one extra cycle after completion to refresh the file list --}}
+    @php $jobStatus = $this->backupJobStatus; @endphp
+    @if (in_array($jobStatus['status'], ['queued', 'running']) || ($jobStatus['status'] === 'completed' && ! collect($this->localBackups)->contains('filename', $jobStatus['filename'])))
         <div wire:poll.3s></div>
     @endif
 
@@ -339,13 +342,12 @@ new class extends Component
         <div class="flex items-center justify-between mb-4">
             <div class="flex items-center gap-3">
                 <flux:heading size="lg">Local Backups</flux:heading>
-                @php $jobStatus = $this->backupJobStatus; @endphp
                 @if ($jobStatus['status'] === 'queued')
                     <flux:badge color="yellow" icon="clock">Queued{{ $jobStatus['updated_at'] ? ' · '.$jobStatus['updated_at'] : '' }}</flux:badge>
                 @elseif ($jobStatus['status'] === 'running')
                     <flux:badge color="blue" icon="arrow-path">Running{{ $jobStatus['updated_at'] ? ' · '.$jobStatus['updated_at'] : '' }}</flux:badge>
                 @elseif ($jobStatus['status'] === 'completed')
-                    <flux:badge color="green" icon="check-circle">Completed{{ $jobStatus['updated_at'] ? ' · '.$jobStatus['updated_at'] : '' }}</flux:badge>
+                    <flux:badge color="green" icon="check-circle">Completed{{ $jobStatus['updated_at'] ? ' · '.$jobStatus['updated_at'] : '' }}{{ $jobStatus['filename'] ? ' — '.$jobStatus['filename'] : '' }}</flux:badge>
                 @elseif ($jobStatus['status'] === 'failed')
                     <flux:badge color="red" icon="exclamation-triangle">Failed{{ $jobStatus['updated_at'] ? ' · '.$jobStatus['updated_at'] : '' }}</flux:badge>
                 @endif

--- a/resources/views/livewire/backup/dashboard.blade.php
+++ b/resources/views/livewire/backup/dashboard.blade.php
@@ -372,14 +372,29 @@ new class extends Component
         @if (count($this->localBackups) === 0)
             <p class="text-sm text-zinc-500 dark:text-zinc-400">No local backups found.</p>
             @if ($jobStatus['status'] === 'completed' && $jobStatus['filename'])
-                <div class="mt-3 rounded border border-yellow-300 bg-yellow-50 dark:bg-yellow-900/20 dark:border-yellow-700 p-3 text-sm space-y-1">
-                    <p class="font-medium text-yellow-800 dark:text-yellow-300">Backup was reported as completed but the file is not visible here.</p>
-                    <p class="text-yellow-700 dark:text-yellow-400">File created by worker: <code class="font-mono">{{ $jobStatus['full_path'] ?? 'unknown' }}</code></p>
-                    <p class="text-yellow-700 dark:text-yellow-400">Scanning for files in: <code class="font-mono">{{ $jobStatus['scan_dir'] }}</code></p>
-                    <p class="text-yellow-700 dark:text-yellow-400">Scan dir exists (web): <strong>{{ $jobStatus['scan_dir_exists'] ? 'Yes' : 'No — directory not visible to web process' }}</strong></p>
-                    <p class="text-yellow-700 dark:text-yellow-400">Files visible via scandir: <strong>{{ $jobStatus['scan_dir_contents'] }}</strong></p>
-                    <p class="text-yellow-700 dark:text-yellow-400">open_basedir: <code class="font-mono">{{ $jobStatus['open_basedir'] ?: '(not set)' }}</code></p>
-                </div>
+                @if (! $jobStatus['scan_dir_exists'])
+                    <div class="mt-3 rounded border border-yellow-300 bg-yellow-50 dark:bg-yellow-900/20 dark:border-yellow-700 p-3 text-sm space-y-2">
+                        <p class="font-medium text-yellow-800 dark:text-yellow-300">Local backup storage is not shared between the queue worker and web server.</p>
+                        <p class="text-yellow-700 dark:text-yellow-400">
+                            The worker successfully created <code class="font-mono">{{ $jobStatus['filename'] }}</code>, but the web process cannot see the
+                            <code class="font-mono">{{ $jobStatus['scan_dir'] }}</code> directory at all. This happens when the worker and web containers
+                            have separate filesystems (e.g. Docker containers without a shared storage volume).
+                        </p>
+                        <p class="text-yellow-700 dark:text-yellow-400">
+                            <strong>Fix:</strong> Mount the same volume for <code class="font-mono">storage/app</code> in both your web and worker containers.
+                            Until then, use <strong>S3 Backups</strong> — they are shared across all processes and already scheduled automatically.
+                        </p>
+                    </div>
+                @else
+                    <div class="mt-3 rounded border border-yellow-300 bg-yellow-50 dark:bg-yellow-900/20 dark:border-yellow-700 p-3 text-sm space-y-1">
+                        <p class="font-medium text-yellow-800 dark:text-yellow-300">Backup completed but file is not visible here.</p>
+                        <p class="text-yellow-700 dark:text-yellow-400">Worker path: <code class="font-mono">{{ $jobStatus['full_path'] ?? 'unknown' }}</code></p>
+                        <p class="text-yellow-700 dark:text-yellow-400">Files in scan dir: {{ $jobStatus['scan_dir_contents'] }}</p>
+                        @if ($jobStatus['open_basedir'])
+                            <p class="text-yellow-700 dark:text-yellow-400">open_basedir restriction: <code class="font-mono">{{ $jobStatus['open_basedir'] }}</code></p>
+                        @endif
+                    </div>
+                @endif
             @endif
         @else
             <flux:table>

--- a/resources/views/livewire/backup/dashboard.blade.php
+++ b/resources/views/livewire/backup/dashboard.blade.php
@@ -14,12 +14,15 @@ new class extends Component
 {
     use WithFileUploads;
 
-    public ?string $deleteTarget    = null;
-    public ?string $restoreTarget   = null;
-    public ?string $deleteS3Target  = null;
+    public ?string $deleteTarget = null;
+
+    public ?string $restoreTarget = null;
+
+    public ?string $deleteS3Target = null;
 
     // Settings
-    public bool $offlineDuringBackup  = false;
+    public bool $offlineDuringBackup = false;
+
     public bool $offlineDuringRestore = true;
 
     // Upload
@@ -28,7 +31,7 @@ new class extends Component
     public function mount(): void
     {
         $this->authorize('backup-manager');
-        $this->offlineDuringBackup  = SiteConfig::getValue('backup.offline_during_backup', 'false') === 'true';
+        $this->offlineDuringBackup = SiteConfig::getValue('backup.offline_during_backup', 'false') === 'true';
         $this->offlineDuringRestore = SiteConfig::getValue('backup.offline_during_restore', 'true') === 'true';
     }
 
@@ -45,7 +48,7 @@ new class extends Component
     #[\Livewire\Attributes\Computed]
     public function localBackups(): array
     {
-        $dir   = storage_path('app/backups');
+        $dir = storage_path('app/backups');
         $files = glob("{$dir}/*.sql.gz") ?: [];
 
         usort($files, fn ($a, $b) => filemtime($b) - filemtime($a));
@@ -56,9 +59,9 @@ new class extends Component
 
             return [
                 'filename' => $filename,
-                'size'     => $this->formatBytes(filesize($path)),
-                'date'     => \Carbon\Carbon::createFromTimestamp(filemtime($path))->format('Y-m-d H:i'),
-                'db_type'  => $m[1] ?? 'unknown',
+                'size' => $this->formatBytes(filesize($path)),
+                'date' => \Carbon\Carbon::createFromTimestamp(filemtime($path))->format('Y-m-d H:i'),
+                'db_type' => $m[1] ?? 'unknown',
             ];
         }, $files);
     }
@@ -89,34 +92,34 @@ new class extends Component
     public function storageStats(): array
     {
         $directories = [
-            'Staff Photos'        => 'staff-photos',
+            'Staff Photos' => 'staff-photos',
             'Board Member Photos' => 'board-member-photos',
-            'Community Stories'   => 'community-stories',
-            'Message Images'      => 'message-images',
-            'Report Evidence'     => 'report-evidence',
-            'Blog Images'         => 'blog/images',
-            'Blog Category Hero'  => 'blog/category-hero',
+            'Community Stories' => 'community-stories',
+            'Message Images' => 'message-images',
+            'Report Evidence' => 'report-evidence',
+            'Blog Images' => 'blog/images',
+            'Blog Category Hero' => 'blog/category-hero',
         ];
 
         $s3Available = $this->s3Connected;
-        $stats       = [];
+        $stats = [];
 
         foreach ($directories as $label => $dir) {
-            $localFiles    = Storage::disk('public')->allFiles($dir);
-            $localCount    = count($localFiles);
-            $localSize     = 0;
+            $localFiles = Storage::disk('public')->allFiles($dir);
+            $localCount = count($localFiles);
+            $localSize = 0;
 
             foreach ($localFiles as $file) {
                 $localSize += Storage::disk('public')->size($file);
             }
 
             $s3Count = null;
-            $s3Size  = null;
+            $s3Size = null;
 
             if ($s3Available) {
                 $s3Files = Storage::disk('s3')->allFiles($dir);
                 $s3Count = count($s3Files);
-                $raw     = 0;
+                $raw = 0;
                 foreach ($s3Files as $file) {
                     $raw += Storage::disk('s3')->size($file);
                 }
@@ -124,12 +127,12 @@ new class extends Component
             }
 
             $stats[] = [
-                'label'       => $label,
-                'directory'   => $dir,
+                'label' => $label,
+                'directory' => $dir,
                 'local_count' => $localCount,
-                'local_size'  => $this->formatBytes($localSize),
-                's3_count'    => $s3Count,
-                's3_size'     => $s3Size,
+                'local_size' => $this->formatBytes($localSize),
+                's3_count' => $s3Count,
+                's3_size' => $s3Size,
             ];
         }
 
@@ -139,26 +142,26 @@ new class extends Component
     #[\Livewire\Attributes\Computed]
     public function backupJobStatus(): array
     {
-        $status    = SiteConfig::getValue('backup.last_job_status');
+        $status = SiteConfig::getValue('backup.last_job_status');
         $updatedAt = SiteConfig::getValue('backup.last_job_updated_at');
-        $filename  = SiteConfig::getValue('backup.last_job_filename');
-        $fullPath  = SiteConfig::getValue('backup.last_job_full_path');
+        $filename = SiteConfig::getValue('backup.last_job_filename');
+        $fullPath = SiteConfig::getValue('backup.last_job_full_path');
 
-        $scanDir      = storage_path('app/backups');
+        $scanDir = storage_path('app/backups');
         $scanDirExists = is_dir($scanDir);
         $scanContents = $scanDirExists ? (scandir($scanDir) ?: []) : [];
         $scanContents = array_values(array_filter($scanContents, fn ($f) => ! in_array($f, ['.', '..'])));
 
         return [
-            'status'           => $status,
-            'updated_at'       => $updatedAt ? \Carbon\Carbon::parse($updatedAt)->diffForHumans() : null,
-            'filename'         => $filename,
-            'full_path'        => $fullPath,
-            'path_exists'      => $fullPath ? file_exists($fullPath) : null,
-            'scan_dir'         => $scanDir,
-            'scan_dir_exists'  => $scanDirExists,
+            'status' => $status,
+            'updated_at' => $updatedAt ? \Carbon\Carbon::parse($updatedAt)->diffForHumans() : null,
+            'filename' => $filename,
+            'full_path' => $fullPath,
+            'path_exists' => $fullPath ? file_exists($fullPath) : null,
+            'scan_dir' => $scanDir,
+            'scan_dir_exists' => $scanDirExists,
             'scan_dir_contents' => $scanDirExists ? (count($scanContents) > 0 ? implode(', ', $scanContents) : '(empty)') : 'N/A',
-            'open_basedir'     => ini_get('open_basedir'),
+            'open_basedir' => ini_get('open_basedir'),
         ];
     }
 
@@ -207,7 +210,7 @@ new class extends Component
             mkdir($dir, 0755, true);
         }
 
-        $src  = $this->uploadFile->getRealPath();
+        $src = $this->uploadFile->getRealPath();
         $dest = "{$dir}/{$originalName}";
 
         if (! copy($src, $dest)) {
@@ -299,8 +302,10 @@ new class extends Component
 
         $this->validateBackupFilename($this->deleteTarget);
         $path = storage_path("app/backups/{$this->deleteTarget}");
-        if (file_exists($path)) {
-            unlink($path);
+        if (file_exists($path) && ! unlink($path)) {
+            Flux::toast('Backup could not be deleted. Check storage permissions.', 'Error', variant: 'danger');
+
+            return;
         }
 
         $this->deleteTarget = null;

--- a/resources/views/livewire/backup/dashboard.blade.php
+++ b/resources/views/livewire/backup/dashboard.blade.php
@@ -145,13 +145,21 @@ new class extends Component
         $filename  = SiteConfig::getValue('backup.last_job_filename');
         $fullPath  = SiteConfig::getValue('backup.last_job_full_path');
 
+        $scanDir      = storage_path('app/backups');
+        $scanDirExists = is_dir($scanDir);
+        $scanContents = $scanDirExists ? (scandir($scanDir) ?: []) : [];
+        $scanContents = array_values(array_filter($scanContents, fn ($f) => ! in_array($f, ['.', '..'])));
+
         return [
-            'status'     => $status,
-            'updated_at' => $updatedAt ? \Carbon\Carbon::parse($updatedAt)->diffForHumans() : null,
-            'filename'   => $filename,
-            'full_path'  => $fullPath,
-            'path_exists' => $fullPath ? file_exists($fullPath) : null,
-            'scan_dir'   => storage_path('app/backups'),
+            'status'           => $status,
+            'updated_at'       => $updatedAt ? \Carbon\Carbon::parse($updatedAt)->diffForHumans() : null,
+            'filename'         => $filename,
+            'full_path'        => $fullPath,
+            'path_exists'      => $fullPath ? file_exists($fullPath) : null,
+            'scan_dir'         => $scanDir,
+            'scan_dir_exists'  => $scanDirExists,
+            'scan_dir_contents' => $scanDirExists ? (count($scanContents) > 0 ? implode(', ', $scanContents) : '(empty)') : 'N/A',
+            'open_basedir'     => ini_get('open_basedir'),
         ];
     }
 
@@ -368,7 +376,9 @@ new class extends Component
                     <p class="font-medium text-yellow-800 dark:text-yellow-300">Backup was reported as completed but the file is not visible here.</p>
                     <p class="text-yellow-700 dark:text-yellow-400">File created by worker: <code class="font-mono">{{ $jobStatus['full_path'] ?? 'unknown' }}</code></p>
                     <p class="text-yellow-700 dark:text-yellow-400">Scanning for files in: <code class="font-mono">{{ $jobStatus['scan_dir'] }}</code></p>
-                    <p class="text-yellow-700 dark:text-yellow-400">File exists at worker path: <strong>{{ $jobStatus['path_exists'] === true ? 'Yes' : ($jobStatus['path_exists'] === false ? 'No — path mismatch between queue worker and web process' : 'Unknown') }}</strong></p>
+                    <p class="text-yellow-700 dark:text-yellow-400">Scan dir exists (web): <strong>{{ $jobStatus['scan_dir_exists'] ? 'Yes' : 'No — directory not visible to web process' }}</strong></p>
+                    <p class="text-yellow-700 dark:text-yellow-400">Files visible via scandir: <strong>{{ $jobStatus['scan_dir_contents'] }}</strong></p>
+                    <p class="text-yellow-700 dark:text-yellow-400">open_basedir: <code class="font-mono">{{ $jobStatus['open_basedir'] ?: '(not set)' }}</code></p>
                 </div>
             @endif
         @else

--- a/resources/views/livewire/backup/dashboard.blade.php
+++ b/resources/views/livewire/backup/dashboard.blade.php
@@ -1,38 +1,51 @@
 <?php
 
 use App\Jobs\CreateBackupJob;
+use App\Jobs\RestoreBackupJob;
+use App\Models\SiteConfig;
 use Flux\Flux;
 use Livewire\Volt\Component;
+use Livewire\WithFileUploads;
 use Symfony\Component\HttpFoundation\StreamedResponse;
 
 new class extends Component
 {
-    public ?string $deleteTarget = null;
+    use WithFileUploads;
+
+    public ?string $deleteTarget  = null;
+    public ?string $restoreTarget = null;
+
+    // Settings
+    public bool $offlineDuringBackup  = false;
+    public bool $offlineDuringRestore = true;
+
+    // Upload
+    public $uploadFile = null;
 
     public function mount(): void
     {
         $this->authorize('backup-manager');
+        $this->offlineDuringBackup  = SiteConfig::getValue('backup.offline_during_backup', 'false') === 'true';
+        $this->offlineDuringRestore = SiteConfig::getValue('backup.offline_during_restore', 'true') === 'true';
     }
 
     #[\Livewire\Attributes\Computed]
     public function localBackups(): array
     {
-        $dir = storage_path('app/backups');
+        $dir   = storage_path('app/backups');
         $files = glob("{$dir}/*.sql.gz") ?: [];
 
         usort($files, fn ($a, $b) => filemtime($b) - filemtime($a));
 
         return array_map(function ($path) {
             $filename = basename($path);
-
             preg_match('/_(pgsql|mysql|sqlite)\.sql\.gz$/', $filename, $m);
-            $dbType = $m[1] ?? 'unknown';
 
             return [
                 'filename' => $filename,
                 'size'     => $this->formatBytes(filesize($path)),
                 'date'     => \Carbon\Carbon::createFromTimestamp(filemtime($path))->format('Y-m-d H:i'),
-                'db_type'  => $dbType,
+                'db_type'  => $m[1] ?? 'unknown',
             ];
         }, $files);
     }
@@ -44,17 +57,66 @@ new class extends Component
         Flux::toast('Backup job queued.', 'Success', variant: 'success');
     }
 
+    public function uploadBackup(): void
+    {
+        $this->authorize('backup-manager');
+
+        $this->validate([
+            'uploadFile' => ['required', 'file', 'mimes:gz', 'max:524288'], // 512 MB
+        ]);
+
+        $originalName = $this->uploadFile->getClientOriginalName();
+
+        if (! str_ends_with($originalName, '.sql.gz')) {
+            $this->addError('uploadFile', 'File must be a .sql.gz backup file.');
+
+            return;
+        }
+
+        $dir = storage_path('app/backups');
+        if (! is_dir($dir)) {
+            mkdir($dir, 0755, true);
+        }
+
+        $this->uploadFile->storeAs('backups', $originalName, 'local');
+        $this->uploadFile = null;
+        unset($this->localBackups);
+        Flux::toast("Uploaded {$originalName}.", 'Done', variant: 'success');
+    }
+
     public function download(string $filename): StreamedResponse
     {
         $this->authorize('backup-manager');
 
         $path = storage_path("app/backups/{$filename}");
-
         abort_if(! file_exists($path), 404);
 
         return response()->streamDownload(function () use ($path) {
             readfile($path);
         }, $filename, ['Content-Type' => 'application/gzip']);
+    }
+
+    public function confirmRestore(string $filename): void
+    {
+        $this->restoreTarget = $filename;
+        Flux::modal('confirm-restore')->show();
+    }
+
+    public function restoreBackup(): void
+    {
+        $this->authorize('backup-manager');
+
+        if ($this->restoreTarget === null) {
+            return;
+        }
+
+        $path = storage_path("app/backups/{$this->restoreTarget}");
+        abort_if(! file_exists($path), 404);
+
+        RestoreBackupJob::dispatch($path);
+        $this->restoreTarget = null;
+        Flux::modal('confirm-restore')->close();
+        Flux::toast('Restore job queued.', 'Success', variant: 'success');
     }
 
     public function confirmDelete(string $filename): void
@@ -72,7 +134,6 @@ new class extends Component
         }
 
         $path = storage_path("app/backups/{$this->deleteTarget}");
-
         if (file_exists($path)) {
             unlink($path);
         }
@@ -81,6 +142,18 @@ new class extends Component
         Flux::modal('confirm-delete')->close();
         Flux::toast('Backup deleted.', 'Done', variant: 'success');
         unset($this->localBackups);
+    }
+
+    public function updatedOfflineDuringBackup(bool $value): void
+    {
+        $this->authorize('backup-manager');
+        SiteConfig::setValue('backup.offline_during_backup', $value ? 'true' : 'false');
+    }
+
+    public function updatedOfflineDuringRestore(bool $value): void
+    {
+        $this->authorize('backup-manager');
+        SiteConfig::setValue('backup.offline_during_restore', $value ? 'true' : 'false');
     }
 
     private function formatBytes(int $bytes): string
@@ -139,6 +212,9 @@ new class extends Component
                                     <flux:button size="sm" icon="arrow-down-tray" wire:click="download('{{ $backup['filename'] }}')">
                                         Download
                                     </flux:button>
+                                    <flux:button size="sm" variant="primary" icon="arrow-path" wire:click="confirmRestore('{{ $backup['filename'] }}')">
+                                        Restore
+                                    </flux:button>
                                     <flux:button size="sm" variant="danger" icon="trash" wire:click="confirmDelete('{{ $backup['filename'] }}')">
                                         Delete
                                     </flux:button>
@@ -150,6 +226,62 @@ new class extends Component
             </flux:table>
         @endif
     </flux:card>
+
+    {{-- Upload Panel --}}
+    <flux:card class="mb-6">
+        <flux:heading size="lg" class="mb-4">Upload Backup</flux:heading>
+        <p class="text-sm text-zinc-500 dark:text-zinc-400 mb-4">
+            Upload a <code>.sql.gz</code> backup file from another server.
+            For files larger than the PHP upload limit, use SCP to place the file directly
+            in <code>storage/app/backups/</code>.
+        </p>
+        <form wire:submit="uploadBackup" class="flex items-end gap-3">
+            <div class="flex-1">
+                <flux:input type="file" wire:model="uploadFile" accept=".gz" />
+                @error('uploadFile')
+                    <p class="mt-1 text-sm text-red-600">{{ $message }}</p>
+                @enderror
+            </div>
+            <flux:button type="submit" variant="primary" icon="arrow-up-tray">
+                Upload
+            </flux:button>
+        </form>
+    </flux:card>
+
+    {{-- Settings Panel --}}
+    <flux:card>
+        <flux:heading size="lg" class="mb-4">Settings</flux:heading>
+        <div class="space-y-4">
+            <div class="flex items-center justify-between">
+                <div>
+                    <p class="font-medium">Take site offline during backup</p>
+                    <p class="text-sm text-zinc-500 dark:text-zinc-400">Puts the site in maintenance mode while a backup is running.</p>
+                </div>
+                <flux:switch wire:model.live="offlineDuringBackup" />
+            </div>
+            <div class="flex items-center justify-between">
+                <div>
+                    <p class="font-medium">Take site offline during restore</p>
+                    <p class="text-sm text-zinc-500 dark:text-zinc-400">Puts the site in maintenance mode while a restore is running.</p>
+                </div>
+                <flux:switch wire:model.live="offlineDuringRestore" />
+            </div>
+        </div>
+    </flux:card>
+
+    {{-- Restore Confirmation Modal --}}
+    <flux:modal name="confirm-restore" class="w-full max-w-md">
+        <flux:heading size="lg">Restore Database</flux:heading>
+        <p class="mt-2 text-sm text-zinc-600 dark:text-zinc-400">
+            Are you sure you want to restore from
+            <span class="font-mono font-semibold">{{ $restoreTarget }}</span>?
+            This will replace the current database contents.
+        </p>
+        <div class="mt-4 flex justify-end gap-2">
+            <flux:button x-on:click="$flux.modal('confirm-restore').close()">Cancel</flux:button>
+            <flux:button variant="danger" wire:click="restoreBackup">Restore</flux:button>
+        </div>
+    </flux:modal>
 
     {{-- Delete Confirmation Modal --}}
     <flux:modal name="confirm-delete" class="w-full max-w-md">

--- a/resources/views/livewire/backup/dashboard.blade.php
+++ b/resources/views/livewire/backup/dashboard.blade.php
@@ -1,6 +1,5 @@
 <?php
 
-use App\Jobs\CreateBackupJob;
 use App\Jobs\RestoreBackupJob;
 use App\Models\SiteConfig;
 use App\Services\BackupStorageService;
@@ -166,10 +165,25 @@ new class extends Component
     public function createBackup(): void
     {
         $this->authorize('backup-manager');
-        SiteConfig::setValue('backup.last_job_status', 'queued');
+
+        SiteConfig::setValue('backup.last_job_status', 'running');
         SiteConfig::setValue('backup.last_job_updated_at', now()->toIso8601String());
-        CreateBackupJob::dispatch();
-        Flux::toast('Backup job queued.', 'Success', variant: 'success');
+        SiteConfig::setValue('backup.last_job_filename', null);
+        SiteConfig::setValue('backup.last_job_full_path', null);
+
+        try {
+            $path = app(\App\Services\BackupService::class)->create();
+            SiteConfig::setValue('backup.last_job_status', 'completed');
+            SiteConfig::setValue('backup.last_job_updated_at', now()->toIso8601String());
+            SiteConfig::setValue('backup.last_job_filename', basename($path));
+            SiteConfig::setValue('backup.last_job_full_path', $path);
+            unset($this->localBackups);
+            Flux::toast('Backup created successfully.', 'Success', variant: 'success');
+        } catch (\Throwable $e) {
+            SiteConfig::setValue('backup.last_job_status', 'failed');
+            SiteConfig::setValue('backup.last_job_updated_at', now()->toIso8601String());
+            Flux::toast('Backup failed: '.$e->getMessage(), 'Error', variant: 'danger');
+        }
     }
 
     public function uploadBackup(): void

--- a/resources/views/livewire/backup/dashboard.blade.php
+++ b/resources/views/livewire/backup/dashboard.blade.php
@@ -147,6 +147,11 @@ new class extends Component
         $filename = SiteConfig::getValue('backup.last_job_filename');
         $fullPath = SiteConfig::getValue('backup.last_job_full_path');
 
+        // Auto-expire the completed badge after 60 seconds.
+        if ($status === 'completed' && $updatedAt && now()->diffInSeconds(\Carbon\Carbon::parse($updatedAt)) > 60) {
+            $status = null;
+        }
+
         $scanDir = storage_path('app/backups');
         $scanDirExists = is_dir($scanDir);
         $scanContents = $scanDirExists ? (scandir($scanDir) ?: []) : [];
@@ -163,6 +168,16 @@ new class extends Component
             'scan_dir_contents' => $scanDirExists ? (count($scanContents) > 0 ? implode(', ', $scanContents) : '(empty)') : 'N/A',
             'open_basedir' => ini_get('open_basedir'),
         ];
+    }
+
+    public function dismissJobStatus(): void
+    {
+        $this->authorize('backup-manager');
+        SiteConfig::setValue('backup.last_job_status', null);
+        SiteConfig::setValue('backup.last_job_updated_at', null);
+        SiteConfig::setValue('backup.last_job_filename', null);
+        SiteConfig::setValue('backup.last_job_full_path', null);
+        unset($this->backupJobStatus);
     }
 
     public function createBackup(): void
@@ -371,10 +386,12 @@ new class extends Component
         </flux:button>
     </div>
 
-    {{-- Poll while a job is in-flight, and one extra cycle after completion to refresh the file list --}}
+    {{-- Poll while a job is in-flight, one extra cycle to refresh the file list, or every 30s while the completed badge is still showing --}}
     @php $jobStatus = $this->backupJobStatus; @endphp
     @if (in_array($jobStatus['status'], ['queued', 'running']) || ($jobStatus['status'] === 'completed' && ! collect($this->localBackups)->contains('filename', $jobStatus['filename'])))
         <div wire:poll.3s></div>
+    @elseif ($jobStatus['status'] === 'completed')
+        <div wire:poll.30s></div>
     @endif
 
     {{-- Local Backups Panel --}}
@@ -387,9 +404,19 @@ new class extends Component
                 @elseif ($jobStatus['status'] === 'running')
                     <flux:badge color="blue" icon="arrow-path">Running{{ $jobStatus['updated_at'] ? ' · '.$jobStatus['updated_at'] : '' }}</flux:badge>
                 @elseif ($jobStatus['status'] === 'completed')
-                    <flux:badge color="green" icon="check-circle">Completed{{ $jobStatus['updated_at'] ? ' · '.$jobStatus['updated_at'] : '' }}</flux:badge>
+                    <div class="flex items-center gap-1">
+                        <flux:badge color="green" icon="check-circle">Completed{{ $jobStatus['updated_at'] ? ' · '.$jobStatus['updated_at'] : '' }}</flux:badge>
+                        <button wire:click="dismissJobStatus" type="button" class="p-0.5 rounded text-zinc-400 hover:text-zinc-600 dark:hover:text-zinc-300 hover:bg-zinc-100 dark:hover:bg-zinc-800" aria-label="Dismiss">
+                            <svg class="size-3.5" fill="none" viewBox="0 0 24 24" stroke-width="2.5" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" /></svg>
+                        </button>
+                    </div>
                 @elseif ($jobStatus['status'] === 'failed')
-                    <flux:badge color="red" icon="exclamation-triangle">Failed{{ $jobStatus['updated_at'] ? ' · '.$jobStatus['updated_at'] : '' }}</flux:badge>
+                    <div class="flex items-center gap-1">
+                        <flux:badge color="red" icon="exclamation-triangle">Failed{{ $jobStatus['updated_at'] ? ' · '.$jobStatus['updated_at'] : '' }}</flux:badge>
+                        <button wire:click="dismissJobStatus" type="button" class="p-0.5 rounded text-zinc-400 hover:text-zinc-600 dark:hover:text-zinc-600 hover:bg-zinc-100 dark:hover:bg-zinc-800" aria-label="Dismiss">
+                            <svg class="size-3.5" fill="none" viewBox="0 0 24 24" stroke-width="2.5" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" /></svg>
+                        </button>
+                    </div>
                 @endif
             </div>
             <flux:button variant="primary" icon="plus" wire:click="createBackup">

--- a/resources/views/livewire/backup/dashboard.blade.php
+++ b/resources/views/livewire/backup/dashboard.blade.php
@@ -89,8 +89,6 @@ new class extends Component
     #[\Livewire\Attributes\Computed]
     public function storageStats(): array
     {
-        $publicDisk = config('filesystems.public_disk', 'public');
-
         $directories = [
             'Staff Photos'        => 'staff-photos',
             'Board Member Photos' => 'board-member-photos',
@@ -101,22 +99,38 @@ new class extends Component
             'Blog Category Hero'  => 'blog/category-hero',
         ];
 
-        $stats = [];
+        $s3Available = $this->s3Connected;
+        $stats       = [];
 
         foreach ($directories as $label => $dir) {
-            $files     = Storage::disk($publicDisk)->allFiles($dir);
-            $count     = count($files);
-            $totalSize = 0;
+            $localFiles    = Storage::disk('public')->allFiles($dir);
+            $localCount    = count($localFiles);
+            $localSize     = 0;
 
-            foreach ($files as $file) {
-                $totalSize += Storage::disk($publicDisk)->size($file);
+            foreach ($localFiles as $file) {
+                $localSize += Storage::disk('public')->size($file);
+            }
+
+            $s3Count = null;
+            $s3Size  = null;
+
+            if ($s3Available) {
+                $s3Files = Storage::disk('s3')->allFiles($dir);
+                $s3Count = count($s3Files);
+                $raw     = 0;
+                foreach ($s3Files as $file) {
+                    $raw += Storage::disk('s3')->size($file);
+                }
+                $s3Size = $this->formatBytes($raw);
             }
 
             $stats[] = [
-                'label'      => $label,
-                'directory'  => $dir,
-                'count'      => $count,
-                'total_size' => $this->formatBytes($totalSize),
+                'label'       => $label,
+                'directory'   => $dir,
+                'local_count' => $localCount,
+                'local_size'  => $this->formatBytes($localSize),
+                's3_count'    => $s3Count,
+                's3_size'     => $s3Size,
             ];
         }
 
@@ -426,25 +440,50 @@ new class extends Component
     {{-- Storage Stats Panel --}}
     <flux:card class="mb-6">
         <flux:heading size="lg" class="mb-4">File Asset Storage</flux:heading>
-        <p class="text-sm text-zinc-500 dark:text-zinc-400 mb-4">File counts and sizes for each public asset directory.</p>
+        <p class="text-sm text-zinc-500 dark:text-zinc-400 mb-4">
+            File counts and sizes per directory — local server vs. S3. Use this to confirm all assets have been migrated.
+        </p>
         <flux:table>
             <flux:table.columns>
                 <flux:table.column>Directory</flux:table.column>
                 <flux:table.column>Path</flux:table.column>
-                <flux:table.column>Files</flux:table.column>
-                <flux:table.column>Total Size</flux:table.column>
+                <flux:table.column>Local Files</flux:table.column>
+                <flux:table.column>Local Size</flux:table.column>
+                @if ($this->s3Connected)
+                    <flux:table.column>S3 Files</flux:table.column>
+                    <flux:table.column>S3 Size</flux:table.column>
+                @endif
             </flux:table.columns>
             <flux:table.rows>
                 @foreach ($this->storageStats as $stat)
                     <flux:table.row wire:key="stat-{{ $stat['directory'] }}">
                         <flux:table.cell>{{ $stat['label'] }}</flux:table.cell>
                         <flux:table.cell class="font-mono text-sm text-zinc-500">{{ $stat['directory'] }}</flux:table.cell>
-                        <flux:table.cell>{{ number_format($stat['count']) }}</flux:table.cell>
-                        <flux:table.cell>{{ $stat['total_size'] }}</flux:table.cell>
+                        <flux:table.cell>
+                            @if ($stat['local_count'] === 0)
+                                <flux:badge color="green" size="sm">0</flux:badge>
+                            @else
+                                <flux:badge color="yellow" size="sm">{{ number_format($stat['local_count']) }}</flux:badge>
+                            @endif
+                        </flux:table.cell>
+                        <flux:table.cell>{{ $stat['local_size'] }}</flux:table.cell>
+                        @if ($this->s3Connected)
+                            <flux:table.cell>
+                                @if ($stat['s3_count'] > 0)
+                                    <flux:badge color="green" size="sm">{{ number_format($stat['s3_count']) }}</flux:badge>
+                                @else
+                                    <flux:badge color="zinc" size="sm">0</flux:badge>
+                                @endif
+                            </flux:table.cell>
+                            <flux:table.cell>{{ $stat['s3_size'] }}</flux:table.cell>
+                        @endif
                     </flux:table.row>
                 @endforeach
             </flux:table.rows>
         </flux:table>
+        @if (! $this->s3Connected)
+            <p class="mt-3 text-sm text-zinc-400 dark:text-zinc-500">S3 not connected — configure AWS credentials to see S3 file counts.</p>
+        @endif
     </flux:card>
 
     {{-- Settings Panel --}}

--- a/resources/views/livewire/backup/dashboard.blade.php
+++ b/resources/views/livewire/backup/dashboard.blade.php
@@ -5,6 +5,7 @@ use App\Jobs\RestoreBackupJob;
 use App\Models\SiteConfig;
 use App\Services\BackupStorageService;
 use Flux\Flux;
+use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Storage;
 use Livewire\Volt\Component;
 use Livewire\WithFileUploads;
@@ -203,6 +204,13 @@ new class extends Component
         $this->validateBackupFilename($this->restoreTarget);
         $path = storage_path("app/backups/{$this->restoreTarget}");
         abort_if(! file_exists($path), 404);
+
+        $lock = Cache::lock('restore:'.$this->restoreTarget, 30);
+        if (! $lock->get()) {
+            Flux::toast('A restore is already queued for this file.', 'Notice', variant: 'warning');
+
+            return;
+        }
 
         RestoreBackupJob::dispatch($path);
         $this->restoreTarget = null;

--- a/resources/views/livewire/backup/dashboard.blade.php
+++ b/resources/views/livewire/backup/dashboard.blade.php
@@ -137,9 +137,23 @@ new class extends Component
         return $stats;
     }
 
+    #[\Livewire\Attributes\Computed]
+    public function backupJobStatus(): array
+    {
+        $status    = SiteConfig::getValue('backup.last_job_status');
+        $updatedAt = SiteConfig::getValue('backup.last_job_updated_at');
+
+        return [
+            'status'     => $status,
+            'updated_at' => $updatedAt ? \Carbon\Carbon::parse($updatedAt)->diffForHumans() : null,
+        ];
+    }
+
     public function createBackup(): void
     {
         $this->authorize('backup-manager');
+        SiteConfig::setValue('backup.last_job_status', 'queued');
+        SiteConfig::setValue('backup.last_job_updated_at', now()->toIso8601String());
         CreateBackupJob::dispatch();
         Flux::toast('Backup job queued.', 'Success', variant: 'success');
     }
@@ -315,10 +329,27 @@ new class extends Component
         </flux:button>
     </div>
 
+    {{-- Poll while a job is in-flight --}}
+    @if (in_array($this->backupJobStatus['status'], ['queued', 'running']))
+        <div wire:poll.3s></div>
+    @endif
+
     {{-- Local Backups Panel --}}
     <flux:card class="mb-6">
         <div class="flex items-center justify-between mb-4">
-            <flux:heading size="lg">Local Backups</flux:heading>
+            <div class="flex items-center gap-3">
+                <flux:heading size="lg">Local Backups</flux:heading>
+                @php $jobStatus = $this->backupJobStatus; @endphp
+                @if ($jobStatus['status'] === 'queued')
+                    <flux:badge color="yellow" icon="clock">Queued{{ $jobStatus['updated_at'] ? ' · '.$jobStatus['updated_at'] : '' }}</flux:badge>
+                @elseif ($jobStatus['status'] === 'running')
+                    <flux:badge color="blue" icon="arrow-path">Running{{ $jobStatus['updated_at'] ? ' · '.$jobStatus['updated_at'] : '' }}</flux:badge>
+                @elseif ($jobStatus['status'] === 'completed')
+                    <flux:badge color="green" icon="check-circle">Completed{{ $jobStatus['updated_at'] ? ' · '.$jobStatus['updated_at'] : '' }}</flux:badge>
+                @elseif ($jobStatus['status'] === 'failed')
+                    <flux:badge color="red" icon="exclamation-triangle">Failed{{ $jobStatus['updated_at'] ? ' · '.$jobStatus['updated_at'] : '' }}</flux:badge>
+                @endif
+            </div>
             <flux:button variant="primary" icon="plus" wire:click="createBackup">
                 Create Backup Now
             </flux:button>

--- a/resources/views/livewire/finance/create-journal-entry.blade.php
+++ b/resources/views/livewire/finance/create-journal-entry.blade.php
@@ -242,16 +242,16 @@ new class extends Component
     {
         $date = \Carbon\Carbon::parse($this->date);
 
-        $period = FinancialPeriod::where('start_date', '<=', $date->toDateString())
-            ->where('end_date', '>=', $date->toDateString())
+        $period = FinancialPeriod::whereRaw('DATE(start_date) <= ?', [$date->toDateString()])
+            ->whereRaw('DATE(end_date) >= ?', [$date->toDateString()])
             ->first();
 
         if (! $period) {
             // Auto-generate periods if missing
             \App\Actions\GenerateFinancialPeriods::generateForCurrentFY();
 
-            $period = FinancialPeriod::where('start_date', '<=', $date->toDateString())
-                ->where('end_date', '>=', $date->toDateString())
+            $period = FinancialPeriod::whereRaw('DATE(start_date) <= ?', [$date->toDateString()])
+                ->whereRaw('DATE(end_date) >= ?', [$date->toDateString()])
                 ->first();
         }
 

--- a/resources/views/livewire/finance/create-manual-entry.blade.php
+++ b/resources/views/livewire/finance/create-manual-entry.blade.php
@@ -149,14 +149,14 @@ new class extends Component
     {
         $date = \Carbon\Carbon::parse($this->date);
 
-        $period = FinancialPeriod::where('start_date', '<=', $date->toDateString())
-            ->where('end_date', '>=', $date->toDateString())
+        $period = FinancialPeriod::whereRaw('DATE(start_date) <= ?', [$date->toDateString()])
+            ->whereRaw('DATE(end_date) >= ?', [$date->toDateString()])
             ->first();
 
         if (! $period) {
             \App\Actions\GenerateFinancialPeriods::generateForCurrentFY();
-            $period = FinancialPeriod::where('start_date', '<=', $date->toDateString())
-                ->where('end_date', '>=', $date->toDateString())
+            $period = FinancialPeriod::whereRaw('DATE(start_date) <= ?', [$date->toDateString()])
+                ->whereRaw('DATE(end_date) >= ?', [$date->toDateString()])
                 ->first();
         }
 

--- a/resources/views/livewire/finance/dashboard.blade.php
+++ b/resources/views/livewire/finance/dashboard.blade.php
@@ -49,7 +49,7 @@ new class extends Component
             ->join('financial_accounts as fa', 'fa.id', '=', 'jel.account_id')
             ->where('je.status', 'posted')
             ->where('fa.type', 'revenue')
-            ->whereBetween('je.date', [$start, $end])
+            ->whereRaw('DATE(je.date) BETWEEN ? AND ?', [$start, $end])
             ->selectRaw('COALESCE(SUM(jel.credit) - SUM(jel.debit), 0) as total')
             ->value('total');
 
@@ -58,7 +58,7 @@ new class extends Component
             ->join('financial_accounts as fa', 'fa.id', '=', 'jel.account_id')
             ->where('je.status', 'posted')
             ->where('fa.type', 'expense')
-            ->whereBetween('je.date', [$start, $end])
+            ->whereRaw('DATE(je.date) BETWEEN ? AND ?', [$start, $end])
             ->selectRaw('COALESCE(SUM(jel.debit) - SUM(jel.credit), 0) as total')
             ->value('total');
 
@@ -106,7 +106,7 @@ new class extends Component
                 ->where('je.status', 'posted')
                 ->whereNot('je.entry_type', 'closing')
                 ->where('fa.type', 'revenue')
-                ->whereBetween('je.date', [$start, $end])
+                ->whereRaw('DATE(je.date) BETWEEN ? AND ?', [$start, $end])
                 ->selectRaw('COALESCE(SUM(jel.credit) - SUM(jel.debit), 0) as total')
                 ->value('total');
 
@@ -116,7 +116,7 @@ new class extends Component
                 ->where('je.status', 'posted')
                 ->whereNot('je.entry_type', 'closing')
                 ->where('fa.type', 'expense')
-                ->whereBetween('je.date', [$start, $end])
+                ->whereRaw('DATE(je.date) BETWEEN ? AND ?', [$start, $end])
                 ->selectRaw('COALESCE(SUM(jel.debit) - SUM(jel.credit), 0) as total')
                 ->value('total');
 

--- a/resources/views/livewire/finance/public-dashboard.blade.php
+++ b/resources/views/livewire/finance/public-dashboard.blade.php
@@ -59,8 +59,8 @@ new class extends Component
     public function getCurrentPeriodProperty(): ?FinancialPeriod
     {
         return FinancialPeriod::where('status', '!=', 'closed')
-            ->where('start_date', '<=', now()->toDateString())
-            ->where('end_date', '>=', now()->toDateString())
+            ->whereRaw('DATE(start_date) <= ?', [now()->toDateString()])
+            ->whereRaw('DATE(end_date) >= ?', [now()->toDateString()])
             ->first();
     }
 

--- a/resources/views/livewire/onboarding/wizard.blade.php
+++ b/resources/views/livewire/onboarding/wizard.blade.php
@@ -26,6 +26,13 @@ new class extends Component
         $this->step = $user->fresh()->currentOnboardingStep();
     }
 
+    public function discordJoinDone(): void
+    {
+        $user = Auth::user();
+        RecordActivity::run($user, 'onboarding_discord_join_done', 'Confirmed joining Discord server.');
+        $this->step = $user->fresh()->currentOnboardingStep();
+    }
+
     public function continueDisabledDiscord(): void
     {
         $user = Auth::user();
@@ -116,6 +123,35 @@ new class extends Component
                         </flux:button>
                     </div>
                 @endif
+            </flux:card>
+
+        @elseif ($step === 'discord-join')
+            <flux:card class="border border-indigo-500/40 bg-indigo-950/20">
+                <div class="flex items-start justify-between">
+                    <flux:heading size="lg" class="text-indigo-300">Join Our Discord Server</flux:heading>
+                    <flux:button wire:click="dismiss" variant="ghost" size="sm" class="text-zinc-400 hover:text-zinc-200 -mt-1 -mr-1">
+                        Dismiss
+                    </flux:button>
+                </div>
+
+                <flux:separator variant="subtle" class="my-4" />
+
+                <flux:text class="mb-2">
+                    Your Discord account is connected! The last step is to join the Lighthouse Discord server
+                    so you can chat with the community, get server role assignments, and receive notifications.
+                </flux:text>
+                <flux:text variant="subtle" class="text-sm mb-4">
+                    Click the button below to open Discord and join the server, then come back and click "I've Joined".
+                </flux:text>
+
+                <div class="flex items-center justify-between">
+                    <flux:button href="https://discord.gg/4RNtFNApYt" target="_blank" rel="noopener noreferrer" variant="primary" icon="arrow-top-right-on-square">
+                        Join Discord Server
+                    </flux:button>
+                    <flux:button wire:click="discordJoinDone" variant="ghost">
+                        I've Joined
+                    </flux:button>
+                </div>
             </flux:card>
 
         @elseif ($step === 'waiting')

--- a/resources/views/livewire/vault/detail.blade.php
+++ b/resources/views/livewire/vault/detail.blade.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Actions\AssignCredentialPositions;
+use App\Actions\ClearCredentialRotationFlag;
 use App\Actions\DeleteCredential;
 use App\Actions\GenerateTotpCode;
 use App\Actions\ReauthenticateVaultSession;
@@ -306,6 +307,18 @@ new class extends Component
         Flux::toast('Position added.', 'Done', variant: 'success');
     }
 
+    public function clearRotationFlag(): void
+    {
+        $this->authorize('update', $this->credential);
+
+        if (! $this->isVaultManager) {
+            return;
+        }
+
+        $this->credential = ClearCredentialRotationFlag::run($this->credential, auth()->user());
+        Flux::toast('Rotation flag cleared.', 'Done', variant: 'success');
+    }
+
     public function removePosition(int $positionId): void
     {
         $this->authorize('managePositions', $this->credential);
@@ -333,12 +346,15 @@ new class extends Component
     <div class="space-y-6">
         <div class="flex items-center justify-between">
             <div>
-                <flux:heading size="xl">
-                    {{ $credential->name }}
+                <div class="flex items-center gap-3">
+                    <flux:heading size="xl">{{ $credential->name }}</flux:heading>
                     @if ($credential->needs_password_change)
-                        <flux:badge color="orange" class="ml-2">Needs Rotation</flux:badge>
+                        <flux:badge color="orange">Needs Rotation</flux:badge>
+                        @if ($this->isVaultManager)
+                            <flux:button size="xs" variant="ghost" wire:click="clearRotationFlag">Clear Flag</flux:button>
+                        @endif
                     @endif
-                </flux:heading>
+                </div>
                 @if ($credential->website_url)
                     <flux:link href="{{ $credential->website_url }}" target="_blank" rel="noopener noreferrer" class="text-sm">
                         {{ $credential->website_url }}

--- a/resources/views/users/show.blade.php
+++ b/resources/views/users/show.blade.php
@@ -13,7 +13,7 @@
         </div>
     @endcan
 
-    @if($user->staffPosition)
+    @if($user->staffPosition || $user->hasEverBeenOnStaff())
         @can('view-staff-activity', $user)
             <div class="my-6">
                 <livewire:users.staff-activity-card :user="$user" />

--- a/routes/console.php
+++ b/routes/console.php
@@ -84,3 +84,8 @@ Schedule::command('app:backup-create')
 Schedule::command('app:backup-cleanup')
     ->dailyAt('04:00')
     ->runInBackground();
+
+// Push most recent local backup to S3 every 3 days at 3:30 AM
+Schedule::command('app:backup-push-s3')
+    ->cron('30 3 */3 * *')
+    ->runInBackground();

--- a/routes/console.php
+++ b/routes/console.php
@@ -79,3 +79,8 @@ Schedule::job(new \App\Jobs\CheckRulesAgreementJob)
 Schedule::command('app:backup-create')
     ->dailyAt('03:00')
     ->runInBackground();
+
+// Clean up local backup files past the retention window daily at 4:00 AM
+Schedule::command('app:backup-cleanup')
+    ->dailyAt('04:00')
+    ->runInBackground();

--- a/routes/console.php
+++ b/routes/console.php
@@ -74,3 +74,8 @@ Schedule::job(new \App\Jobs\CheckRulesAgreementJob)
     ->dailyAt('07:00')
     ->withoutOverlapping(10)
     ->onOneServer();
+
+// Create daily database backup at 3:00 AM
+Schedule::command('app:backup-create')
+    ->dailyAt('03:00')
+    ->runInBackground();

--- a/routes/console.php
+++ b/routes/console.php
@@ -78,14 +78,20 @@ Schedule::job(new \App\Jobs\CheckRulesAgreementJob)
 // Create daily database backup at 3:00 AM
 Schedule::command('app:backup-create')
     ->dailyAt('03:00')
+    ->withoutOverlapping()
+    ->onOneServer()
     ->runInBackground();
 
 // Clean up local backup files past the retention window daily at 4:00 AM
 Schedule::command('app:backup-cleanup')
     ->dailyAt('04:00')
+    ->withoutOverlapping()
+    ->onOneServer()
     ->runInBackground();
 
 // Push most recent local backup to S3 every 3 days at 3:30 AM
 Schedule::command('app:backup-push-s3')
     ->cron('30 3 */3 * *')
+    ->withoutOverlapping()
+    ->onOneServer()
     ->runInBackground();

--- a/routes/web.php
+++ b/routes/web.php
@@ -257,6 +257,14 @@ Route::prefix('finance')
         Volt::route('/reports', 'finance.reports')->name('reports.index');
     });
 
+// Backup Management Dashboard
+Route::prefix('backups')
+    ->name('backups.')
+    ->middleware(['auth', 'can:backup-manager'])
+    ->group(function () {
+        Volt::route('/', 'backup.dashboard')->name('index');
+    });
+
 // Staff Credential Vault
 Route::prefix('vault')
     ->name('vault.')

--- a/tests/Feature/Backup/BackupDashboardTest.php
+++ b/tests/Feature/Backup/BackupDashboardTest.php
@@ -2,7 +2,6 @@
 
 declare(strict_types=1);
 
-use App\Jobs\CreateBackupJob;
 use App\Jobs\RestoreBackupJob;
 use App\Models\SiteConfig;
 use App\Models\User;
@@ -12,6 +11,12 @@ use Illuminate\Support\Facades\Storage;
 use Livewire\Volt\Volt;
 
 uses()->group('backup', 'dashboard');
+
+afterEach(function () {
+    foreach ((glob(storage_path('app/backups/*.sql.gz')) ?: []) as $file) {
+        @unlink($file);
+    }
+});
 
 function makeLocalBackup(string $filename): string
 {
@@ -85,15 +90,16 @@ it('dashboard lists local backup files with metadata', function () {
 
 // ── Create Backup ─────────────────────────────────────────────────────────────
 
-it('clicking Create Backup Now dispatches a CreateBackupJob', function () {
-    Queue::fake();
+it('clicking Create Backup Now runs the backup synchronously and shows the file', function () {
     $user = User::factory()->withRole('Backup Manager')->create();
 
     Volt::actingAs($user)
         ->test('backup.dashboard')
-        ->call('createBackup');
+        ->call('createBackup')
+        ->assertHasNoErrors();
 
-    Queue::assertPushed(CreateBackupJob::class);
+    expect(SiteConfig::getValue('backup.last_job_status'))->toBe('completed');
+    expect(SiteConfig::getValue('backup.last_job_filename'))->not->toBeNull();
 });
 
 // ── Delete ────────────────────────────────────────────────────────────────────

--- a/tests/Feature/Backup/BackupDashboardTest.php
+++ b/tests/Feature/Backup/BackupDashboardTest.php
@@ -3,8 +3,12 @@
 declare(strict_types=1);
 
 use App\Jobs\CreateBackupJob;
+use App\Jobs\RestoreBackupJob;
+use App\Models\SiteConfig;
 use App\Models\User;
+use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Facades\Queue;
+use Illuminate\Support\Facades\Storage;
 use Livewire\Volt\Volt;
 
 uses()->group('backup', 'dashboard');
@@ -112,4 +116,99 @@ it('non-backup-manager is blocked at the route level', function () {
     $this->actingAs($user)
         ->get(route('backups.index'))
         ->assertForbidden();
+});
+
+// ── Restore ───────────────────────────────────────────────────────────────────
+
+it('restore action dispatches RestoreBackupJob', function () {
+    Queue::fake();
+    $user = User::factory()->withRole('Backup Manager')->create();
+    makeLocalBackup('test_dash_restore_2026-04-01_03-00-00_sqlite.sql.gz');
+
+    Volt::actingAs($user)
+        ->test('backup.dashboard')
+        ->set('restoreTarget', 'test_dash_restore_2026-04-01_03-00-00_sqlite.sql.gz')
+        ->call('restoreBackup');
+
+    Queue::assertPushed(RestoreBackupJob::class);
+});
+
+it('confirmRestore sets restoreTarget', function () {
+    $user = User::factory()->withRole('Backup Manager')->create();
+    makeLocalBackup('test_dash_confirm_2026-04-01_03-00-00_sqlite.sql.gz');
+
+    Volt::actingAs($user)
+        ->test('backup.dashboard')
+        ->call('confirmRestore', 'test_dash_confirm_2026-04-01_03-00-00_sqlite.sql.gz')
+        ->assertSet('restoreTarget', 'test_dash_confirm_2026-04-01_03-00-00_sqlite.sql.gz');
+});
+
+// ── Upload ────────────────────────────────────────────────────────────────────
+
+it('uploading a valid .sql.gz file places it in storage', function () {
+    Storage::fake('local');
+
+    $user = User::factory()->withRole('Backup Manager')->create();
+
+    $gzContent = gzencode('-- SQL dump');
+    $file = UploadedFile::fake()->createWithContent('test_dash_upload_2026-04-01_03-00-00_sqlite.sql.gz', $gzContent);
+
+    Volt::actingAs($user)
+        ->test('backup.dashboard')
+        ->set('uploadFile', $file)
+        ->call('uploadBackup')
+        ->assertHasNoErrors();
+
+    Storage::disk('local')->assertExists('backups/test_dash_upload_2026-04-01_03-00-00_sqlite.sql.gz');
+});
+
+it('uploading a non-.sql.gz file is rejected', function () {
+    $user = User::factory()->withRole('Backup Manager')->create();
+
+    $gzContent = gzencode('bad file');
+    $file = UploadedFile::fake()->createWithContent('test_dash_upload_bad.tar.gz', $gzContent);
+
+    Volt::actingAs($user)
+        ->test('backup.dashboard')
+        ->set('uploadFile', $file)
+        ->call('uploadBackup')
+        ->assertHasErrors(['uploadFile']);
+});
+
+// ── Settings ──────────────────────────────────────────────────────────────────
+
+it('toggling offlineDuringBackup persists to SiteConfig', function () {
+    $user = User::factory()->withRole('Backup Manager')->create();
+
+    SiteConfig::setValue('backup.offline_during_backup', 'false');
+
+    Volt::actingAs($user)
+        ->test('backup.dashboard')
+        ->set('offlineDuringBackup', true);
+
+    expect(SiteConfig::getValue('backup.offline_during_backup', 'false'))->toBe('true');
+});
+
+it('toggling offlineDuringRestore persists to SiteConfig', function () {
+    $user = User::factory()->withRole('Backup Manager')->create();
+
+    SiteConfig::setValue('backup.offline_during_restore', 'true');
+
+    Volt::actingAs($user)
+        ->test('backup.dashboard')
+        ->set('offlineDuringRestore', false);
+
+    expect(SiteConfig::getValue('backup.offline_during_restore', 'true'))->toBe('false');
+});
+
+it('mount loads SiteConfig values into toggle properties', function () {
+    $user = User::factory()->withRole('Backup Manager')->create();
+
+    SiteConfig::setValue('backup.offline_during_backup', 'true');
+    SiteConfig::setValue('backup.offline_during_restore', 'false');
+
+    Volt::actingAs($user)
+        ->test('backup.dashboard')
+        ->assertSet('offlineDuringBackup', true)
+        ->assertSet('offlineDuringRestore', false);
 });

--- a/tests/Feature/Backup/BackupDashboardTest.php
+++ b/tests/Feature/Backup/BackupDashboardTest.php
@@ -1,0 +1,115 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Jobs\CreateBackupJob;
+use App\Models\User;
+use Illuminate\Support\Facades\Queue;
+use Livewire\Volt\Volt;
+
+uses()->group('backup', 'dashboard');
+
+function makeLocalBackup(string $filename): string
+{
+    $dir = storage_path('app/backups');
+    if (! is_dir($dir)) {
+        mkdir($dir, 0755, true);
+    }
+    $path = "{$dir}/{$filename}";
+    $gz = gzopen($path, 'wb');
+    gzwrite($gz, '-- SQLite dump');
+    gzclose($gz);
+
+    return $path;
+}
+
+afterEach(function () {
+    foreach (glob(storage_path('app/backups/test_dash_*.sql.gz')) as $file) {
+        @unlink($file);
+    }
+});
+
+// ── Authorization ─────────────────────────────────────────────────────────────
+
+it('unauthenticated users are redirected from the backup dashboard', function () {
+    $this->get(route('backups.index'))->assertRedirect(route('login'));
+});
+
+it('users without backup-manager role get 403 on the backup dashboard', function () {
+    $user = User::factory()->create();
+
+    $this->actingAs($user)
+        ->get(route('backups.index'))
+        ->assertForbidden();
+});
+
+it('backup manager can access the backup dashboard', function () {
+    $user = User::factory()->withRole('Backup Manager')->create();
+
+    $this->actingAs($user)
+        ->get(route('backups.index'))
+        ->assertOk();
+});
+
+// ── Ready Room link ───────────────────────────────────────────────────────────
+
+it('ready room header shows Backups link only for backup managers', function () {
+    // Backup Manager also needs Staff Access to pass the ready-room controller gate
+    $manager = User::factory()->withRole('Staff Access')->withRole('Backup Manager')->create();
+    $staff = User::factory()->withRole('Staff Access')->create();
+
+    $this->actingAs($manager)
+        ->get(route('ready-room.index'))
+        ->assertSee('Backups');
+
+    $this->actingAs($staff)
+        ->get(route('ready-room.index'))
+        ->assertDontSee(route('backups.index'));
+});
+
+// ── Local backup list ─────────────────────────────────────────────────────────
+
+it('dashboard lists local backup files with metadata', function () {
+    $user = User::factory()->withRole('Backup Manager')->create();
+    makeLocalBackup('test_dash_backup_2026-04-01_03-00-00_sqlite.sql.gz');
+
+    $this->actingAs($user)
+        ->get(route('backups.index'))
+        ->assertSee('test_dash_backup_2026-04-01_03-00-00_sqlite.sql.gz')
+        ->assertSee('sqlite');
+});
+
+// ── Create Backup ─────────────────────────────────────────────────────────────
+
+it('clicking Create Backup Now dispatches a CreateBackupJob', function () {
+    Queue::fake();
+    $user = User::factory()->withRole('Backup Manager')->create();
+
+    Volt::actingAs($user)
+        ->test('backup.dashboard')
+        ->call('createBackup');
+
+    Queue::assertPushed(CreateBackupJob::class);
+});
+
+// ── Delete ────────────────────────────────────────────────────────────────────
+
+it('deleting a backup removes it from disk', function () {
+    $user = User::factory()->withRole('Backup Manager')->create();
+    $path = makeLocalBackup('test_dash_delete_2026-04-01_03-00-00_sqlite.sql.gz');
+
+    Volt::actingAs($user)
+        ->test('backup.dashboard')
+        ->set('deleteTarget', 'test_dash_delete_2026-04-01_03-00-00_sqlite.sql.gz')
+        ->call('deleteBackup');
+
+    expect(file_exists($path))->toBeFalse();
+});
+
+it('non-backup-manager is blocked at the route level', function () {
+    $user = User::factory()->create();
+
+    $this->actingAs($user)
+        ->get(route('backups.index'))
+        ->assertForbidden();
+});

--- a/tests/Feature/Backup/BackupDashboardTest.php
+++ b/tests/Feature/Backup/BackupDashboardTest.php
@@ -158,8 +158,6 @@ it('confirmRestore sets restoreTarget', function () {
 // ── Upload ────────────────────────────────────────────────────────────────────
 
 it('uploading a valid .sql.gz file places it in storage', function () {
-    Storage::fake('local');
-
     $user = User::factory()->withRole('Backup Manager')->create();
 
     $gzContent = gzencode('-- SQL dump');
@@ -171,7 +169,8 @@ it('uploading a valid .sql.gz file places it in storage', function () {
         ->call('uploadBackup')
         ->assertHasNoErrors();
 
-    Storage::disk('local')->assertExists('backups/test_dash_upload_2026-04-01_03-00-00_sqlite.sql.gz');
+    $dest = storage_path('app/backups/test_dash_upload_2026-04-01_03-00-00_sqlite.sql.gz');
+    expect(file_exists($dest))->toBeTrue();
 });
 
 it('uploading a non-.sql.gz file is rejected', function () {

--- a/tests/Feature/Backup/BackupDashboardTest.php
+++ b/tests/Feature/Backup/BackupDashboardTest.php
@@ -126,6 +126,25 @@ it('non-backup-manager is blocked at the route level', function () {
 
 // ── Restore ───────────────────────────────────────────────────────────────────
 
+it('restore action is blocked in production environment', function () {
+    Queue::fake();
+    $user = User::factory()->withRole('Backup Manager')->create();
+    makeLocalBackup('test_dash_restore_prod_2026-04-01_03-00-00_sqlite.sql.gz');
+
+    $this->app->detectEnvironment(fn () => 'production');
+
+    try {
+        Volt::actingAs($user)
+            ->test('backup.dashboard')
+            ->set('restoreTarget', 'test_dash_restore_prod_2026-04-01_03-00-00_sqlite.sql.gz')
+            ->call('restoreBackup');
+
+        Queue::assertNothingPushed();
+    } finally {
+        $this->app->detectEnvironment(fn () => 'testing');
+    }
+});
+
 it('restore action dispatches RestoreBackupJob', function () {
     Queue::fake();
     $user = User::factory()->withRole('Backup Manager')->create();

--- a/tests/Feature/Backup/BackupDashboardTest.php
+++ b/tests/Feature/Backup/BackupDashboardTest.php
@@ -13,12 +13,6 @@ use Livewire\Volt\Volt;
 
 uses()->group('backup', 'dashboard');
 
-afterEach(function () {
-    foreach ((glob(storage_path('app/backups/*.sql.gz')) ?: []) as $file) {
-        @unlink($file);
-    }
-});
-
 function makeLocalBackup(string $filename): string
 {
     $dir = storage_path('app/backups');

--- a/tests/Feature/Backup/BackupDashboardTest.php
+++ b/tests/Feature/Backup/BackupDashboardTest.php
@@ -212,3 +212,65 @@ it('mount loads SiteConfig values into toggle properties', function () {
         ->assertSet('offlineDuringBackup', true)
         ->assertSet('offlineDuringRestore', false);
 });
+
+// ── S3 Panel ──────────────────────────────────────────────────────────────────
+
+it('dashboard shows S3 not configured when credentials are missing', function () {
+    config(['filesystems.disks.s3.key' => null]);
+
+    $user = User::factory()->withRole('Backup Manager')->create();
+
+    $this->actingAs($user)
+        ->get(route('backups.index'))
+        ->assertSee('S3 Not Configured');
+});
+
+it('dashboard shows S3 connected when S3 is reachable', function () {
+    Storage::fake('s3');
+    config(['filesystems.disks.s3.key' => 'fake-key', 'filesystems.disks.s3.bucket' => 'fake-bucket']);
+
+    $user = User::factory()->withRole('Backup Manager')->create();
+
+    $this->actingAs($user)
+        ->get(route('backups.index'))
+        ->assertSee('S3 Connected');
+});
+
+it('dashboard lists S3 backup files in the S3 panel', function () {
+    Storage::fake('s3');
+    config(['filesystems.disks.s3.key' => 'fake-key', 'filesystems.disks.s3.bucket' => 'fake-bucket']);
+    Storage::disk('s3')->put('backups/backup_2026-04-01_03-00-00_sqlite.sql.gz', 'gz content');
+
+    $user = User::factory()->withRole('Backup Manager')->create();
+
+    $this->actingAs($user)
+        ->get(route('backups.index'))
+        ->assertSee('backup_2026-04-01_03-00-00_sqlite.sql.gz');
+});
+
+it('deleteS3Backup removes file from S3', function () {
+    Storage::fake('s3');
+    config(['filesystems.disks.s3.key' => 'fake-key', 'filesystems.disks.s3.bucket' => 'fake-bucket']);
+    Storage::disk('s3')->put('backups/backup_2026-04-01_03-00-00_sqlite.sql.gz', 'gz content');
+
+    $user = User::factory()->withRole('Backup Manager')->create();
+
+    Volt::actingAs($user)
+        ->test('backup.dashboard')
+        ->set('deleteS3Target', 'backup_2026-04-01_03-00-00_sqlite.sql.gz')
+        ->call('deleteS3Backup');
+
+    Storage::disk('s3')->assertMissing('backups/backup_2026-04-01_03-00-00_sqlite.sql.gz');
+});
+
+// ── Storage Stats ─────────────────────────────────────────────────────────────
+
+it('dashboard storage stats panel shows known asset directories', function () {
+    $user = User::factory()->withRole('Backup Manager')->create();
+
+    $this->actingAs($user)
+        ->get(route('backups.index'))
+        ->assertSee('Staff Photos')
+        ->assertSee('Message Images')
+        ->assertSee('Community Stories');
+});

--- a/tests/Feature/Backup/BackupDashboardTest.php
+++ b/tests/Feature/Backup/BackupDashboardTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 use App\Jobs\RestoreBackupJob;
 use App\Models\SiteConfig;
 use App\Models\User;
+use App\Services\BackupService;
 use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Facades\Queue;
 use Illuminate\Support\Facades\Storage;
@@ -92,6 +93,11 @@ it('dashboard lists local backup files with metadata', function () {
 
 it('clicking Create Backup Now runs the backup synchronously and shows the file', function () {
     $user = User::factory()->withRole('Backup Manager')->create();
+
+    $fakePath = storage_path('app/backups/backup_2026-04-01_03-00-00_sqlite.sql.gz');
+    $mock = Mockery::mock(BackupService::class);
+    $mock->shouldReceive('create')->once()->andReturn($fakePath);
+    app()->instance(BackupService::class, $mock);
 
     Volt::actingAs($user)
         ->test('backup.dashboard')

--- a/tests/Feature/Commands/CleanupBackupsTest.php
+++ b/tests/Feature/Commands/CleanupBackupsTest.php
@@ -76,7 +76,9 @@ it('the app:backup-cleanup command exits successfully', function () {
 });
 
 it('app:backup-cleanup is scheduled daily at 04:00', function () {
-    $this->artisan('schedule:list')
-        ->expectsOutputToContain('app:backup-cleanup')
-        ->expectsOutputToContain('0   4 * * *');
+    $events = collect(app(\Illuminate\Console\Scheduling\Schedule::class)->events())
+        ->filter(fn ($e) => str_contains($e->command ?? '', 'backup-cleanup'));
+
+    expect($events->isNotEmpty())->toBeTrue()
+        ->and($events->first()->expression)->toBe('0 4 * * *');
 });

--- a/tests/Feature/Commands/CleanupBackupsTest.php
+++ b/tests/Feature/Commands/CleanupBackupsTest.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\SiteConfig;
+use App\Services\BackupRetentionService;
+
+uses()->group('backup', 'commands');
+
+function makeAgedBackupFile(string $filename, int $daysOld): string
+{
+    $dir = storage_path('app/backups');
+    if (! is_dir($dir)) {
+        mkdir($dir, 0755, true);
+    }
+    $path = "{$dir}/{$filename}";
+    $gz = gzopen($path, 'wb');
+    gzwrite($gz, '-- SQLite dump');
+    gzclose($gz);
+
+    $mtime = now()->subDays($daysOld)->timestamp;
+    touch($path, $mtime);
+
+    return $path;
+}
+
+afterEach(function () {
+    foreach (glob(storage_path('app/backups/cleanup_test_*.sql.gz')) as $file) {
+        @unlink($file);
+    }
+});
+
+it('deletes files older than the retention window and keeps newer files', function () {
+    SiteConfig::setValue('backup.local_retention_days', '7');
+
+    $old = makeAgedBackupFile('cleanup_test_old_sqlite.sql.gz', 10);
+    $edge = makeAgedBackupFile('cleanup_test_edge_sqlite.sql.gz', 7);
+    $new = makeAgedBackupFile('cleanup_test_new_sqlite.sql.gz', 3);
+
+    $service = app(BackupRetentionService::class);
+    $deleted = $service->enforceLocalRetention();
+
+    expect(file_exists($old))->toBeFalse()
+        ->and(file_exists($edge))->toBeFalse()
+        ->and(file_exists($new))->toBeTrue()
+        ->and(count($deleted))->toBe(2);
+});
+
+it('respects a custom retention window from SiteConfig', function () {
+    SiteConfig::setValue('backup.local_retention_days', '14');
+
+    $old = makeAgedBackupFile('cleanup_test_14old_sqlite.sql.gz', 15);
+    $new = makeAgedBackupFile('cleanup_test_14new_sqlite.sql.gz', 5);
+
+    $service = app(BackupRetentionService::class);
+    $service->enforceLocalRetention();
+
+    expect(file_exists($old))->toBeFalse()
+        ->and(file_exists($new))->toBeTrue();
+});
+
+it('returns an empty array when no files need to be deleted', function () {
+    SiteConfig::setValue('backup.local_retention_days', '7');
+    makeAgedBackupFile('cleanup_test_recent_sqlite.sql.gz', 2);
+
+    $deleted = app(BackupRetentionService::class)->enforceLocalRetention();
+
+    expect($deleted)->toBeEmpty();
+});
+
+it('the app:backup-cleanup command exits successfully', function () {
+    SiteConfig::setValue('backup.local_retention_days', '7');
+    makeAgedBackupFile('cleanup_test_cmd_sqlite.sql.gz', 10);
+
+    $this->artisan('app:backup-cleanup')->assertSuccessful();
+});
+
+it('app:backup-cleanup is scheduled daily at 04:00', function () {
+    $this->artisan('schedule:list')
+        ->expectsOutputToContain('app:backup-cleanup')
+        ->expectsOutputToContain('0   4 * * *');
+});

--- a/tests/Feature/Commands/CreateBackupTest.php
+++ b/tests/Feature/Commands/CreateBackupTest.php
@@ -7,11 +7,21 @@ use App\Notifications\BackupCreatedNotification;
 use App\Notifications\BackupFailedNotification;
 use App\Services\BackupService;
 use Illuminate\Support\Facades\Notification;
+use Illuminate\Support\Facades\Process;
 
 uses()->group('backup', 'commands');
 
+// pg_dump on ubuntu-latest (pg client 16) fails against the CI PostgreSQL 17 service.
+// Fake all process calls to return a synthetic SQL dump so the tests focus on command
+// behaviour (file creation, notifications, maintenance mode) rather than the dump binary.
+beforeEach(function () {
+    if (config('database.default') === 'pgsql') {
+        Process::fake(fn () => Process::result('-- PostgreSQL SQL dump'));
+    }
+});
+
 afterEach(function () {
-    foreach (glob(storage_path('app/backups/*.sql.gz')) as $file) {
+    foreach ((glob(storage_path('app/backups/*.sql.gz')) ?: []) as $file) {
         @unlink($file);
     }
 });

--- a/tests/Feature/Commands/CreateBackupTest.php
+++ b/tests/Feature/Commands/CreateBackupTest.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\User;
+use App\Notifications\BackupCreatedNotification;
+use App\Notifications\BackupFailedNotification;
+use App\Services\BackupService;
+use Illuminate\Support\Facades\Notification;
+
+uses()->group('backup', 'commands');
+
+afterEach(function () {
+    foreach (glob(storage_path('app/backups/*.sql.gz')) as $file) {
+        @unlink($file);
+    }
+});
+
+it('creates a .sql.gz backup file', function () {
+    $this->artisan('app:backup-create')->assertSuccessful();
+
+    $files = glob(storage_path('app/backups/*.sql.gz'));
+    expect($files)->toHaveCount(1);
+});
+
+it('backup file has non-zero size', function () {
+    $this->artisan('app:backup-create')->assertSuccessful();
+
+    $files = glob(storage_path('app/backups/*.sql.gz'));
+    expect(filesize($files[0]))->toBeGreaterThan(0);
+});
+
+it('backup filename includes timestamp and database type', function () {
+    $this->artisan('app:backup-create')->assertSuccessful();
+
+    $files = glob(storage_path('app/backups/*.sql.gz'));
+    $filename = basename($files[0]);
+
+    expect($filename)->toMatch('/^backup_\d{4}-\d{2}-\d{2}_\d{2}-\d{2}-\d{2}_\w+\.sql\.gz$/');
+});
+
+it('notifies backup managers on success', function () {
+    $manager = User::factory()->withRole('Backup Manager')->create();
+
+    $this->artisan('app:backup-create')->assertSuccessful();
+
+    Notification::assertSentTo($manager, BackupCreatedNotification::class);
+});
+
+it('notifies backup managers on failure', function () {
+    $manager = User::factory()->withRole('Backup Manager')->create();
+
+    $service = $this->mock(BackupService::class);
+    $service->shouldReceive('setSkipOffline')->andReturnSelf();
+    $service->shouldReceive('create')->andThrow(new \RuntimeException('Simulated backup failure'));
+
+    $this->artisan('app:backup-create')->assertFailed();
+
+    Notification::assertSentTo($manager, BackupFailedNotification::class);
+});
+
+it('does not trigger maintenance mode when offline_during_backup is false', function () {
+    \App\Models\SiteConfig::setValue('backup.offline_during_backup', 'false');
+
+    $this->artisan('app:backup-create')->assertSuccessful();
+
+    expect(app()->isDownForMaintenance())->toBeFalse();
+});
+
+it('does not trigger maintenance mode with --skip-offline flag', function () {
+    \App\Models\SiteConfig::setValue('backup.offline_during_backup', 'true');
+
+    $this->artisan('app:backup-create', ['--skip-offline' => true])->assertSuccessful();
+
+    expect(app()->isDownForMaintenance())->toBeFalse();
+});
+
+it('is scheduled daily at 03:00', function () {
+    $this->artisan('schedule:list')
+        ->expectsOutputToContain('app:backup-create')
+        ->assertSuccessful();
+});

--- a/tests/Feature/Commands/CreateBackupTest.php
+++ b/tests/Feature/Commands/CreateBackupTest.php
@@ -20,31 +20,38 @@ beforeEach(function () {
     }
 });
 
+beforeEach(function () {
+    $this->preExistingBackupFiles = glob(storage_path('app/backups/*.sql.gz')) ?: [];
+});
+
 afterEach(function () {
+    $pre = $this->preExistingBackupFiles ?? [];
     foreach ((glob(storage_path('app/backups/*.sql.gz')) ?: []) as $file) {
-        @unlink($file);
+        if (! in_array($file, $pre, true)) {
+            @unlink($file);
+        }
     }
 });
 
 it('creates a .sql.gz backup file', function () {
     $this->artisan('app:backup-create')->assertSuccessful();
 
-    $files = glob(storage_path('app/backups/*.sql.gz'));
-    expect($files)->toHaveCount(1);
+    $newFiles = array_diff(glob(storage_path('app/backups/*.sql.gz')) ?: [], $this->preExistingBackupFiles);
+    expect($newFiles)->toHaveCount(1);
 });
 
 it('backup file has non-zero size', function () {
     $this->artisan('app:backup-create')->assertSuccessful();
 
-    $files = glob(storage_path('app/backups/*.sql.gz'));
-    expect(filesize($files[0]))->toBeGreaterThan(0);
+    $newFiles = array_values(array_diff(glob(storage_path('app/backups/*.sql.gz')) ?: [], $this->preExistingBackupFiles));
+    expect(filesize($newFiles[0]))->toBeGreaterThan(0);
 });
 
 it('backup filename includes timestamp and database type', function () {
     $this->artisan('app:backup-create')->assertSuccessful();
 
-    $files = glob(storage_path('app/backups/*.sql.gz'));
-    $filename = basename($files[0]);
+    $newFiles = array_values(array_diff(glob(storage_path('app/backups/*.sql.gz')) ?: [], $this->preExistingBackupFiles));
+    $filename = basename($newFiles[0]);
 
     expect($filename)->toMatch('/^backup_\d{4}-\d{2}-\d{2}_\d{2}-\d{2}-\d{2}_\w+\.sql\.gz$/');
 });

--- a/tests/Feature/Commands/CreateBackupTest.php
+++ b/tests/Feature/Commands/CreateBackupTest.php
@@ -57,6 +57,8 @@ it('backup filename includes timestamp and database type', function () {
 });
 
 it('notifies backup managers on success', function () {
+    Notification::fake();
+
     $manager = User::factory()->withRole('Backup Manager')->create();
 
     $this->artisan('app:backup-create')->assertSuccessful();
@@ -65,6 +67,8 @@ it('notifies backup managers on success', function () {
 });
 
 it('notifies backup managers on failure', function () {
+    Notification::fake();
+
     $manager = User::factory()->withRole('Backup Manager')->create();
 
     $service = $this->mock(BackupService::class);

--- a/tests/Feature/Commands/RestoreBackupTest.php
+++ b/tests/Feature/Commands/RestoreBackupTest.php
@@ -27,9 +27,16 @@ function makeBackupFile(string $filename, string $sql = '-- SQLite dump'): strin
     return $path;
 }
 
+beforeEach(function () {
+    $this->preExistingBackupFiles = glob(storage_path('app/backups/*.sql.gz')) ?: [];
+});
+
 afterEach(function () {
+    $pre = $this->preExistingBackupFiles ?? [];
     foreach ((glob(storage_path('app/backups/*.sql.gz')) ?: []) as $file) {
-        @unlink($file);
+        if (! in_array($file, $pre, true)) {
+            @unlink($file);
+        }
     }
     if (app()->isDownForMaintenance()) {
         \Illuminate\Support\Facades\Artisan::call('up');

--- a/tests/Feature/Commands/RestoreBackupTest.php
+++ b/tests/Feature/Commands/RestoreBackupTest.php
@@ -87,6 +87,52 @@ it('restores a backup and results in expected database state', function () {
     }
 });
 
+it('restores correctly when text values contain semicolons', function () {
+    $tmpDb = sys_get_temp_dir().'/restore_semi_'.uniqid().'.sqlite';
+    $gzFile = storage_path('app/backups/restore_semi_test_2026-01-01_00-00-00_sqlite.sql.gz');
+    $originalDefault = config('database.default');
+
+    try {
+        touch($tmpDb);
+
+        config(['database.connections.restore_semi' => [
+            'driver' => 'sqlite',
+            'database' => $tmpDb,
+            'foreign_key_constraints' => false,
+        ]]);
+
+        // RestoreService reads offline_during_restore from site_configs before swapping the default.
+        $pdo = DB::connection('restore_semi')->getPdo();
+        $pdo->exec('CREATE TABLE "site_configs" ("id" INTEGER PRIMARY KEY AUTOINCREMENT, "key" TEXT, "value" TEXT, "description" TEXT, "created_at" TEXT, "updated_at" TEXT)');
+        $pdo->exec("INSERT INTO \"site_configs\" (\"key\", \"value\") VALUES ('backup.offline_during_restore', 'false')");
+
+        // Dump contains a value with a semicolon — the naive explode(';') approach splits this.
+        $dumpSql = "CREATE TABLE \"notes\" (\"id\" INTEGER PRIMARY KEY, \"body\" TEXT NOT NULL);\n"
+            ."INSERT INTO \"notes\" (\"id\", \"body\") VALUES (1, 'Hello; World');\n"
+            ."INSERT INTO \"notes\" (\"id\", \"body\") VALUES (2, 'No; semicolons; here; either');\n";
+
+        $gz = gzopen($gzFile, 'wb');
+        gzwrite($gz, $dumpSql);
+        gzclose($gz);
+
+        config(['database.default' => 'restore_semi']);
+
+        (new RestoreService)->restore($gzFile);
+
+        $rows = DB::connection('restore_semi')->getPdo()
+            ->query('SELECT body FROM "notes" ORDER BY id')
+            ->fetchAll(\PDO::FETCH_COLUMN);
+
+        expect($rows)->toBe(['Hello; World', 'No; semicolons; here; either']);
+
+    } finally {
+        config(['database.default' => $originalDefault]);
+        DB::purge('restore_semi');
+        @unlink($tmpDb);
+        @unlink($gzFile);
+    }
+});
+
 it('aborts cross-type restore with clear error when pgloader is not installed', function () {
     Process::fake([
         'which pgloader' => Process::result('', '', 1),

--- a/tests/Feature/Commands/RestoreBackupTest.php
+++ b/tests/Feature/Commands/RestoreBackupTest.php
@@ -1,0 +1,147 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\SiteConfig;
+use App\Models\User;
+use App\Notifications\RestoreCompletedNotification;
+use App\Notifications\RestoreFailedNotification;
+use App\Services\RestoreService;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Notification;
+use Illuminate\Support\Facades\Process;
+
+uses()->group('backup', 'commands');
+
+function makeBackupFile(string $filename, string $sql = '-- SQLite dump'): string
+{
+    $dir = storage_path('app/backups');
+    if (! is_dir($dir)) {
+        mkdir($dir, 0755, true);
+    }
+    $path = "{$dir}/{$filename}";
+    $gz = gzopen($path, 'wb');
+    gzwrite($gz, $sql);
+    gzclose($gz);
+
+    return $path;
+}
+
+afterEach(function () {
+    foreach (glob(storage_path('app/backups/*.sql.gz')) as $file) {
+        @unlink($file);
+    }
+    if (app()->isDownForMaintenance()) {
+        \Illuminate\Support\Facades\Artisan::call('up');
+    }
+});
+
+it('restores a backup and results in expected database state', function () {
+    $tmpDb = sys_get_temp_dir().'/restore_test_'.uniqid().'.sqlite';
+    $gzFile = storage_path('app/backups/restore_state_test_2026-01-01_00-00-00_sqlite.sql.gz');
+
+    try {
+        // Create the file first so Laravel's SQLite connector can find it.
+        touch($tmpDb);
+
+        // Register a named connection for the temp file so we don't touch the :memory: test DB.
+        config(['database.connections.restore_test' => [
+            'driver' => 'sqlite',
+            'database' => $tmpDb,
+            'foreign_key_constraints' => false,
+        ]]);
+
+        // Build the pre-restore state: one row to keep, one marker to remove.
+        // Also include site_configs so SiteConfig::getValue can query it after we switch default.
+        $pdo = DB::connection('restore_test')->getPdo();
+        $pdo->exec('CREATE TABLE "site_configs" ("id" INTEGER PRIMARY KEY AUTOINCREMENT, "key" TEXT, "value" TEXT, "description" TEXT, "created_at" TEXT, "updated_at" TEXT)');
+        $pdo->exec("INSERT INTO \"site_configs\" (\"key\", \"value\") VALUES ('backup.offline_during_restore', 'false')");
+        $pdo->exec('CREATE TABLE "items" ("id" INTEGER PRIMARY KEY, "name" TEXT NOT NULL)');
+        $pdo->exec("INSERT INTO \"items\" VALUES (1, 'kept')");
+        $pdo->exec("INSERT INTO \"items\" VALUES (2, 'to_be_removed')");
+
+        // The dump represents the backup taken before the marker was inserted.
+        $dumpSql = "CREATE TABLE \"items\" (\"id\" INTEGER PRIMARY KEY, \"name\" TEXT NOT NULL);\n"
+            ."INSERT INTO \"items\" (\"id\", \"name\") VALUES (1, 'kept');\n";
+        $gz = gzopen($gzFile, 'wb');
+        gzwrite($gz, $dumpSql);
+        gzclose($gz);
+
+        // Switch default connection to the temp file for the duration of the restore.
+        config(['database.default' => 'restore_test']);
+
+        $restoreService = new RestoreService;
+        $restoreService->restore($gzFile);
+
+        $count = (int) DB::connection('restore_test')->getPdo()
+            ->query("SELECT COUNT(*) FROM \"items\" WHERE name='to_be_removed'")
+            ->fetchColumn();
+        expect($count)->toBe(0);
+
+    } finally {
+        config(['database.default' => 'sqlite']);
+        DB::purge('restore_test');
+        @unlink($tmpDb);
+        @unlink($gzFile);
+    }
+});
+
+it('aborts cross-type restore with clear error when pgloader is not installed', function () {
+    Process::fake([
+        'which pgloader' => Process::result('', '', 1),
+    ]);
+
+    // pgsql-typed backup on a sqlite target — cross-type
+    makeBackupFile('backup_2026-01-01_00-00-00_pgsql.sql.gz', '-- PostgreSQL dump');
+
+    $this->artisan('app:backup-restore', ['filename' => 'backup_2026-01-01_00-00-00_pgsql.sql.gz'])
+        ->assertFailed()
+        ->expectsOutputToContain('pgloader');
+});
+
+it('enters and exits maintenance mode during restore when offline_during_restore is true', function () {
+    SiteConfig::setValue('backup.offline_during_restore', 'true');
+
+    // Mock so the restore throws, ensuring the up/down flow is exercised and
+    // the site comes back online even on failure
+    $service = $this->mock(RestoreService::class);
+    $service->shouldReceive('restore')->andThrow(new \RuntimeException('Simulated failure'));
+
+    makeBackupFile('backup_2026-01-01_00-00-00_sqlite.sql.gz');
+
+    $this->artisan('app:backup-restore', ['filename' => 'backup_2026-01-01_00-00-00_sqlite.sql.gz'])
+        ->assertFailed();
+
+    expect(app()->isDownForMaintenance())->toBeFalse();
+});
+
+it('notifies backup managers on successful restore', function () {
+    $manager = User::factory()->withRole('Backup Manager')->create();
+
+    // Mock RestoreService so tables are never dropped — notification queries stay intact
+    $this->mock(RestoreService::class)
+        ->shouldReceive('restore')
+        ->once();
+
+    makeBackupFile('backup_2026-01-01_00-00-00_sqlite.sql.gz');
+
+    $this->artisan('app:backup-restore', ['filename' => 'backup_2026-01-01_00-00-00_sqlite.sql.gz'])
+        ->assertSuccessful();
+
+    Notification::assertSentTo($manager, RestoreCompletedNotification::class);
+});
+
+it('notifies backup managers on restore failure', function () {
+    $manager = User::factory()->withRole('Backup Manager')->create();
+
+    $this->mock(RestoreService::class)
+        ->shouldReceive('restore')
+        ->andThrow(new \RuntimeException('Simulated restore failure'));
+
+    makeBackupFile('backup_2026-01-01_00-00-00_sqlite.sql.gz');
+
+    $this->artisan('app:backup-restore', ['filename' => 'backup_2026-01-01_00-00-00_sqlite.sql.gz'])
+        ->assertFailed();
+
+    Notification::assertSentTo($manager, RestoreFailedNotification::class);
+});

--- a/tests/Feature/Commands/RestoreBackupTest.php
+++ b/tests/Feature/Commands/RestoreBackupTest.php
@@ -185,6 +185,31 @@ it('notifies backup managers on successful restore', function () {
     Notification::assertSentTo($manager, RestoreCompletedNotification::class);
 });
 
+it('blocks restore in production environment', function () {
+    $this->app->detectEnvironment(fn () => 'production');
+
+    try {
+        $path = makeBackupFile('backup_2026-01-01_00-00-00_sqlite.sql.gz');
+
+        expect(fn () => (new \App\Services\RestoreService)->restore($path))
+            ->toThrow(\RuntimeException::class, 'production environment');
+    } finally {
+        $this->app->detectEnvironment(fn () => 'testing');
+    }
+});
+
+it('passes production guard when APP_ENV is backup-restore', function () {
+    $this->app->detectEnvironment(fn () => 'backup-restore');
+
+    try {
+        // Nonexistent path: guard lets it through, then "file not found" confirms the guard passed.
+        expect(fn () => (new \App\Services\RestoreService)->restore('/nonexistent/path_sqlite.sql.gz'))
+            ->toThrow(\RuntimeException::class, 'Backup file not found');
+    } finally {
+        $this->app->detectEnvironment(fn () => 'testing');
+    }
+});
+
 it('notifies backup managers on restore failure', function () {
     $manager = User::factory()->withRole('Backup Manager')->create();
 

--- a/tests/Feature/Commands/RestoreBackupTest.php
+++ b/tests/Feature/Commands/RestoreBackupTest.php
@@ -28,7 +28,7 @@ function makeBackupFile(string $filename, string $sql = '-- SQLite dump'): strin
 }
 
 afterEach(function () {
-    foreach (glob(storage_path('app/backups/*.sql.gz')) as $file) {
+    foreach ((glob(storage_path('app/backups/*.sql.gz')) ?: []) as $file) {
         @unlink($file);
     }
     if (app()->isDownForMaintenance()) {
@@ -39,12 +39,13 @@ afterEach(function () {
 it('restores a backup and results in expected database state', function () {
     $tmpDb = sys_get_temp_dir().'/restore_test_'.uniqid().'.sqlite';
     $gzFile = storage_path('app/backups/restore_state_test_2026-01-01_00-00-00_sqlite.sql.gz');
+    $originalDefault = config('database.default');
 
     try {
         // Create the file first so Laravel's SQLite connector can find it.
         touch($tmpDb);
 
-        // Register a named connection for the temp file so we don't touch the :memory: test DB.
+        // Register a named connection for the temp file so we don't touch the real test DB.
         config(['database.connections.restore_test' => [
             'driver' => 'sqlite',
             'database' => $tmpDb,
@@ -79,7 +80,7 @@ it('restores a backup and results in expected database state', function () {
         expect($count)->toBe(0);
 
     } finally {
-        config(['database.default' => 'sqlite']);
+        config(['database.default' => $originalDefault]);
         DB::purge('restore_test');
         @unlink($tmpDb);
         @unlink($gzFile);
@@ -91,10 +92,10 @@ it('aborts cross-type restore with clear error when pgloader is not installed', 
         'which pgloader' => Process::result('', '', 1),
     ]);
 
-    // pgsql-typed backup on a sqlite target — cross-type
-    makeBackupFile('backup_2026-01-01_00-00-00_pgsql.sql.gz', '-- PostgreSQL dump');
+    // mysql-typed backup is always cross-type regardless of whether the test DB is sqlite or pgsql
+    makeBackupFile('backup_2026-01-01_00-00-00_mysql.sql.gz', '-- MySQL dump');
 
-    $this->artisan('app:backup-restore', ['filename' => 'backup_2026-01-01_00-00-00_pgsql.sql.gz'])
+    $this->artisan('app:backup-restore', ['filename' => 'backup_2026-01-01_00-00-00_mysql.sql.gz'])
         ->assertFailed()
         ->expectsOutputToContain('pgloader');
 });

--- a/tests/Feature/Commands/RestoreBackupTest.php
+++ b/tests/Feature/Commands/RestoreBackupTest.php
@@ -170,6 +170,8 @@ it('enters and exits maintenance mode during restore when offline_during_restore
 });
 
 it('notifies backup managers on successful restore', function () {
+    Notification::fake();
+
     $manager = User::factory()->withRole('Backup Manager')->create();
 
     // Mock RestoreService so tables are never dropped — notification queries stay intact
@@ -211,6 +213,8 @@ it('passes production guard when APP_ENV is backup-restore', function () {
 });
 
 it('notifies backup managers on restore failure', function () {
+    Notification::fake();
+
     $manager = User::factory()->withRole('Backup Manager')->create();
 
     $this->mock(RestoreService::class)

--- a/tests/Feature/Models/UserOnboardingWizardTest.php
+++ b/tests/Feature/Models/UserOnboardingWizardTest.php
@@ -81,9 +81,25 @@ test('currentOnboardingStep returns discord for a Stowaway with parent_allows_di
 
 // ─── currentOnboardingStep() — Stowaway waiting step ─────────────────────────
 
-test('currentOnboardingStep returns waiting for a Stowaway who has linked Discord', function () {
+test('currentOnboardingStep returns discord-join for a Stowaway who has linked Discord but not joined the server', function () {
     $user = User::factory()->create(['membership_level' => MembershipLevel::Stowaway]);
     DiscordAccount::factory()->active()->for($user)->create();
+
+    expect($user->currentOnboardingStep())->toBe('discord-join');
+});
+
+test('currentOnboardingStep returns waiting for a Stowaway who has linked Discord and completed the join step', function () {
+    $user = User::factory()->create(['membership_level' => MembershipLevel::Stowaway]);
+    DiscordAccount::factory()->active()->for($user)->create();
+
+    ActivityLog::create([
+        'causer_id' => $user->id,
+        'subject_type' => User::class,
+        'subject_id' => $user->id,
+        'action' => 'onboarding_discord_join_done',
+        'description' => 'Confirmed joining Discord server.',
+        'meta' => [],
+    ]);
 
     expect($user->currentOnboardingStep())->toBe('waiting');
 });

--- a/tests/Feature/Onboarding/WizardDashboardTakeoverTest.php
+++ b/tests/Feature/Onboarding/WizardDashboardTakeoverTest.php
@@ -216,6 +216,14 @@ test('Dismiss button is present on the waiting step', function () {
         'rules_accepted_at' => now(),
     ]);
     DiscordAccount::factory()->active()->for($user)->create();
+    ActivityLog::create([
+        'causer_id' => $user->id,
+        'subject_type' => User::class,
+        'subject_id' => $user->id,
+        'action' => 'onboarding_discord_join_done',
+        'description' => 'Confirmed joining Discord server.',
+        'meta' => [],
+    ]);
     loginAs($user);
 
     Volt::test('onboarding.wizard')

--- a/tests/Feature/Onboarding/WizardWaitingStepTest.php
+++ b/tests/Feature/Onboarding/WizardWaitingStepTest.php
@@ -10,12 +10,33 @@ use Livewire\Volt\Volt;
 
 // ─── Waiting step visibility ──────────────────────────────────────────────────
 
-test('Stowaway who linked Discord sees the waiting step', function () {
+test('Stowaway who linked Discord sees the discord-join step before completing it', function () {
     $user = User::factory()->create([
         'membership_level' => MembershipLevel::Stowaway,
         'rules_accepted_at' => now(),
     ]);
     DiscordAccount::factory()->active()->for($user)->create();
+    loginAs($user);
+
+    Volt::test('onboarding.wizard')
+        ->assertSet('step', 'discord-join')
+        ->assertSee('Join Our Discord Server');
+});
+
+test('Stowaway who linked Discord and completed the join step sees the waiting step', function () {
+    $user = User::factory()->create([
+        'membership_level' => MembershipLevel::Stowaway,
+        'rules_accepted_at' => now(),
+    ]);
+    DiscordAccount::factory()->active()->for($user)->create();
+    ActivityLog::create([
+        'causer_id' => $user->id,
+        'subject_type' => User::class,
+        'subject_id' => $user->id,
+        'action' => 'onboarding_discord_join_done',
+        'description' => 'Confirmed joining Discord server.',
+        'meta' => [],
+    ]);
     loginAs($user);
 
     Volt::test('onboarding.wizard')
@@ -72,6 +93,14 @@ test('waiting card explains the approval process', function () {
         'rules_accepted_at' => now(),
     ]);
     DiscordAccount::factory()->active()->for($user)->create();
+    ActivityLog::create([
+        'causer_id' => $user->id,
+        'subject_type' => User::class,
+        'subject_id' => $user->id,
+        'action' => 'onboarding_discord_join_done',
+        'description' => 'Confirmed joining Discord server.',
+        'meta' => [],
+    ]);
     loginAs($user);
 
     Volt::test('onboarding.wizard')
@@ -85,6 +114,14 @@ test('waiting card has no action button besides Dismiss', function () {
         'rules_accepted_at' => now(),
     ]);
     DiscordAccount::factory()->active()->for($user)->create();
+    ActivityLog::create([
+        'causer_id' => $user->id,
+        'subject_type' => User::class,
+        'subject_id' => $user->id,
+        'action' => 'onboarding_discord_join_done',
+        'description' => 'Confirmed joining Discord server.',
+        'meta' => [],
+    ]);
     loginAs($user);
 
     Volt::test('onboarding.wizard')
@@ -128,6 +165,14 @@ test('Dismiss from the waiting step sets dismissed_at', function () {
         'rules_accepted_at' => now(),
     ]);
     DiscordAccount::factory()->active()->for($user)->create();
+    ActivityLog::create([
+        'causer_id' => $user->id,
+        'subject_type' => User::class,
+        'subject_id' => $user->id,
+        'action' => 'onboarding_discord_join_done',
+        'description' => 'Confirmed joining Discord server.',
+        'meta' => [],
+    ]);
     loginAs($user);
 
     Volt::test('onboarding.wizard')

--- a/tests/Feature/Services/BackupStorageServiceTest.php
+++ b/tests/Feature/Services/BackupStorageServiceTest.php
@@ -140,3 +140,53 @@ it('app:backup-push-s3 is scheduled every 3 days at 03:30', function () {
     expect($events->isNotEmpty())->toBeTrue()
         ->and($events->first()->expression)->toBe('30 3 */3 * *');
 });
+
+// ── isConfigured / isConnected ────────────────────────────────────────────────
+
+it('isConfigured returns true when S3 credentials are set', function () {
+    config(['filesystems.disks.s3.key' => 'fake-key', 'filesystems.disks.s3.bucket' => 'fake-bucket']);
+
+    expect(app(BackupStorageService::class)->isConfigured())->toBeTrue();
+});
+
+it('isConfigured returns false when S3 key is missing', function () {
+    config(['filesystems.disks.s3.key' => null, 'filesystems.disks.s3.bucket' => 'fake-bucket']);
+
+    expect(app(BackupStorageService::class)->isConfigured())->toBeFalse();
+});
+
+it('isConnected returns true when S3 is reachable', function () {
+    config(['filesystems.disks.s3.key' => 'fake-key', 'filesystems.disks.s3.bucket' => 'fake-bucket']);
+
+    // Storage::fake('s3') is set up in beforeEach; a successful list() call means connected
+    expect(app(BackupStorageService::class)->isConnected())->toBeTrue();
+});
+
+it('isConnected returns false when S3 is not configured', function () {
+    config(['filesystems.disks.s3.key' => null, 'filesystems.disks.s3.bucket' => null]);
+
+    expect(app(BackupStorageService::class)->isConnected())->toBeFalse();
+});
+
+// ── listWithMetadata ──────────────────────────────────────────────────────────
+
+it('listWithMetadata returns filename, size, and date for each S3 backup', function () {
+    Storage::disk('s3')->put('backups/backup_2026-03-01_03-00-00_sqlite.sql.gz', 'gz content');
+
+    $list = app(BackupStorageService::class)->listWithMetadata();
+
+    expect($list)->toHaveCount(1)
+        ->and($list[0]['filename'])->toBe('backup_2026-03-01_03-00-00_sqlite.sql.gz')
+        ->and($list[0]['key'])->toBe('backups/backup_2026-03-01_03-00-00_sqlite.sql.gz')
+        ->and($list[0])->toHaveKeys(['filename', 'key', 'size', 'date']);
+});
+
+it('listWithMetadata returns newest-first ordering', function () {
+    Storage::disk('s3')->put('backups/backup_2026-01-01_03-00-00_sqlite.sql.gz', 'a');
+    Storage::disk('s3')->put('backups/backup_2026-03-01_03-00-00_sqlite.sql.gz', 'b');
+
+    $list = app(BackupStorageService::class)->listWithMetadata();
+
+    expect($list[0]['filename'])->toContain('2026-03-01')
+        ->and($list[1]['filename'])->toContain('2026-01-01');
+});

--- a/tests/Feature/Services/BackupStorageServiceTest.php
+++ b/tests/Feature/Services/BackupStorageServiceTest.php
@@ -63,6 +63,12 @@ it('deletes an S3 backup by key', function () {
 // ── S3 retention tiers ────────────────────────────────────────────────────────
 
 it('S3 retention keeps 2 most recent, 1 per week for 4 weeks, 1 per month for 3 months', function () {
+    // Freeze to the last day of the current month (at noon) so that all 4-week
+    // window files land in the current calendar month and month-1 is unambiguously
+    // the previous month — prevents false extra deletions when the test runs early
+    // in a new month (e.g. May 1 puts "month-1" = April which also holds week files).
+    $this->travelTo(now()->endOfMonth()->setTime(12, 0, 0));
+
     $service = app(BackupStorageService::class);
     $now = now();
 

--- a/tests/Feature/Services/BackupStorageServiceTest.php
+++ b/tests/Feature/Services/BackupStorageServiceTest.php
@@ -107,6 +107,8 @@ it('S3 retention returns empty when no files exist', function () {
 // ── PushBackupToS3 command ────────────────────────────────────────────────────
 
 it('app:backup-push-s3 uploads most recent local backup to S3', function () {
+    config(['filesystems.disks.s3.key' => 'fake-key', 'filesystems.disks.s3.bucket' => 'fake-bucket']);
+
     $dir = storage_path('app/backups');
     if (! is_dir($dir)) {
         mkdir($dir, 0755, true);

--- a/tests/Feature/Services/BackupStorageServiceTest.php
+++ b/tests/Feature/Services/BackupStorageServiceTest.php
@@ -1,0 +1,142 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Services\BackupRetentionService;
+use App\Services\BackupStorageService;
+use Illuminate\Support\Facades\Storage;
+
+uses()->group('backup', 's3');
+
+beforeEach(function () {
+    Storage::fake('s3');
+});
+
+// ── BackupStorageService ──────────────────────────────────────────────────────
+
+it('uploads a local backup to S3 under the backups/ prefix', function () {
+    $tmpFile = tempnam(sys_get_temp_dir(), 'backup_').'.sql.gz';
+    file_put_contents($tmpFile, 'test content');
+
+    $service = app(BackupStorageService::class);
+    $key = $service->upload($tmpFile);
+
+    expect($key)->toStartWith('backups/')
+        ->and(Storage::disk('s3')->exists($key))->toBeTrue();
+
+    @unlink($tmpFile);
+});
+
+it('lists S3 backups sorted newest-first by filename timestamp', function () {
+    Storage::disk('s3')->put('backups/backup_2026-01-01_03-00-00_sqlite.sql.gz', 'a');
+    Storage::disk('s3')->put('backups/backup_2026-01-10_03-00-00_sqlite.sql.gz', 'b');
+    Storage::disk('s3')->put('backups/backup_2026-01-05_03-00-00_sqlite.sql.gz', 'c');
+
+    $list = app(BackupStorageService::class)->list();
+
+    expect($list[0])->toContain('2026-01-10')
+        ->and($list[1])->toContain('2026-01-05')
+        ->and($list[2])->toContain('2026-01-01');
+});
+
+it('downloads an S3 backup to a temp file', function () {
+    Storage::disk('s3')->put('backups/backup_2026-01-01_03-00-00_sqlite.sql.gz', 'gz content');
+
+    $service = app(BackupStorageService::class);
+    $tmpPath = $service->download('backups/backup_2026-01-01_03-00-00_sqlite.sql.gz');
+
+    expect(file_exists($tmpPath))->toBeTrue()
+        ->and(file_get_contents($tmpPath))->toBe('gz content');
+
+    @unlink($tmpPath);
+});
+
+it('deletes an S3 backup by key', function () {
+    $key = 'backups/backup_2026-01-01_03-00-00_sqlite.sql.gz';
+    Storage::disk('s3')->put($key, 'data');
+
+    app(BackupStorageService::class)->delete($key);
+
+    expect(Storage::disk('s3')->exists($key))->toBeFalse();
+});
+
+// ── S3 retention tiers ────────────────────────────────────────────────────────
+
+it('S3 retention keeps 2 most recent, 1 per week for 4 weeks, 1 per month for 3 months', function () {
+    $service = app(BackupStorageService::class);
+    $now = now();
+
+    // Tier-1 targets: 2 most recent (days 0 and 3)
+    $t1a = 'backups/backup_'.$now->copy()->subDays(0)->format('Y-m-d').'_03-00-00_sqlite.sql.gz';
+    $t1b = 'backups/backup_'.$now->copy()->subDays(3)->format('Y-m-d').'_03-00-00_sqlite.sql.gz';
+
+    // Tier-2 targets: 1 per 7-day window
+    $w1 = 'backups/backup_'.$now->copy()->subDays(6)->format('Y-m-d').'_03-00-00_sqlite.sql.gz';
+    $w2 = 'backups/backup_'.$now->copy()->subDays(10)->format('Y-m-d').'_03-00-00_sqlite.sql.gz';
+    $w3 = 'backups/backup_'.$now->copy()->subDays(17)->format('Y-m-d').'_03-00-00_sqlite.sql.gz';
+    $w4 = 'backups/backup_'.$now->copy()->subDays(24)->format('Y-m-d').'_03-00-00_sqlite.sql.gz';
+
+    // Tier-3 targets: 1 per calendar month (1, 2, 3 months ago)
+    $m1 = 'backups/backup_'.$now->copy()->subMonths(1)->format('Y-m-d').'_03-00-00_sqlite.sql.gz';
+    $m2 = 'backups/backup_'.$now->copy()->subMonths(2)->format('Y-m-d').'_03-00-00_sqlite.sql.gz';
+    $m3 = 'backups/backup_'.$now->copy()->subMonths(3)->format('Y-m-d').'_03-00-00_sqlite.sql.gz';
+
+    // Old file that should be deleted (5 months ago)
+    $old = 'backups/backup_'.$now->copy()->subMonths(5)->format('Y-m-d').'_03-00-00_sqlite.sql.gz';
+
+    $allKeys = [$t1a, $t1b, $w1, $w2, $w3, $w4, $m1, $m2, $m3, $old];
+    foreach ($allKeys as $key) {
+        Storage::disk('s3')->put($key, 'data');
+    }
+
+    $deleted = app(BackupRetentionService::class)->enforceS3Retention($service);
+
+    expect(Storage::disk('s3')->exists($old))->toBeFalse()
+        ->and($deleted)->toContain($old);
+
+    // w1 (day 6) is superseded by t1a (day 0) for the week-1 window; old (5 months) has no tier
+    expect(count($deleted))->toBe(2);
+});
+
+it('S3 retention returns empty when no files exist', function () {
+    $deleted = app(BackupRetentionService::class)->enforceS3Retention(app(BackupStorageService::class));
+
+    expect($deleted)->toBeEmpty();
+});
+
+// ── PushBackupToS3 command ────────────────────────────────────────────────────
+
+it('app:backup-push-s3 uploads most recent local backup to S3', function () {
+    $dir = storage_path('app/backups');
+    if (! is_dir($dir)) {
+        mkdir($dir, 0755, true);
+    }
+
+    $path = "{$dir}/backup_".now()->format('Y-m-d_H-i-s').'_sqlite.sql.gz';
+    $gz = gzopen($path, 'wb');
+    gzwrite($gz, '-- SQLite dump');
+    gzclose($gz);
+
+    $this->artisan('app:backup-push-s3')->assertSuccessful();
+
+    $list = app(BackupStorageService::class)->list();
+    expect($list)->not->toBeEmpty();
+
+    @unlink($path);
+});
+
+it('app:backup-push-s3 fails when no local backups exist', function () {
+    foreach (glob(storage_path('app/backups/*.sql.gz')) ?: [] as $f) {
+        @unlink($f);
+    }
+
+    $this->artisan('app:backup-push-s3')->assertFailed();
+});
+
+it('app:backup-push-s3 is scheduled every 3 days at 03:30', function () {
+    $events = collect(app(\Illuminate\Console\Scheduling\Schedule::class)->events())
+        ->filter(fn ($e) => str_contains($e->command ?? '', 'backup-push-s3'));
+
+    expect($events->isNotEmpty())->toBeTrue()
+        ->and($events->first()->expression)->toBe('30 3 */3 * *');
+});

--- a/tests/Feature/Services/BackupStorageServiceTest.php
+++ b/tests/Feature/Services/BackupStorageServiceTest.php
@@ -76,10 +76,12 @@ it('S3 retention keeps 2 most recent, 1 per week for 4 weeks, 1 per month for 3 
     $w3 = 'backups/backup_'.$now->copy()->subDays(17)->format('Y-m-d').'_03-00-00_sqlite.sql.gz';
     $w4 = 'backups/backup_'.$now->copy()->subDays(24)->format('Y-m-d').'_03-00-00_sqlite.sql.gz';
 
-    // Tier-3 targets: 1 per calendar month (1, 2, 3 months ago)
-    $m1 = 'backups/backup_'.$now->copy()->subMonths(1)->format('Y-m-d').'_03-00-00_sqlite.sql.gz';
-    $m2 = 'backups/backup_'.$now->copy()->subMonths(2)->format('Y-m-d').'_03-00-00_sqlite.sql.gz';
-    $m3 = 'backups/backup_'.$now->copy()->subMonths(3)->format('Y-m-d').'_03-00-00_sqlite.sql.gz';
+    // Tier-3 targets: 1 per calendar month (1, 2, 3 months ago).
+    // Anchor to the 1st of the current month to avoid date-of-month overflow
+    // (e.g. April 29 - 2 months naively = March 1, not February).
+    $m1 = 'backups/backup_'.$now->copy()->startOfMonth()->subMonths(1)->format('Y-m-d').'_03-00-00_sqlite.sql.gz';
+    $m2 = 'backups/backup_'.$now->copy()->startOfMonth()->subMonths(2)->format('Y-m-d').'_03-00-00_sqlite.sql.gz';
+    $m3 = 'backups/backup_'.$now->copy()->startOfMonth()->subMonths(3)->format('Y-m-d').'_03-00-00_sqlite.sql.gz';
 
     // Old file that should be deleted (5 months ago)
     $old = 'backups/backup_'.$now->copy()->subMonths(5)->format('Y-m-d').'_03-00-00_sqlite.sql.gz';


### PR DESCRIPTION
## What Changed

Backup Managers can now create, download, restore, and delete database backups directly from the Staff Ready Room — no SSH or command-line access required. The system automatically creates a daily backup at 3:00 AM, pushes a copy to S3 every three days, and cleans up old files on a configurable retention schedule. A new Backup Management dashboard is accessible via the Ready Room header to anyone assigned the Backup Manager role.

## How to Test

### Accessing the Dashboard

1. Assign the "Backup Manager" role to a staff position, or grant it directly to a test user.
2. Log in as that user and go to the Staff Ready Room.
3. Expected: a **Backups** button appears in the Ready Room header.
4. Click it — you should land on `/backups`.
5. Log in as a user WITHOUT the Backup Manager role — expected: no Backups button, and navigating to `/backups` returns 403.

### Creating a Backup

1. On the Backup Dashboard, click **Create Backup Now**.
2. Expected: a "Backup job queued" toast appears.
3. Wait ~10 seconds and refresh the page.
4. Expected: a new backup file appears in the **Local Backups** table with today's timestamp, a non-zero size, and the correct database type label.

### Downloading a Backup

1. In the Local Backups table, click **Download** on any row.
2. Expected: a `.sql.gz` file downloads to your browser.

### Uploading a Backup

1. Click the file picker in the **Upload Backup** section.
2. Select a valid `.sql.gz` backup file.
3. Click **Upload** — expected: "Uploaded {filename}" toast and file appears in Local Backups.
4. Try uploading a file that does NOT end in `.sql.gz` (e.g., rename a `.tar.gz`) — expected: error message, file not stored.

### Deleting a Backup

1. Click **Delete** on a backup row.
2. Confirm in the modal.
3. Expected: backup disappears from the list.

### Restoring a Backup

1. Click **Restore** on a local backup row.
2. Read the confirmation modal carefully — it shows the filename being restored from.
3. Click **Restore** to confirm.
4. Expected: "Restore job queued" toast. The restore runs in the background. Note: by default, this puts the site in maintenance mode while it runs and brings it back up when done.

### Settings Toggles

1. Toggle **Take site offline during backup** on and off — expected: each change persists if you refresh.
2. Toggle **Take site offline during restore** on and off — expected: same.

### S3 Panel

1. If S3 is NOT configured on this environment, expected: S3 Backups panel shows a grey "S3 Not Configured" badge.
2. If S3 IS configured and reachable, expected: green "S3 Connected" badge and a list of S3 backup files (if any exist).
3. On a configured environment, test Download and Delete on an S3 backup row.

### Storage Stats Panel

1. Scroll to the **File Asset Storage** section.
2. Expected: a table listing staff photos, board member photos, community stories, message images, blog images, report evidence, and blog category hero — with file counts and sizes.

## Things to Watch For

- Backup Manager role: the role should appear in the role manager under the Admin section and be assignable to any staff position.
- The "Backups" button in the Ready Room should only appear for users with the Backup Manager role — not all staff.
- The restore confirmation modal should clearly display the filename being restored from before the user confirms.
- After a restore, verify the site comes back online (no stuck maintenance mode).
- Dashboard-triggered backups and restores do NOT send email notifications — only the automated scheduled backup (3:00 AM) sends notifications. Verify you don't receive a spurious email when creating a backup manually.
- The upload form should reject `.gz` files that don't end in `.sql.gz` with a clear error message.
- S3 panel: if S3 credentials are set but the bucket is unreachable, the badge should show red "S3 Unreachable" rather than crashing.

## Parent PRD

#656

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Backup Management dashboard with create/download/restore/upload/delete, scheduled automated backups/cleanup/S3 uploads, maintenance-mode toggles, storage stats, and Ready Room access for authorized users
  * Artisan commands and queued jobs for create/restore/cleanup/push-to-S3; S3 upload with tiered retention and cross-type restore support
  * Notifications (email + optional Pushover) for backup/restore success or failure

* **Documentation**
  * Complete Backup Management docs and staff handbook pages

* **Tests**
  * Feature and service tests covering dashboard, commands, storage, retention, and restore flows

* **Chores**
  * Ignore backups directory in VCS; seed Backup Manager role and backup-related site config entries
<!-- end of auto-generated comment: release notes by coderabbit.ai -->