### PR TITLE
fix: restore status tracking and PostgreSQL schema wipe ownership error

### DIFF
--- a/app/Jobs/RestoreBackupJob.php
+++ b/app/Jobs/RestoreBackupJob.php
@@ -3,6 +3,7 @@
 namespace App\Jobs;
 
 use App\Services\RestoreService;
+use App\Services\RestoreStatusService;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Queue\Queueable;
 
@@ -12,8 +13,19 @@ class RestoreBackupJob implements ShouldQueue
 
     public function __construct(public string $path) {}
 
-    public function handle(RestoreService $service): void
+    public function handle(RestoreService $service, RestoreStatusService $statusService): void
     {
-        $service->restore($this->path);
+        $statusService->set('running', ['started_at' => now()->toIso8601String()]);
+
+        try {
+            $service->restore($this->path);
+            $statusService->set('completed', ['completed_at' => now()->toIso8601String()]);
+        } catch (\Throwable $e) {
+            $statusService->set('failed', [
+                'error' => $e->getMessage(),
+                'completed_at' => now()->toIso8601String(),
+            ]);
+            throw $e;
+        }
     }
 }

--- a/app/Services/RestoreService.php
+++ b/app/Services/RestoreService.php
@@ -113,7 +113,14 @@ BEGIN
 END $$;
 SQL;
         $tempFile = tempnam(sys_get_temp_dir(), 'wipe_pg_');
