### PR TITLE
fix: background check test feedback fixes (#700, #698)

### DIFF
--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -119,6 +119,7 @@ class User extends Authenticatable // implements MustVerifyEmail
             'admin_granted_at' => 'datetime',
             'onboarding_wizard_dismissed_at' => 'datetime',
             'onboarding_wizard_completed_at' => 'datetime',
+            'rules_reminder_sent_at' => 'datetime',
         ];
     }
 

--- a/resources/views/livewire/users/background-checks-card.blade.php
+++ b/resources/views/livewire/users/background-checks-card.blade.php
@@ -27,6 +27,8 @@ new class extends Component {
     public bool $canManage = false;
     #[Locked]
     public bool $canViewRenewal = false;
+    #[Locked]
+    public bool $canViewNotes = false;
 
     // Add-check modal
     public string $newService = '';
@@ -53,6 +55,7 @@ new class extends Component {
         $this->userId = $user->id;
         $this->canManage = (bool) $canManage;
         $this->canViewRenewal = (bool) ($canView || $canManage);
+        $this->canViewNotes = (bool) ($canView || $canManage);
     }
 
     #[Computed]
@@ -278,8 +281,8 @@ new class extends Component {
                             @endif
                         </div>
 
-                        {{-- Notes display as chat bubbles --}}
-                        @if(count($parsedNotes) > 0)
+                        {{-- Notes display as chat bubbles (hidden from self-viewers without view/manage role) --}}
+                        @if($canViewNotes && count($parsedNotes) > 0)
                             <div class="mt-3 space-y-2">
                                 @foreach($parsedNotes as $noteIndex => $note)
                                     @if($note['type'] === 'timestamped')


### PR DESCRIPTION
## What Changed

Two production bug fixes from test feedback on the Background Check Tracking System (PRD #681):

**Fix 1 — ACP Config tab error (#700):**
The Rules Compliance list was crashing with "Call to a member function format() on string" because `rules_reminder_sent_at` was missing from the User model's casts array. Added the `datetime` cast so the field is returned as a Carbon instance.

**Fix 2 — Background check notes hidden from self-viewers (#698):**
Staff notes on a background check record are internal. A user viewing their own check history could previously see all staff notes. Notes are now hidden unless the viewer holds the Background Checks - View or Manage role. Users can still see status, documents, and renewal badges on their own profile.

## How to Test

### ACP Config tab (#700)
1. Log in as admin and go to ACP → Config tab
2. Confirm the Rules Compliance section loads without error
3. If any users have a `rules_reminder_sent_at` value set, confirm the date formats correctly in the "Reminder Sent" column

### Background check notes visibility (#698)
1. Add a background check record with a note to a staff member's profile (as a Background Checks - Manage user)
2. Log in as that staff member (who does NOT have Background Checks - View or Manage role)
3. Go to their own profile — the background check card should show their check status and documents, but **notes should not be visible**
4. Log in as a user WITH Background Checks - View or Manage role and view the same profile — notes should be visible

## Things to Watch For

- Notes should remain visible to Background Checks - View and Manage role holders regardless of whether they are viewing their own profile or another user's
- Status, documents, and renewal badges (Overdue/Due Soon/Waived) should still display normally for self-viewers without view/manage role

## Parent PRD

#681

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Implemented permission-based access control for background check notes. Users with appropriate permissions can now view notes within the background checks section, while others are restricted from accessing this content.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Lighthouse-Minecraft/website/pull/701)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->