### PR TITLE
feat: Forge per-PR test environments via GitHub Actions

### DIFF
--- a/.github/workflows/pr-env-provision.yml
+++ b/.github/workflows/pr-env-provision.yml
@@ -113,7 +113,7 @@ jobs:
                   "php artisan config:cache\n"
                   "php artisan route:cache\n"
                   "php artisan view:cache\n"
-                  "( flock -w 10 9 || exit 1; sudo -S service php8.2-fpm reload ) 9>/tmp/fpmlock\n"
+                  "( flock -w 10 9 || exit 1; sudo -S service php8.4-fpm reload ) 9>/tmp/fpmlock\n"
               )
 
           # Parse existing resource IDs from the PR comment (if any)

--- a/.github/workflows/pr-env-provision.yml
+++ b/.github/workflows/pr-env-provision.yml
@@ -38,6 +38,8 @@ jobs:
           PR_BRANCH: ${{ github.head_ref }}
           PR_ACTION: ${{ github.event.action }}
           EXISTING_COMMENT: ${{ steps.find.outputs.comment-body }}
+          FLUX_USERNAME: ${{ secrets.FLUX_USERNAME }}
+          FLUX_LICENSE_KEY: ${{ secrets.FLUX_LICENSE_KEY }}
         run: |
           cat > /tmp/provision.py << 'PYEOF'
           import os, json, time, re, secrets, urllib.request, urllib.error
@@ -52,6 +54,8 @@ jobs:
           BRANCH   = os.environ["PR_BRANCH"]
           ACTION   = os.environ["PR_ACTION"]
           COMMENT  = os.environ.get("EXISTING_COMMENT", "")
+          FLUX_USER = os.environ["FLUX_USERNAME"]
+          FLUX_KEY  = os.environ["FLUX_LICENSE_KEY"]
 
           DOMAIN   = f"pr-{PR}.{IP}.nip.io"
           DB_NAME  = f"pr_{PR}"