-        file_put_contents($tempFile, $wipeSql);
+        if ($tempFile === false) {
+            throw new \RuntimeException('Failed to create temporary file for PostgreSQL wipe SQL');
+        }
+
+        if (file_put_contents($tempFile, $wipeSql) === false) {
+            @unlink($tempFile);
+            throw new \RuntimeException('Failed to write PostgreSQL wipe SQL to temporary file');
+        }
 
         try {
             $wipeResult = Process::run(

--- a/app/Services/RestoreService.php
+++ b/app/Services/RestoreService.php
@@ -94,10 +94,34 @@ class RestoreService
             .' -U '.escapeshellarg($config['username'])
             .' '.escapeshellarg($config['database']);
 
-        // Wipe the public schema so the restore starts against an empty database.
-        $wipeResult = Process::run(
-            $envPrefix.' psql'.$connArgs.' -c "DROP SCHEMA public CASCADE; CREATE SCHEMA public;"'
-        );
+        // Drop all objects in the public schema without requiring schema ownership.
+        // DROP SCHEMA CASCADE requires the user to own the schema (PostgreSQL 15+),
+        // but dropping individual tables/sequences/views works with table ownership.
+        $wipeSql = <<<'SQL'
+DO $$
+DECLARE r RECORD;
+BEGIN
+    FOR r IN (SELECT tablename FROM pg_tables WHERE schemaname = 'public') LOOP
+        EXECUTE 'DROP TABLE IF EXISTS public.' || quote_ident(r.tablename) || ' CASCADE';
+    END LOOP;
+    FOR r IN (SELECT sequence_name FROM information_schema.sequences WHERE sequence_schema = 'public') LOOP
+        EXECUTE 'DROP SEQUENCE IF EXISTS public.' || quote_ident(r.sequence_name) || ' CASCADE';
+    END LOOP;
+    FOR r IN (SELECT table_name FROM information_schema.views WHERE table_schema = 'public') LOOP
+        EXECUTE 'DROP VIEW IF EXISTS public.' || quote_ident(r.table_name) || ' CASCADE';
+    END LOOP;
+END $$;
+SQL;
+        $tempFile = tempnam(sys_get_temp_dir(), 'wipe_pg_');
+        file_put_contents($tempFile, $wipeSql);
+
+        try {
+            $wipeResult = Process::run(
+                $envPrefix.' psql'.$connArgs.' -f '.escapeshellarg($tempFile)
+            );
+        } finally {
+            @unlink($tempFile);
+        }
 
         if (! $wipeResult->successful()) {
             throw new \RuntimeException('Failed to wipe PostgreSQL schema before restore: '.$wipeResult->errorOutput());

--- a/app/Services/RestoreStatusService.php
+++ b/app/Services/RestoreStatusService.php
@@ -15,7 +15,10 @@ class RestoreStatusService
     {
         $existing = $this->read();
         $data = array_merge($existing, ['status' => $status], $extra);
-        file_put_contents($this->path, json_encode($data));
+        $encoded = json_encode($data, JSON_THROW_ON_ERROR);
+        if (file_put_contents($this->path, $encoded) === false) {
+            throw new \RuntimeException('Failed to write restore status file: '.$this->path);
+        }
     }
 
     public function read(): array

--- a/app/Services/RestoreStatusService.php
+++ b/app/Services/RestoreStatusService.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Services;
+
+class RestoreStatusService
+{
+    private string $path;
+
+    public function __construct()
+    {
+        $this->path = storage_path('app/restore-status.json');
+    }
+
+    public function set(string $status, array $extra = []): void
+    {
+        $existing = $this->read();
+        $data = array_merge($existing, ['status' => $status], $extra);
+        file_put_contents($this->path, json_encode($data));
+    }
+
+    public function read(): array
+    {
+        if (! file_exists($this->path)) {
+            return [];
+        }
+        $data = json_decode((string) file_get_contents($this->path), true);
+
+        return is_array($data) ? $data : [];
+    }
+
+    public function clear(): void
+    {
+        @unlink($this->path);
+    }
+}

--- a/resources/views/livewire/backup/dashboard.blade.php
+++ b/resources/views/livewire/backup/dashboard.blade.php
@@ -445,7 +445,7 @@ new class extends Component
     @php $jobStatus = $this->backupJobStatus; $restoreStatus = $this->restoreJobStatus; @endphp
     @if (in_array($jobStatus['status'], ['queued', 'running']) || in_array($restoreStatus['status'], ['queued', 'running']) || ($jobStatus['status'] === 'completed' && ! collect($this->localBackups)->contains('filename', $jobStatus['filename'])))
         <div wire:poll.3s></div>
-    @elseif ($jobStatus['status'] === 'completed' || in_array($restoreStatus['status'], ['completed', 'failed']))
+    @elseif ($jobStatus['status'] === 'completed' || $restoreStatus['status'] === 'completed')
         <div wire:poll.30s></div>
     @endif
 

--- a/resources/views/livewire/backup/dashboard.blade.php
+++ b/resources/views/livewire/backup/dashboard.blade.php
@@ -338,12 +338,18 @@ new class extends Component
             return;
         }
 
+        try {
+            RestoreBackupJob::dispatch($path);
+        } catch (\Throwable $e) {
+            $lock->release();
+            throw $e;
+        }
+
         app(RestoreStatusService::class)->set('queued', [
             'filename' => $this->restoreTarget,
             'queued_at' => now()->toIso8601String(),
         ]);
 
-        RestoreBackupJob::dispatch($path);
         unset($this->restoreJobStatus);
         $this->restoreTarget = null;
         Flux::modal('confirm-restore')->close();

--- a/resources/views/livewire/backup/dashboard.blade.php
+++ b/resources/views/livewire/backup/dashboard.blade.php
@@ -3,6 +3,7 @@
 use App\Jobs\RestoreBackupJob;
 use App\Models\SiteConfig;
 use App\Services\BackupStorageService;
+use App\Services\RestoreStatusService;
 use Flux\Flux;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Storage;
@@ -180,6 +181,38 @@ new class extends Component
         unset($this->backupJobStatus);
     }
 
+    #[\Livewire\Attributes\Computed]
+    public function restoreJobStatus(): array
+    {
+        $data = app(RestoreStatusService::class)->read();
+        $status = $data['status'] ?? null;
+
+        if ($status === 'completed' && isset($data['completed_at'])) {
+            if (now()->diffInSeconds(\Carbon\Carbon::parse($data['completed_at'])) > 60) {
+                $status = null;
+            }
+        }
+
+        return [
+            'status' => $status,
+            'filename' => $data['filename'] ?? null,
+            'timestamp' => match (true) {
+                $status === 'queued' && isset($data['queued_at']) => \Carbon\Carbon::parse($data['queued_at'])->diffForHumans(),
+                $status === 'running' && isset($data['started_at']) => \Carbon\Carbon::parse($data['started_at'])->diffForHumans(),
+                in_array($status, ['completed', 'failed']) && isset($data['completed_at']) => \Carbon\Carbon::parse($data['completed_at'])->diffForHumans(),
+                default => null,
+            },
+            'error' => $data['error'] ?? null,
+        ];
+    }
+
+    public function dismissRestoreStatus(): void
+    {
+        $this->authorize('backup-manager');
+        app(RestoreStatusService::class)->clear();
+        unset($this->restoreJobStatus);
+    }
+
     public function createBackup(): void
     {
         $this->authorize('backup-manager');
@@ -305,7 +338,13 @@ new class extends Component
             return;
         }
 
+        app(RestoreStatusService::class)->set('queued', [
+            'filename' => $this->restoreTarget,
+            'queued_at' => now()->toIso8601String(),
+        ]);
+
         RestoreBackupJob::dispatch($path);
+        unset($this->restoreJobStatus);
         $this->restoreTarget = null;
         Flux::modal('confirm-restore')->close();
         Flux::toast('Restore job queued.', 'Success', variant: 'success');
@@ -397,10 +436,10 @@ new class extends Component
     </div>
 
     {{-- Poll while a job is in-flight, one extra cycle to refresh the file list, or every 30s while the completed badge is still showing --}}
-    @php $jobStatus = $this->backupJobStatus; @endphp
-    @if (in_array($jobStatus['status'], ['queued', 'running']) || ($jobStatus['status'] === 'completed' && ! collect($this->localBackups)->contains('filename', $jobStatus['filename'])))
+    @php $jobStatus = $this->backupJobStatus; $restoreStatus = $this->restoreJobStatus; @endphp
+    @if (in_array($jobStatus['status'], ['queued', 'running']) || in_array($restoreStatus['status'], ['queued', 'running']) || ($jobStatus['status'] === 'completed' && ! collect($this->localBackups)->contains('filename', $jobStatus['filename'])))
         <div wire:poll.3s></div>
-    @elseif ($jobStatus['status'] === 'completed')
+    @elseif ($jobStatus['status'] === 'completed' || in_array($restoreStatus['status'], ['completed', 'failed']))
         <div wire:poll.30s></div>
     @endif
 
@@ -410,20 +449,40 @@ new class extends Component
             <div class="flex items-center gap-3">
                 <flux:heading size="lg">Local Backups</flux:heading>
                 @if ($jobStatus['status'] === 'queued')
-                    <flux:badge color="yellow" icon="clock">Queued{{ $jobStatus['updated_at'] ? ' · '.$jobStatus['updated_at'] : '' }}</flux:badge>
+                    <flux:badge color="yellow" icon="clock">Backup: Queued{{ $jobStatus['updated_at'] ? ' · '.$jobStatus['updated_at'] : '' }}</flux:badge>
                 @elseif ($jobStatus['status'] === 'running')
-                    <flux:badge color="blue" icon="arrow-path">Running{{ $jobStatus['updated_at'] ? ' · '.$jobStatus['updated_at'] : '' }}</flux:badge>
+                    <flux:badge color="blue" icon="arrow-path">Backup: Running{{ $jobStatus['updated_at'] ? ' · '.$jobStatus['updated_at'] : '' }}</flux:badge>
                 @elseif ($jobStatus['status'] === 'completed')
                     <div class="flex items-center gap-1">
-                        <flux:badge color="green" icon="check-circle">Completed{{ $jobStatus['updated_at'] ? ' · '.$jobStatus['updated_at'] : '' }}</flux:badge>
+                        <flux:badge color="green" icon="check-circle">Backup: Completed{{ $jobStatus['updated_at'] ? ' · '.$jobStatus['updated_at'] : '' }}</flux:badge>
                         <button wire:click="dismissJobStatus" type="button" class="p-0.5 rounded text-zinc-400 hover:text-zinc-600 dark:hover:text-zinc-300 hover:bg-zinc-100 dark:hover:bg-zinc-800" aria-label="Dismiss">
                             <svg class="size-3.5" fill="none" viewBox="0 0 24 24" stroke-width="2.5" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" /></svg>
                         </button>
                     </div>
                 @elseif ($jobStatus['status'] === 'failed')
                     <div class="flex items-center gap-1">
-                        <flux:badge color="red" icon="exclamation-triangle">Failed{{ $jobStatus['updated_at'] ? ' · '.$jobStatus['updated_at'] : '' }}</flux:badge>
+                        <flux:badge color="red" icon="exclamation-triangle">Backup: Failed{{ $jobStatus['updated_at'] ? ' · '.$jobStatus['updated_at'] : '' }}</flux:badge>
                         <button wire:click="dismissJobStatus" type="button" class="p-0.5 rounded text-zinc-400 hover:text-zinc-600 dark:hover:text-zinc-600 hover:bg-zinc-100 dark:hover:bg-zinc-800" aria-label="Dismiss">
+                            <svg class="size-3.5" fill="none" viewBox="0 0 24 24" stroke-width="2.5" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" /></svg>
+                        </button>
+                    </div>
+                @endif
+
+                @if ($restoreStatus['status'] === 'queued')
+                    <flux:badge color="yellow" icon="clock">Restore: Queued{{ $restoreStatus['timestamp'] ? ' · '.$restoreStatus['timestamp'] : '' }}</flux:badge>
+                @elseif ($restoreStatus['status'] === 'running')
+                    <flux:badge color="blue" icon="arrow-path">Restore: Running{{ $restoreStatus['timestamp'] ? ' · '.$restoreStatus['timestamp'] : '' }}</flux:badge>
+                @elseif ($restoreStatus['status'] === 'completed')
+                    <div class="flex items-center gap-1">
+                        <flux:badge color="green" icon="check-circle">Restore: Completed{{ $restoreStatus['timestamp'] ? ' · '.$restoreStatus['timestamp'] : '' }}</flux:badge>
+                        <button wire:click="dismissRestoreStatus" type="button" class="p-0.5 rounded text-zinc-400 hover:text-zinc-600 dark:hover:text-zinc-300 hover:bg-zinc-100 dark:hover:bg-zinc-800" aria-label="Dismiss">
+                            <svg class="size-3.5" fill="none" viewBox="0 0 24 24" stroke-width="2.5" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" /></svg>
+                        </button>
+                    </div>
+                @elseif ($restoreStatus['status'] === 'failed')
+                    <div class="flex items-center gap-1">
+                        <flux:badge color="red" icon="exclamation-triangle">Restore: Failed{{ $restoreStatus['timestamp'] ? ' · '.$restoreStatus['timestamp'] : '' }}</flux:badge>
+                        <button wire:click="dismissRestoreStatus" type="button" class="p-0.5 rounded text-zinc-400 hover:text-zinc-600 dark:hover:text-zinc-600 hover:bg-zinc-100 dark:hover:bg-zinc-800" aria-label="Dismiss">
                             <svg class="size-3.5" fill="none" viewBox="0 0 24 24" stroke-width="2.5" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" /></svg>
                         </button>
                     </div>

--- a/tests/Feature/Backup/BackupDashboardTest.php
+++ b/tests/Feature/Backup/BackupDashboardTest.php
@@ -6,6 +6,7 @@ use App\Jobs\RestoreBackupJob;
 use App\Models\SiteConfig;
 use App\Models\User;
 use App\Services\BackupService;
+use App\Services\RestoreStatusService;
 use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Facades\Queue;
 use Illuminate\Support\Facades\Storage;
@@ -31,6 +32,7 @@ afterEach(function () {
     foreach (glob(storage_path('app/backups/test_dash_*.sql.gz')) as $file) {
         @unlink($file);
     }
+    app(RestoreStatusService::class)->clear();
 });
 
 // ── Authorization ─────────────────────────────────────────────────────────────
@@ -145,7 +147,7 @@ it('restore action is blocked in production environment', function () {
     }
 });
 