@@ -107,6 +111,7 @@ jobs:
               return (
                   f"cd /home/forge/{DOMAIN}\n"
                   f"git pull origin {BRANCH}\n"
+                  f"composer config --global http-basic.composer.fluxui.dev {FLUX_USER} {FLUX_KEY}\n"
                   "composer install --no-dev --no-interaction --prefer-dist\n"
                   "npm ci && npm run build\n"
                   "php artisan migrate --force\n"

--- a/.github/workflows/pr-env-provision.yml
+++ b/.github/workflows/pr-env-provision.yml
@@ -1,0 +1,195 @@
+name: PR Environment — Provision
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize]
+    branches: [staging]
+
+concurrency:
+  group: pr-env-${{ github.event.number }}
+  cancel-in-progress: true
+
+jobs:
+  provision:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Find existing environment comment
+        id: find
+        uses: peter-evans/find-comment@v3
+        with:
+          issue-number: ${{ github.event.number }}
+          comment-author: github-actions[bot]
+          body-includes: "<!-- forge-pr-env"
+
+      - name: Provision or redeploy
+        id: forge
+        env:
+          FORGE_TOKEN: ${{ secrets.FORGE_API_TOKEN }}
+          SERVER_ID: ${{ secrets.FORGE_SERVER_ID }}
+          SERVER_IP: ${{ secrets.FORGE_SERVER_IP }}
+          FORGE_REPO: ${{ secrets.FORGE_GITHUB_REPO }}
+          BASE_ENV: ${{ secrets.PR_ENV_BASE }}
+          PR_NUMBER: ${{ github.event.number }}
+          PR_BRANCH: ${{ github.head_ref }}
+          PR_ACTION: ${{ github.event.action }}
+          EXISTING_COMMENT: ${{ steps.find.outputs.comment-body }}
+        run: |
+          cat > /tmp/provision.py << 'PYEOF'
+          import os, json, time, re, secrets, urllib.request, urllib.error
+
+          BASE     = "https://forge.laravel.com/api/v1"
+          TOKEN    = os.environ["FORGE_TOKEN"]
+          SRV      = os.environ["SERVER_ID"]
+          IP       = os.environ["SERVER_IP"]
+          REPO     = os.environ["FORGE_REPO"]
+          BASE_ENV = os.environ["BASE_ENV"]
+          PR       = os.environ["PR_NUMBER"]
+          BRANCH   = os.environ["PR_BRANCH"]
+          ACTION   = os.environ["PR_ACTION"]
+          COMMENT  = os.environ.get("EXISTING_COMMENT", "")
+
+          DOMAIN   = f"pr-{PR}.{IP}.nip.io"
+          DB_NAME  = f"pr_{PR}"
+          DB_USER  = f"pr_{PR}"
+
+          def api(method, path, data=None):
+              req = urllib.request.Request(
+                  f"{BASE}{path}",
+                  data=json.dumps(data).encode() if data else None,
+                  headers={
+                      "Authorization": f"Bearer {TOKEN}",
+                      "Content-Type": "application/json",
+                      "Accept": "application/json",
+                  },
+                  method=method,
+              )
+              try:
+                  with urllib.request.urlopen(req) as r:
+                      return json.loads(r.read())
+              except urllib.error.HTTPError as e:
+                  raise RuntimeError(f"Forge {method} {path}: {e.code} {e.read().decode()}")
+
+          def set_output(key, value):
+              delim = "GHEOF"
+              with open(os.environ["GITHUB_OUTPUT"], "a") as f:
+                  f.write(f"{key}<<{delim}\n{value}\n{delim}\n")
+
+          def wait_for_site(site_id, timeout=300):
+              deadline = time.time() + timeout
+              while time.time() < deadline:
+                  site = api("GET", f"/servers/{SRV}/sites/{site_id}")["site"]
+                  if site["status"] == "installed":
+                      return
+                  time.sleep(10)
+              raise RuntimeError("Timed out waiting for site provisioning")
+
+          def build_env(db_pass):
+              lines = [l for l in BASE_ENV.splitlines()
+                       if not l.startswith(("APP_URL=", "APP_ENV=", "DB_"))]
+              lines += [
+                  f"APP_URL=http://{DOMAIN}",
+                  "APP_ENV=staging",
+                  "DB_CONNECTION=mysql",
+                  "DB_HOST=127.0.0.1",
+                  "DB_PORT=3306",
+                  f"DB_DATABASE={DB_NAME}",
+                  f"DB_USERNAME={DB_USER}",
+                  f"DB_PASSWORD={db_pass}",
+              ]
+              return "\n".join(lines)
+
+          def deploy_script():
+              return (
+                  f"cd /home/forge/{DOMAIN}\n"
+                  f"git pull origin {BRANCH}\n"
+                  "composer install --no-dev --no-interaction --prefer-dist\n"
+                  "npm ci && npm run build\n"
+                  "php artisan migrate --force\n"
+                  "php artisan config:cache\n"
+                  "php artisan route:cache\n"
+                  "php artisan view:cache\n"
+                  "( flock -w 10 9 || exit 1; sudo -S service php8.2-fpm reload ) 9>/tmp/fpmlock\n"
+              )
+
+          # Parse existing resource IDs from the PR comment (if any)
+          site_m = re.search(r"site_id=(\d+)", COMMENT)
+          db_m   = re.search(r"db_id=(\d+)",   COMMENT)
+          site_id = int(site_m.group(1)) if site_m else None
+          db_id   = int(db_m.group(1))   if db_m   else None
+
+          if site_id and ACTION == "synchronize":
+              # Environment already exists — just redeploy the new commits
+              api("POST", f"/servers/{SRV}/sites/{site_id}/deployment/deploy")
+              comment = (
+                  f"<!-- forge-pr-env site_id={site_id} db_id={db_id} -->\n"
+                  f"## \U0001f680 PR Test Environment\n\n"
+                  f"| | |\n"
+                  f"|---|---|\n"
+                  f"| **Site** | http://{DOMAIN} |\n"
+                  f"| **Forge Dashboard** | https://forge.laravel.com/servers/{SRV}/sites/{site_id} |\n"
+                  f"| **Branch** | `{BRANCH}` |\n\n"
+                  f"Redeploying — refresh in ~60 seconds.\n\n"
+                  f"_Tears down automatically when this PR is closed._"
+              )
+          else:
+              # Full provision: site + database + git + env + deploy script + first deploy
+              db_pass = secrets.token_urlsafe(16)
+
+              site = api("POST", f"/servers/{SRV}/sites", {
+                  "domain": DOMAIN,
+                  "project_type": "php",
+                  "directory": "/public",
+              })["site"]
+              site_id = site["id"]
+              wait_for_site(site_id)
+
+              db = api("POST", f"/servers/{SRV}/databases", {
+                  "name": DB_NAME,
+                  "user": DB_USER,
+                  "password": db_pass,
+              })["database"]
+              db_id = db["id"]
+
+              api("POST", f"/servers/{SRV}/sites/{site_id}/git", {
+                  "provider": "github",
+                  "repository": REPO,
+                  "branch": BRANCH,
+                  "composer": True,
+              })
+
+              api("PUT", f"/servers/{SRV}/sites/{site_id}/env",
+                  {"content": build_env(db_pass)})
+
+              api("PUT", f"/servers/{SRV}/sites/{site_id}/deployment/script",
+                  {"content": deploy_script(), "auto_source": False})
+
+              api("POST", f"/servers/{SRV}/sites/{site_id}/deployment/deploy")
+
+              comment = (
+                  f"<!-- forge-pr-env site_id={site_id} db_id={db_id} -->\n"
+                  f"## \U0001f680 PR Test Environment\n\n"
+                  f"| | |\n"
+                  f"|---|---|\n"
+                  f"| **Site** | http://{DOMAIN} |\n"
+                  f"| **Forge Dashboard** | https://forge.laravel.com/servers/{SRV}/sites/{site_id} |\n"
+                  f"| **Branch** | `{BRANCH}` |\n\n"
+                  f"Provisioning now — first deploy takes ~2 minutes.\n\n"
+                  f"_Tears down automatically when this PR is closed._"
+              )
+
+          set_output("comment", comment)
+          PYEOF
+          python3 /tmp/provision.py
+
+      - name: Create or update PR comment
+        uses: peter-evans/create-or-update-comment@v4
+        with:
+          comment-id: ${{ steps.find.outputs.comment-id }}
+          issue-number: ${{ github.event.number }}
+          body: ${{ steps.forge.outputs.comment }}
+          edit-mode: replace