-it('restore action dispatches RestoreBackupJob', function () {
+it('restore action dispatches RestoreBackupJob and writes queued status', function () {
     Queue::fake();
     $user = User::factory()->withRole('Backup Manager')->create();
     makeLocalBackup('test_dash_restore_2026-04-01_03-00-00_sqlite.sql.gz');
@@ -156,6 +158,24 @@ it('restore action dispatches RestoreBackupJob', function () {
         ->call('restoreBackup');
 
     Queue::assertPushed(RestoreBackupJob::class);
+
+    $status = app(RestoreStatusService::class)->read();
+    expect($status['status'])->toBe('queued');
+    expect($status['filename'])->toBe('test_dash_restore_2026-04-01_03-00-00_sqlite.sql.gz');
+});
+
+it('dismissRestoreStatus clears the restore status file', function () {
+    $user = User::factory()->withRole('Backup Manager')->create();
+    app(RestoreStatusService::class)->set('completed', [
+        'filename' => 'test_dash_restore_2026-04-01_03-00-00_sqlite.sql.gz',
+        'completed_at' => now()->toIso8601String(),
+    ]);
+
+    Volt::actingAs($user)
+        ->test('backup.dashboard')
+        ->call('dismissRestoreStatus');
+
+    expect(app(RestoreStatusService::class)->read())->toBe([]);
 });
 
 it('confirmRestore sets restoreTarget', function () {


### PR DESCRIPTION
## What Changed

Two fixes to the backup restore system:

**1. Restore Status Tracking**

When a restore is initiated, the UI now shows live status — Queued, Running, Completed, or Failed — without relying on the database. Status is stored in a flat file (`storage/app/restore-status.json`) so it survives the DB wipe that happens during restore. The restore status badge appears alongside the existing backup status badge in the Local Backups panel header, with the same dismiss-on-complete behavior.

**2. PostgreSQL Schema Wipe Fix**

The previous approach used `DROP SCHEMA public CASCADE; CREATE SCHEMA public;` to clear the database before a restore. On managed PostgreSQL hosts (Forge, Render, etc.) running PostgreSQL 15+, the DB user doesn't own the `public` schema, causing an ownership error that blocked all restores. The fix uses a DO block to drop individual tables, sequences, and views — the user owns those objects even without schema ownership.

## How to Test

### Restore Status Badges

1. Go to Ready Room → Backups (must have Backup Manager role)
2. Click **Restore** on any local backup and confirm
3. In the Local Backups panel header, a yellow **Restore: Queued** badge should appear immediately
4. As the job runs, it should change to blue **Restore: Running**
5. On completion it shows green **Restore: Completed** (auto-dismisses after 60s, or click ✕)
6. If the restore fails, it shows red **Restore: Failed** with a dismiss button
7. Verify that backup status badges and restore status badges can coexist in the header row

### PostgreSQL Restore (staging environment)

1. Set `APP_ENV=backup-restore` in staging `.env`
2. Initiate a restore from a PostgreSQL backup
3. Expected: restore completes without "must be owner of schema public" error

## Things to Watch For

- The status file (`storage/app/restore-status.json`) persists across restores — a stale "Completed" badge from a previous restore should auto-dismiss after 60 seconds
- After a successful restore the user's session is gone (DB was wiped); the status badge will be visible when they log back in
- Restore can only be initiated from local backups — the S3 panel has no Restore button, so the status badge always reflects local restores

## Parent PRD

#656

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Restore jobs now display live status in the dashboard (queued, running, completed, failed) with phase timestamps and error details.
  * Users can dismiss restore status notifications; completed badges auto-clear after 60s.

* **Improvements**
  * Restore queuing persists status so UI reflects queued restores immediately.
  * Database restore uses a more thorough pre-restore cleanup step.
  * Polling adjusted to reduce frequency when operations are terminal.

* **Tests**
  * Added coverage for restore status persistence and dismissal behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->