--- a/.github/workflows/pr-env-teardown.yml
+++ b/.github/workflows/pr-env-teardown.yml
@@ -1,0 +1,88 @@
+name: PR Environment — Teardown
+
+on:
+  pull_request:
+    types: [closed]
+    branches: [staging]
+
+jobs:
+  teardown:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+
+    steps:
+      - name: Find environment comment
+        id: find
+        uses: peter-evans/find-comment@v3
+        with:
+          issue-number: ${{ github.event.number }}
+          comment-author: github-actions[bot]
+          body-includes: "<!-- forge-pr-env"
+
+      - name: Tear down Forge environment
+        if: steps.find.outputs.comment-id != ''
+        id: forge
+        env:
+          FORGE_TOKEN: ${{ secrets.FORGE_API_TOKEN }}
+          SERVER_ID: ${{ secrets.FORGE_SERVER_ID }}
+          SERVER_IP: ${{ secrets.FORGE_SERVER_IP }}
+          PR_NUMBER: ${{ github.event.number }}
+          EXISTING_COMMENT: ${{ steps.find.outputs.comment-body }}
+        run: |
+          cat > /tmp/teardown.py << 'PYEOF'
+          import os, json, re, urllib.request, urllib.error
+
+          BASE    = "https://forge.laravel.com/api/v1"
+          TOKEN   = os.environ["FORGE_TOKEN"]
+          SRV     = os.environ["SERVER_ID"]
+          IP      = os.environ["SERVER_IP"]
+          PR      = os.environ["PR_NUMBER"]
+          COMMENT = os.environ.get("EXISTING_COMMENT", "")
+
+          DOMAIN = f"pr-{PR}.{IP}.nip.io"
+
+          def api_delete(path):
+              req = urllib.request.Request(
+                  f"{BASE}{path}",
+                  headers={
+                      "Authorization": f"Bearer {TOKEN}",
+                      "Accept": "application/json",
+                  },
+                  method="DELETE",
+              )
+              try:
+                  with urllib.request.urlopen(req) as r:
+                      return r.status
+              except urllib.error.HTTPError as e:
+                  if e.code == 404:
+                      return 404  # already gone, fine
+                  raise RuntimeError(f"Forge DELETE {path}: {e.code} {e.read().decode()}")
+
+          def set_output(key, value):
+              delim = "GHEOF"
+              with open(os.environ["GITHUB_OUTPUT"], "a") as f:
+                  f.write(f"{key}<<{delim}\n{value}\n{delim}\n")
+
+          site_m = re.search(r"site_id=(\d+)", COMMENT)
+          db_m   = re.search(r"db_id=(\d+)",   COMMENT)
+
+          if site_m:
+              api_delete(f"/servers/{SRV}/sites/{site_m.group(1)}")
+          if db_m:
+              api_delete(f"/servers/{SRV}/databases/{db_m.group(1)}")
+
+          set_output("comment",
+              f"<!-- forge-pr-env-torn-down -->\n"
+              f"~~\U0001f680 PR Test Environment~~ — torn down when PR was closed."
+          )
+          PYEOF
+          python3 /tmp/teardown.py
+
+      - name: Update PR comment
+        if: steps.find.outputs.comment-id != ''
+        uses: peter-evans/create-or-update-comment@v4
+        with:
+          comment-id: ${{ steps.find.outputs.comment-id }}
+          body: ${{ steps.forge.outputs.comment }}
+          edit-mode: replace


### PR DESCRIPTION
## What Changed

Two GitHub Actions workflows that automatically provision and tear down a per-PR test environment on Laravel Forge, triggered by PRs targeting `staging`.

**How it works:**
- PR opened/reopened → creates a Forge site + MySQL database, installs the repo, configures `.env`, and runs the first deploy
- PR updated (new push) → redeploys the existing site with the new commits
- PR closed → deletes the Forge site and database

Each environment gets a unique `nip.io` URL (e.g. `http://pr-42.1.2.3.4.nip.io`) so no DNS config is needed. A comment is posted on the PR with the site URL and a direct Forge dashboard link for the tester.

Resource IDs (site + database) are stored in a hidden HTML comment on the PR so the teardown workflow can find and clean up the right resources.

## Setup Required Before Merging

Seven GitHub repository secrets must be added (Settings → Secrets and variables → Actions):

| Secret | Where to find it |
|---|---|
| `FORGE_API_TOKEN` | Forge → Account → API Tokens |
| `FORGE_SERVER_ID` | Numeric ID in your Forge server URL |
| `FORGE_SERVER_IP` | Your server's public IP address |
| `FORGE_GITHUB_REPO` | e.g. `Lighthouse-Minecraft/website` |
| `PR_ENV_BASE` | Copy your staging `.env`, remove the `APP_URL=`, `APP_ENV=`, and all `DB_*` lines — the workflow adds those |
| `FLUX_USERNAME` | Flux UI license username |
| `FLUX_LICENSE_KEY` | Flux UI license key |

## Things to Verify

- Check that `php8.4-fpm` in the deploy script matches the PHP version running on the Forge server
- Confirm the Forge GitHub app has access to the repo so the git install step can clone it
- The `peter-evans/find-comment` and `peter-evans/create-or-update-comment` actions are used — they are well-maintained OSS actions with no special permissions beyond `pull-requests: write`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
